### PR TITLE
Add SMC calls forwarding framework

### DIFF
--- a/src/arch/aarch64/smc.h
+++ b/src/arch/aarch64/smc.h
@@ -23,17 +23,16 @@ uint64_t smc_get_arg(seL4_UserContext *u, uint64_t arg);
 
 #if defined(CONFIG_ALLOW_SMC_CALLS)
 
-/* Set SMC Call Cap to use by the library API */
-bool smc_set_cap(seL4_CPtr smcccap);
-
 /* Default handler of calls to a SMC Service */
 bool smc_default_handle_service(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number);
 
 /* Service handler type */
 typedef bool (* smc_handle_service_type)(size_t, seL4_UserContext *, uint64_t);
 
-/* Default handler of SiP service calls */
-bool smc_default_handle_sip(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number);
+/* API for user: */
+
+/* Set SMC Call Cap to use by the library API */
+bool smc_set_cap(seL4_CPtr smcccap);
 
 /* 'set_handler_sip_service()' assigns/removes active SiP Service handler */
 bool smc_set_handler_sip_service(smc_handle_service_type handler_func);

--- a/src/arch/aarch64/smc.h
+++ b/src/arch/aarch64/smc.h
@@ -21,11 +21,21 @@ void smc_set_return_value(seL4_UserContext *u, uint64_t val);
 /* Gets the value of x1-x6 */
 uint64_t smc_get_arg(seL4_UserContext *u, uint64_t arg);
 
+#if defined(CONFIG_ALLOW_SMC_CALLS)
+
+/* Set SMC Call Cap to use by the library API */
+bool smc_set_cap(seL4_CPtr smcccap);
+
 /* Default handler of calls to a SMC Service */
-bool default_handle_service(uint64_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number);
+bool smc_default_handle_service(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number);
 
 /* Service handler type */
-typedef bool (* handle_service_type)(uint64_t, seL4_UserContext *, uint64_t);
+typedef bool (* smc_handle_service_type)(size_t, seL4_UserContext *, uint64_t);
 
 /* Default handler of SiP service calls */
-bool default_handle_sip(uint64_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number);
+bool smc_default_handle_sip(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number);
+
+/* 'set_handler_sip_service()' assigns/removes active SiP Service handler */
+bool smc_set_handler_sip_service(smc_handle_service_type handler_func);
+
+#endif

--- a/src/arch/aarch64/smc.h
+++ b/src/arch/aarch64/smc.h
@@ -20,3 +20,12 @@ void smc_set_return_value(seL4_UserContext *u, uint64_t val);
 
 /* Gets the value of x1-x6 */
 uint64_t smc_get_arg(seL4_UserContext *u, uint64_t arg);
+
+/* Default handler of calls to a SMC Service */
+bool default_handle_service(uint64_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number);
+
+/* Service handler type */
+typedef bool (* handle_service_type)(uint64_t, seL4_UserContext *, uint64_t);
+
+/* Default handler of SiP service calls */
+bool default_handle_sip(uint64_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number);


### PR DESCRIPTION
Added:
- a framework for forwarding SMC calls to Secure Monitor,
- SiP Service entry in the framework.