### PR TITLE
lib: log error when vIRQ cannot be set to pending

### DIFF
--- a/src/arch/aarch64/vgic/vdist.h
+++ b/src/arch/aarch64/vgic/vdist.h
@@ -181,13 +181,13 @@ static bool vgic_dist_set_pending_irq(vgic_t *vgic, size_t vcpu_id, int irq)
 
     if (virq_data->virq == VIRQ_INVALID || !vgic_dist_is_enabled(dist) || !is_enabled(dist, irq, vcpu_id)) {
         if (virq_data->virq == VIRQ_INVALID) {
-            LOG_DIST("vIRQ data could not be found\n");
+            LOG_VMM_ERR("vIRQ data could not be found for IRQ 0%lx\n", irq);
         }
         if (!vgic_dist_is_enabled(dist)) {
-            LOG_DIST("vGIC distributor is not enabled\n");
+            LOG_VMM_ERR("vGIC distributor is not enabled for IRQ 0x%lx\n", irq);
         }
         if (!is_enabled(dist, irq, vcpu_id)) {
-            LOG_DIST("vIRQ is not enabled\n");
+            LOG_VMM_ERR("vIRQ 0%lx is not enabled\n", irq);
         }
         return false;
     }


### PR DESCRIPTION
These logs should be errors rather than just normal logs as it is a case that should not happen.