### PR TITLE
Fixes for latest master Zig version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,9 +43,9 @@ jobs:
         run: sudo apt update && sudo apt install -y make clang lld llvm qemu-system-arm device-tree-compiler expect
       - name: Install Zig
         run: |
-          wget https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.1594+7048e9366.tar.xz
-          tar xf zig-linux-x86_64-0.12.0-dev.1594+7048e9366.tar.xz
-          echo "${PWD}/zig-linux-x86_64-0.12.0-dev.1594+7048e9366/:$PATH" >> $GITHUB_PATH
+          wget https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.2150+63de8a598.tar.xz
+          tar xf zig-linux-x86_64-0.12.0-dev.2150+63de8a598.tar.xz
+          echo "${PWD}/zig-linux-x86_64-0.12.0-dev.2150+63de8a598/:$PATH" >> $GITHUB_PATH
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Build and run examples
@@ -76,9 +76,9 @@ jobs:
           echo "/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_PATH
       - name: Install Zig
         run: |
-          wget https://ziglang.org/builds/zig-macos-x86_64-0.12.0-dev.1594+7048e9366.tar.xz
-          tar xf zig-macos-x86_64-0.12.0-dev.1594+7048e9366.tar.xz
-          echo "${PWD}/zig-macos-x86_64-0.12.0-dev.1594+7048e9366/:$PATH" >> $GITHUB_PATH
+          wget https://ziglang.org/builds/zig-macos-x86_64-0.12.0-dev.2150+63de8a598.tar.xz
+          tar xf zig-macos-x86_64-0.12.0-dev.2150+63de8a598.tar.xz
+          echo "${PWD}/zig-macos-x86_64-0.12.0-dev.2150+63de8a598/:$PATH" >> $GITHUB_PATH
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Build and run examples

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -36,7 +36,7 @@ For educational purposes, you can also build and run this example using the
 
 At the moment, Zig still under heavy development and hence this example depends
 on the 'master' version of Zig for now. This example has been built using
-`0.12.0-dev.1533+b2ed2c4d4`, so anything equal to or above that version should work.
+`0.12.0-dev.2150+63de8a598`, so anything equal to or above that version should work.
 
 You can download Zig [here](https://ziglang.org/download/).
 

--- a/examples/zig/README.md
+++ b/examples/zig/README.md
@@ -15,7 +15,7 @@ the Zig C compiler. Building the example is done via the Zig build system.
 
 At the moment, Zig still under heavy development and hence this example depends
 on the 'master' version of Zig for now. This example has been built using
-`0.12.0-dev.1533+b2ed2c4d4`, so anything equal to or above that version should work.
+`0.12.0-dev.2150+63de8a598`, so anything equal to or above that version should work.
 
 You can download Zig [here](https://ziglang.org/download/).
 

--- a/examples/zig/src/libmicrokit.c
+++ b/examples/zig/src/libmicrokit.c
@@ -1,4 +1,4 @@
-#include "libmicrokit.h";
+#include "libmicrokit.h"
 
 void zig_arm_sys_send(seL4_Word sys, seL4_Word dest, seL4_Word info_arg, seL4_Word mr0, seL4_Word mr1,
                                 seL4_Word mr2, seL4_Word mr3)

--- a/examples/zig/src/vmm.zig
+++ b/examples/zig/src/vmm.zig
@@ -36,9 +36,9 @@ const guest_kernel_image = blk: {
     break :blk &arr;
 };
 // Data for the device tree to be passed to the kernel.
-const guest_dtb_image = @embedFile("linux.dtb");
+const guest_dtb_image = @embedFile("dtb");
 // Data for the initial RAM disk to be passed to the kernel.
-const guest_initrd_image = @embedFile("rootfs.cpio.gz");
+const guest_initrd_image = @embedFile("rootfs");
 
 // In Zig the standard library comes with printf-like functionality with the
 // ability to provide your own function to ouput the characters. This is


### PR DESCRIPTION
There are some minor breaking API changes to the Zig build system. It is good to get ahead of these so we don't have to deal with all of them at the next release of Zig.

Hopefully soon we can pin the examples that use Zig to an official release rather than the master version.

This patch also includes some minor cleanup and fixes unrelated to latest Zig version.