### PR TITLE
Various cleanup and minor fixes

### DIFF
--- a/src/arch/aarch64/fault.c
+++ b/src/arch/aarch64/fault.c
@@ -44,27 +44,22 @@ char *fault_to_string(seL4_Word fault_label) {
     }
 }
 
+/*
+ * Possible 'Syndrome Access Size' defined in ARMv8-A specification. The values
+ * of the enums line up with the SAS encoding of the ISS encoding for an
+ * exception from a Data Abort.
+ */
 enum fault_width {
-    WIDTH_DOUBLEWORD = 0,
-    WIDTH_WORD = 1,
-    WIDTH_HALFWORD = 2,
-    WIDTH_BYTE = 3,
+    WIDTH_BYTE = 0b00,
+    WIDTH_HALFWORD = 0b01,
+    WIDTH_WORD = 0b10,
+    WIDTH_DOUBLEWORD = 0b11,
 };
 
 static enum fault_width fault_get_width(uint64_t fsr)
 {
-    if (HSR_IS_SYNDROME_VALID(fsr)) {
-        switch (HSR_SYNDROME_WIDTH(fsr)) {
-            case 0: return WIDTH_BYTE;
-            case 1: return WIDTH_HALFWORD;
-            case 2: return WIDTH_WORD;
-            case 3: return WIDTH_DOUBLEWORD;
-            default:
-                // @ivanv: reviist
-                // print_fault(f);
-                assert(0);
-                return 0;
-        }
+    if (HSR_IS_SYNDROME_VALID(fsr) && HSR_SYNDROME_WIDTH(fsr) <= WIDTH_DOUBLEWORD) {
+        return (enum fault_width) (HSR_SYNDROME_WIDTH(fsr));
     } else {
         LOG_VMM_ERR("Received invalid FSR: 0x%lx\n", fsr);
         // @ivanv: reviist
@@ -105,9 +100,14 @@ uint64_t fault_get_data_mask(uint64_t addr, uint64_t fsr)
 }
 
 static seL4_Word wzr = 0;
-seL4_Word *decode_rt(uint64_t reg, seL4_UserContext *regs)
+seL4_Word *decode_rt(size_t reg_idx, seL4_UserContext *regs)
 {
-    switch (reg) {
+    /*
+     * This switch statement is necessary due to a mismatch between how
+     * seL4 orders the TCB registers compared to what the architecture
+     * encodes the Syndrome Register transfer.
+     */
+    switch (reg_idx) {
         case 0: return &regs->x0;
         case 1: return &regs->x1;
         case 2: return &regs->x2;
@@ -141,8 +141,7 @@ seL4_Word *decode_rt(uint64_t reg, seL4_UserContext *regs)
         case 30: return &regs->x30;
         case 31: return &wzr;
         default:
-            printf("invalid reg %d\n", reg);
-            assert(!"Invalid register");
+            LOG_VMM_ERR("failed to decode Rt, attempted to access invalid register index 0x%lx\n", reg_idx);
             return NULL;
     }
 }

--- a/src/arch/aarch64/fault.c
+++ b/src/arch/aarch64/fault.c
@@ -24,7 +24,7 @@
 
 bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs) {
     // For now we just ignore it and continue
-    // Assume 64-bit instruction
+    // Assume 32-bit instruction
     regs->pc += 4;
     int err = seL4_TCB_WriteRegisters(BASE_VM_TCB_CAP + vcpu_id, true, 0, SEL4_USER_CONTEXT_SIZE, regs);
     assert(err == seL4_NoError);

--- a/src/arch/aarch64/fault.c
+++ b/src/arch/aarch64/fault.c
@@ -159,7 +159,6 @@ bool fault_is_read(uint64_t fsr)
 
 static int get_rt(uint64_t fsr)
 {
-
     int rt = -1;
     if (HSR_IS_SYNDROME_VALID(fsr)) {
         rt = HSR_SYNDROME_RT(fsr);
@@ -176,7 +175,7 @@ static int get_rt(uint64_t fsr)
 uint64_t fault_get_data(seL4_UserContext *regs, uint64_t fsr)
 {
     /* Get register opearand */
-    int rt  = get_rt(fsr);
+    int rt = get_rt(fsr);
 
     uint64_t data = *decode_rt(rt, regs);
 
@@ -212,8 +211,6 @@ bool fault_advance(size_t vcpu_id, seL4_UserContext *regs, uint64_t addr, uint64
 
     seL4_Word *reg_ctx = decode_rt(rt, regs);
     *reg_ctx = fault_emulate(regs, *reg_ctx, addr, fsr, reg_val);
-    // DFAULT("%s: Emulate fault @ 0x%x from PC 0x%x\n",
-    //        fault->vcpu->vm->vm_name, fault->addr, fault->ip);
 
     return fault_advance_vcpu(vcpu_id, regs);
 }

--- a/src/guest.c
+++ b/src/guest.c
@@ -19,7 +19,7 @@ bool guest_start(size_t boot_vcpu_id, uintptr_t kernel_pc, uintptr_t dtb, uintpt
         BASE_VM_TCB_CAP + boot_vcpu_id,
         false, // We'll explcitly start the guest below rather than in this call
         0, // No flags
-        SEL4_USER_CONTEXT_SIZE, // Writing to x0, pc, and spsr // @ivanv: for some reason having the number of registers here does not work... (in this case 2)
+        4, // Writing to x0, pc, and spsr. Due to the ordering of seL4_UserContext the count must be 4.
         &regs
     );
     assert(err == seL4_NoError);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -58,6 +58,13 @@ static void assert_fail(
     while (1) {}
 }
 
+#ifndef CONFIG_DEBUG_BUILD
+
+#define _unused(x) ((void)(x))
+#define assert(expr) _unused(expr)
+
+#else
+
 #define assert(expr) \
     do { \
         if (!(expr)) { \
@@ -65,3 +72,4 @@ static void assert_fail(
         } \
     } while(0)
 
+#endif


### PR DESCRIPTION
When I originally (in a rather hacky fashion) ported the CAmkES VMM code I did not really look at the code that much or inspect. Over time I've looked at the core parts of libvmm and done some clean up and improvements but there are still two main areas that need more looking at:
* the vGIC driver code
* the fault handling code (mainly the fault decoding/emulating a read or write code).

This PR cleans up some of the fault handling code among other cleanup but still more needs to be done.