### PR TITLE
Fix virtIO MMIO QueueNotify field

### DIFF
--- a/src/virtio/mmio.c
+++ b/src/virtio/mmio.c
@@ -204,6 +204,7 @@ static bool handle_virtio_mmio_reg_write(virtio_device_t *dev, size_t vcpu_id, s
             }
             break;
         case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_NOTIFY, REG_VIRTIO_MMIO_INTERRUPT_STATUS):
+            dev->data.QueueNotify = (uint32_t)data;
             success = dev->funs->queue_notify(dev);
             break;
         case REG_RANGE(REG_VIRTIO_MMIO_INTERRUPT_ACK, REG_VIRTIO_MMIO_STATUS):


### PR DESCRIPTION
The `QueueNotify` field in the [MMIO Device Register Layout](https://docs.oasis-open.org/virtio/virtio/v1.2/csd01/virtio-v1.2-csd01.html#x1-1670002) was previously not set.