### PR TITLE
Update to latest Zig version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,9 +43,9 @@ jobs:
         run: sudo apt update && sudo apt install -y make clang lld llvm qemu-system-arm device-tree-compiler expect
       - name: Install Zig
         run: |
-          wget https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.2150+63de8a598.tar.xz
-          tar xf zig-linux-x86_64-0.12.0-dev.2150+63de8a598.tar.xz
-          echo "${PWD}/zig-linux-x86_64-0.12.0-dev.2150+63de8a598/:$PATH" >> $GITHUB_PATH
+          wget https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.3434+e90583f5d.tar.xz
+          tar xf zig-linux-x86_64-0.12.0-dev.3434+e90583f5d.tar.xz
+          echo "${PWD}/zig-linux-x86_64-0.12.0-dev.3434+e90583f5d/:$PATH" >> $GITHUB_PATH
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Build and run examples
@@ -76,9 +76,9 @@ jobs:
           echo "/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_PATH
       - name: Install Zig
         run: |
-          wget https://ziglang.org/builds/zig-macos-x86_64-0.12.0-dev.2150+63de8a598.tar.xz
-          tar xf zig-macos-x86_64-0.12.0-dev.2150+63de8a598.tar.xz
-          echo "${PWD}/zig-macos-x86_64-0.12.0-dev.2150+63de8a598/:$PATH" >> $GITHUB_PATH
+          wget https://ziglang.org/builds/zig-macos-x86_64-0.12.0-dev.3434+e90583f5d.tar.xz
+          tar xf zig-macos-x86_64-0.12.0-dev.3434+e90583f5d.tar.xz
+          echo "${PWD}/zig-macos-x86_64-0.12.0-dev.3434+e90583f5d/:$PATH" >> $GITHUB_PATH
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Build and run examples

--- a/build.zig
+++ b/build.zig
@@ -26,7 +26,7 @@ pub fn build(b: *std.Build) void {
     const microkit_sdk_arg = b.option([]const u8, "sdk", "Path to Microkit SDK");
     if (microkit_sdk_arg == null) {
         std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
-        std.os.exit(1);
+        std.posix.exit(1);
     }
     const microkit_sdk = microkit_sdk_arg.?;
     std.fs.cwd().access(microkit_sdk, .{}) catch |err| {
@@ -34,7 +34,7 @@ pub fn build(b: *std.Build) void {
             error.FileNotFound => std.log.err("Path to SDK '{s}' does not exist\n", .{ microkit_sdk }),
             else => std.log.err("Could not acccess SDK path '{s}', error is {any}\n", .{ microkit_sdk, err })
         }
-        std.os.exit(1);
+        std.posix.exit(1);
     };
 
     const microkit_config = b.option([]const u8, "config", "Microkit config to build for") orelse "debug";
@@ -42,7 +42,7 @@ pub fn build(b: *std.Build) void {
 
     if (microkit_board_arg == null) {
         std.log.err("Missing -Dboard=<BOARD> argument being passed\n", .{});
-        std.os.exit(1);
+        std.posix.exit(1);
     }
     const microkit_board = microkit_board_arg.?;
 
@@ -52,7 +52,7 @@ pub fn build(b: *std.Build) void {
             error.FileNotFound => std.log.err("Path to '{s}' does not exist\n", .{ microkit_board_dir }),
             else => std.log.err("Could not acccess path '{s}', error is {any}\n", .{ microkit_board_dir, err })
         }
-        std.os.exit(1);
+        std.posix.exit(1);
     };
     const libmicrokit_include = b.fmt("{s}/include", .{ microkit_board_dir });
 
@@ -66,7 +66,7 @@ pub fn build(b: *std.Build) void {
         .aarch64 => src_aarch64,
         else => {
             std.log.err("Unsupported libvmm architecture given '{s}'", .{ @tagName(target.result.cpu.arch) });
-            std.os.exit(1);
+            std.posix.exit(1);
         }
     };
     libvmm.addCSourceFiles(.{

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -36,7 +36,7 @@ For educational purposes, you can also build and run this example using the
 
 At the moment, Zig still under heavy development and hence this example depends
 on the 'master' version of Zig for now. This example has been built using
-`0.12.0-dev.2150+63de8a598`, so anything equal to or above that version should work.
+`0.12.0-dev.3434+e90583f5d`, so anything equal to or above that version should work.
 
 You can download Zig [here](https://ziglang.org/download/).
 

--- a/examples/simple/build.zig
+++ b/examples/simple/build.zig
@@ -39,7 +39,7 @@ fn findTarget(board: MicrokitBoard) std.zig.CrossTarget {
     }
 
     std.log.err("Board '{}' is not supported\n", .{ board });
-    std.os.exit(1);
+    std.posix.exit(1);
 }
 
 const ConfigOptions = enum {
@@ -55,7 +55,7 @@ pub fn build(b: *std.Build) void {
     const microkit_sdk_arg = b.option([]const u8, "sdk", "Path to Microkit SDK");
     if (microkit_sdk_arg == null) {
         std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
-        std.os.exit(1);
+        std.posix.exit(1);
     }
     const microkit_sdk = microkit_sdk_arg.?;
 
@@ -67,7 +67,7 @@ pub fn build(b: *std.Build) void {
 
     if (microkit_board_option == null) {
         std.log.err("Missing -Dboard=<BOARD> argument being passed\n", .{});
-        std.os.exit(1);
+        std.posix.exit(1);
     }
     const target = b.resolveTargetQuery(findTarget(microkit_board_option.?));
     const microkit_board = @tagName(microkit_board_option.?);

--- a/examples/zig/README.md
+++ b/examples/zig/README.md
@@ -15,7 +15,7 @@ the Zig C compiler. Building the example is done via the Zig build system.
 
 At the moment, Zig still under heavy development and hence this example depends
 on the 'master' version of Zig for now. This example has been built using
-`0.12.0-dev.2150+63de8a598`, so anything equal to or above that version should work.
+`0.12.0-dev.3434+e90583f5d`, so anything equal to or above that version should work.
 
 You can download Zig [here](https://ziglang.org/download/).
 

--- a/examples/zig/build.zig
+++ b/examples/zig/build.zig
@@ -21,7 +21,7 @@ pub fn build(b: *std.Build) void {
     const microkit_sdk_arg = b.option([]const u8, "sdk", "Path to Microkit SDK");
     if (microkit_sdk_arg == null) {
         std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
-        std.os.exit(1);
+        std.posix.exit(1);
     }
     const microkit_sdk = microkit_sdk_arg.?;
 


### PR DESCRIPTION
Breaking change to Zig standard library. Once Zig 0.12.0 will release we will make libvmm use that, but for now we stick to master.

Fixes CI failing.