### PR TITLE
Serial and sDDF Update

### DIFF
--- a/examples/virtio-snd/Makefile
+++ b/examples/virtio-snd/Makefile
@@ -30,6 +30,9 @@ DTC := dtc
 CC := clang
 CC_USERLEVEL := zig cc
 LD := ld.lld
+AR := llvm-ar
+RANLIB := llvm-ranlib
+
 MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
 
 BOARD_DIR := $(MICROKIT_SDK)/board/$(BOARD)/$(CONFIG)
@@ -188,10 +191,6 @@ directories:
 	$(shell mkdir -p $(BUILD_DIR)/serial)
 
 SDDF_LIB_UTIL_DBG_OBJS := cache.o sddf_printf.o newlibc.o assert.o putchar_debug.o bitarray.o fsmalloc.o
-
-TOOLCHAIN ?= aarch64-none-elf
-AR := $(TOOLCHAIN)-ar
-RANLIB := ${TOOLCHAIN}-ranlib
 
 $(BUILD_DIR)/libsddf_util_debug.a: $(addprefix ${BUILD_DIR}/util/, ${SDDF_LIB_UTIL_DBG_OBJS})
 	${AR} rv $@ $^

--- a/examples/virtio-snd/Makefile
+++ b/examples/virtio-snd/Makefile
@@ -71,15 +71,12 @@ CLIENT_VM_DTS_OVERLAYS :=	$(CLIENT_VM_DTS_DIR)/init.dts \
 SND_DRIVER_VM_DTB := $(BUILD_DIR)/snd_driver_vm.dtb
 CLIENT_VM_DTB := $(BUILD_DIR)/client_vm.dtb
 
-SDDF := $(abspath ../../dep/sddf)
+SDDF_DIR := $(abspath ../../dep/sddf)
 
-SDDF_SERIAL_COMPONENTS := $(SDDF)/serial/components
-SDDF_SOUND_COMPONENTS := $(SDDF)/sound/components
-SDDF_UTIL := $(SDDF)/util
-
-SDDF_SERIAL_DRIVER_qemu_arm_virt := $(SDDF)/drivers/serial/arm
-SDDF_SERIAL_DRIVER_odroidc4 := $(SDDF)/drivers/serial/meson
+SDDF_SERIAL_DRIVER_qemu_arm_virt := $(SDDF_DIR)/drivers/serial/arm
+SDDF_SERIAL_DRIVER_odroidc4 := $(SDDF_DIR)/drivers/serial/meson
 SDDF_SERIAL_DRIVER := ${SDDF_SERIAL_DRIVER_${BOARD}}
+SERIAL_CONFIG_INCLUDE:= include/serial_config
 
 ELFS := client_vmm.elf \
 		serial_virt_tx.elf \
@@ -116,20 +113,14 @@ CLIENT_VMM_OBJS :=	$(VMM_OBJS) \
 					mmio.o
 
 SOUND_VIRT_OBJS :=	sound_virt.o \
-					sddf_printf.o \
-					sddf_putchar_debug.o \
-					sddf_cache.o
+					libsddf_util_debug.a 
 
 SND_DRIVER_VMM_OBJS :=	$(VMM_OBJS) \
 						snd_driver_images.o \
 						snd_driver_vmm.o \
 						console.o \
 						mmio.o \
-						sddf_cache.o
-
-SERIAL_VIRT_TX_OBJS := virt_tx.o sddf_printf.o sddf_putchar_debug.o
-SERIAL_VIRT_RX_OBJS := virt_rx.o sddf_printf.o sddf_putchar_debug.o
-SERIAL_DRIVER_OBJS := uart.o sddf_printf.o sddf_putchar_debug.o
+						libsddf_util_debug.a 
 
 # Toolchain flags
 # FIXME: For optimisation we should consider providing the flag -mcpu.
@@ -148,7 +139,8 @@ CFLAGS := -mstrict-align \
 		  -Wall -Wno-unused-function -Werror \
 		  -I$(VMM_SRC_DIR)/arch/aarch64 -I$(VMM_SRC_DIR) -I$(VMM_SRC_DIR)/util -I$(BOARD_DIR)/include \
 		  -I$(SDDF_SERIAL_DRIVER)/include \
-		  -I$(SDDF)/include \
+		  -I$(SDDF_DIR)/include \
+		  -I$(SERIAL_CONFIG_INCLUDE) \
 		  -I$(LINUX_DIR)/include \
 		  -DBOARD_$(BOARD) \
 		  -DCONFIG_$(CONFIG) \
@@ -158,8 +150,8 @@ CFLAGS := -mstrict-align \
 CFLAGS_USERLEVEL :=	-g \
 					-Wno-unused-command-line-argument \
 		  			-Wall -Wno-unused-function -Werror \
-					-I$(SDDF) \
-					-I$(SDDF)/include \
+					-I$(SDDF_DIR) \
+					-I$(SDDF_DIR)/include \
 					-I$(VMM_SRC_DIR) \
 					-I$(LINUX_DIR)/include \
 					-DBOARD_$(BOARD) \
@@ -170,7 +162,7 @@ CFLAGS_USERLEVEL :=	-g \
 					$(NIX_CFLAGS_COMPILE)
 
 LDFLAGS := -L$(BOARD_DIR)/lib
-LIBS := -lmicrokit -Tmicrokit.ld
+LIBS := -lmicrokit -Tmicrokit.ld $(BUILD_DIR)/libsddf_util_debug.a
 
 
 .PHONY: all qemu clean
@@ -190,6 +182,36 @@ qemu: all
 
 directories:
 	$(shell mkdir -p $(BUILD_DIR))
+	$(shell mkdir -p $(BUILD_DIR)/util)
+	$(shell mkdir -p $(BUILD_DIR)/serial)
+
+SDDF_LIB_UTIL_DBG_OBJS := cache.o sddf_printf.o newlibc.o assert.o putchar_debug.o bitarray.o fsmalloc.o
+
+TOOLCHAIN ?= aarch64-none-elf
+AR := $(TOOLCHAIN)-ar
+RANLIB := ${TOOLCHAIN}-ranlib
+
+$(BUILD_DIR)/libsddf_util_debug.a: $(addprefix ${BUILD_DIR}/util/, ${SDDF_LIB_UTIL_DBG_OBJS})
+	${AR} rv $@ $^
+	${RANLIB} $@
+
+$(BUILD_DIR)/util/sddf_printf.o: ${SDDF_DIR}/util/printf.c
+	${CC} ${CFLAGS} -c -o $@ $<
+
+$(BUILD_DIR)/util/%.o: ${SDDF_DIR}/util/%.c
+	${CC} ${CFLAGS} -c -o $@ $<
+
+$(BUILD_DIR)/uart_driver.elf: $(BUILD_DIR)/serial/uart_driver.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+$(BUILD_DIR)/serial/uart_driver.o: ${SDDF_SERIAL_DRIVER}/uart.c
+	$(CC) -c $(CFLAGS) -I${SDDF_SERIAL_DRIVER}/include -o $@ $< 
+
+$(BUILD_DIR)/serial_virt_%.elf: $(BUILD_DIR)/serial/virt_%.o
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+$(BUILD_DIR)/serial/virt_%.o: ${SDDF_DIR}/serial/components/virt_%.c 
+	${CC} ${CFLAGS} -DSERIAL_NUM_CLIENTS=3 -o $@ -c $<
 
 SND_DRIVER_VM_USERLEVEL_INIT := $(LINUX_SND_DIR)/sound
 SND_DRIVER_VM_ETC := $(LINUX_SND_DIR)/board/$(BOARD)/asound.conf
@@ -262,15 +284,6 @@ $(BUILD_DIR)/%.o: $(VMM_SRC_DIR)/arch/aarch64/vgic/%.c Makefile
 $(BUILD_DIR)/%.o: $(VMM_SRC_DIR)/virtio/%.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
-$(BUILD_DIR)/sddf_%.o: $(SDDF_UTIL)/%.c Makefile
-	$(CC) -c $(CFLAGS) $< -o $@
-
-$(BUILD_DIR)/%.o: $(SDDF_SERIAL_COMPONENTS)/%.c Makefile
-	$(CC) -c $(CFLAGS) -DSERIAL_NUM_CLIENTS=3 -DSERIAL_TRANSFER_WITH_COLOUR=1 $< -o $@
-
-$(BUILD_DIR)/%.o: $(SDDF_SERIAL_DRIVER)/%.c Makefile
-	$(CC) -c $(CFLAGS) $< -o $@
-
 $(BUILD_DIR)/sound_%.o: $(SDDF_SOUND_COMPONENTS)/%.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
@@ -282,16 +295,6 @@ $(BUILD_DIR)/sound_virt.elf: $(addprefix $(BUILD_DIR)/, $(SOUND_VIRT_OBJS))
 
 $(BUILD_DIR)/snd_driver_vmm.elf: $(addprefix $(BUILD_DIR)/, $(SND_DRIVER_VMM_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
-$(BUILD_DIR)/serial_virt_tx.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_VIRT_TX_OBJS))
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
-$(BUILD_DIR)/serial_virt_rx.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_VIRT_RX_OBJS))
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
-$(BUILD_DIR)/uart_driver.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_DRIVER_OBJS))
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
 
 $(IMAGE_FILE) $(REPORT_FILE): $(addprefix $(BUILD_DIR)/, $(ELFS)) $(SYSTEM_DESCRIPTION) $(SND_DRIVER_VM_DIR) $(CLIENT_VM_DIR)
 	$(MICROKIT_TOOL) $(SYSTEM_DESCRIPTION) --search-path $(BUILD_DIR) $(SND_DRIVER_VM_DIR) $(CLIENT_VM_DIR) --board $(BOARD) --config $(CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)

--- a/examples/virtio-snd/Makefile
+++ b/examples/virtio-snd/Makefile
@@ -76,10 +76,16 @@ CLIENT_VM_DTB := $(BUILD_DIR)/client_vm.dtb
 
 SDDF_DIR := $(abspath ../../dep/sddf)
 
+ifeq ($(strip $(BOARD)), odroidc4)
+	export UART_DRIVER_DIR := meson
+else ifeq ($(strip $(BOARD)), qemu_arm_virt)
+	export UART_DRIVER_DIR := arm
+else
+$(error Unsupported BOARD given)
+endif
+
 SDDF_SOUND_COMPONENTS := $(SDDF_DIR)/sound/components
-SDDF_SERIAL_DRIVER_qemu_arm_virt := $(SDDF_DIR)/drivers/serial/arm
-SDDF_SERIAL_DRIVER_odroidc4 := $(SDDF_DIR)/drivers/serial/meson
-SDDF_SERIAL_DRIVER := ${SDDF_SERIAL_DRIVER_${BOARD}}
+SDDF_SERIAL_DRIVER := $(SDDF_DIR)/drivers/serial/$(UART_DRIVER_DIR)
 SERIAL_CONFIG_INCLUDE:= include/serial_config
 
 ELFS := client_vmm.elf \

--- a/examples/virtio-snd/Makefile
+++ b/examples/virtio-snd/Makefile
@@ -73,6 +73,7 @@ CLIENT_VM_DTB := $(BUILD_DIR)/client_vm.dtb
 
 SDDF_DIR := $(abspath ../../dep/sddf)
 
+SDDF_SOUND_COMPONENTS := $(SDDF_DIR)/sound/components
 SDDF_SERIAL_DRIVER_qemu_arm_virt := $(SDDF_DIR)/drivers/serial/arm
 SDDF_SERIAL_DRIVER_odroidc4 := $(SDDF_DIR)/drivers/serial/meson
 SDDF_SERIAL_DRIVER := ${SDDF_SERIAL_DRIVER_${BOARD}}
@@ -110,7 +111,8 @@ CLIENT_VMM_OBJS :=	$(VMM_OBJS) \
 					client_vmm.o \
 					console.o \
 					sound.o \
-					mmio.o
+                    mmio.o \
+                    libsddf_util_debug.a
 
 SOUND_VIRT_OBJS :=	sound_virt.o \
 					libsddf_util_debug.a 

--- a/examples/virtio-snd/board/odroidc4/virtio-snd.system
+++ b/examples/virtio-snd/board/odroidc4/virtio-snd.system
@@ -47,13 +47,10 @@
         <program_image path="client_vmm.elf" />
         <map mr="client_vm_ram_1" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         
-        <map mr="rx_free_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_1" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_1" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_1" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-
-        <map mr="tx_data_serial_vmm_1" vaddr="0x8_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_1" vaddr="0x8_600_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_1" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_1" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_1" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
 
         <map mr="snd_data" vaddr="0x9_200_000" perms="rw" cached="true" setvar_vaddr="sound_data"/>
         
@@ -73,13 +70,10 @@
         <program_image path="client_vmm.elf" />
         <map mr="client_vm_ram_2" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         
-        <map mr="rx_free_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_2" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_2" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_2" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-
-        <map mr="tx_data_serial_vmm_2" vaddr="0x8_800_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_2" vaddr="0x8_a00_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_2" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_2" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_2" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
 
         <map mr="snd_data" vaddr="0x9_200_000" perms="rw" cached="true" setvar_vaddr="sound_data"/>
         
@@ -158,96 +152,66 @@
         <irq irq="5" id="8" trigger="level" />
     </protection_domain>
 
-    <!-- Serial sDDF regions -->
-    <!-- Shared memory for the actual data transfered -->
-    <memory_region name="tx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_1" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_1" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_3" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_3" size="0x200_000" page_size="0x200_000" />
-    <!-- Regions for the shared ring buffers active by the driver and multiplexor -->
-    <memory_region name="rx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <!--
-        Regions for the shared ring buffers active by the multiplexor and the
-        client (in this case the client is the VMM)
-    -->
-    <memory_region name="tx_free_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
+    <!-- Serial sDDF data regions -->
+    <memory_region name="tx_data_serial_driver" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_driver" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_1" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_1" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_2" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_2" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_3" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_3" size="0x2_000" page_size="0x1_000" />
 
-    <memory_region name="tx_free_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
+    <!-- Serial sDDF queue regions -->
+    <memory_region name="rx_queue_serial_driver" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_driver" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_1" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_1" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_2" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_2" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_3" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_3" size="0x1_000" page_size="0x1_000"/>
 
-    <memory_region name="tx_free_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-
-    <!-- Multiplexor for transmit (TX) serial data -->
-    <protection_domain name="serial_virt_tx" priority="100" pp="true">
+    <!-- Serial TX Virtualiser -->
+    <protection_domain name="serial_virt_tx" priority="100">
         <program_image path="serial_virt_tx.elf" />
-         <!-- shared memory for driver/virt ring buffer mechanism -->
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
-        <!-- shared memory for virt/client ring buffer mechanism -->
-        <!-- Ring buffers between the multiplexor and VMM client  -->
-        <map mr="tx_free_serial_vmm_1" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client" />
-        <map mr="tx_active_serial_vmm_1" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client" />
-        <map mr="tx_free_serial_vmm_2" vaddr="0x5_200_000" perms="rw" cached="true" setvar_vaddr="tx_free_client2" />
-        <map mr="tx_active_serial_vmm_2" vaddr="0x5_400_000" perms="rw" cached="true" setvar_vaddr="tx_active_client2" />
-        <map mr="tx_free_serial_vmm_3" vaddr="0x5_600_000" perms="rw" cached="true" setvar_vaddr="tx_free_client3" />
-        <map mr="tx_active_serial_vmm_3" vaddr="0x5_800_000" perms="rw" cached="true" setvar_vaddr="tx_active_client3" />
-        <!-- Data regions between multiplexor/driver and vmm/mulitplexor -->
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
-        <!-- @ivanv: the virtual address of the data region needs to match what it is in the client as well,
-             this is very fragile and should be fixed. -->
-        <map mr="tx_data_serial_vmm_1" vaddr="0x8_400_000" perms="rw" cached="true" setvar_vaddr="tx_data_client" />
-        <map mr="tx_data_serial_vmm_2" vaddr="0x8_800_000" perms="rw" cached="true" setvar_vaddr="tx_data_client2" />
-        <map mr="tx_data_serial_vmm_3" vaddr="0x8_c00_000" perms="rw" cached="true" setvar_vaddr="tx_data_client3" />
+        <map mr="tx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
+        <map mr="tx_queue_serial_vmm_1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
+        <map mr="tx_queue_serial_vmm_2" vaddr="0x4_002_000" perms="rw" cached="true"/>
+        <map mr="tx_queue_serial_vmm_3" vaddr="0x4_003_000" perms="rw" cached="true"/>
+
+        <map mr="tx_data_serial_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
+        <map mr="tx_data_serial_vmm_1" vaddr="0x4_006_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
+        <map mr="tx_data_serial_vmm_2" vaddr="0x4_008_000" perms="r" cached="true"/>
+        <map mr="tx_data_serial_vmm_3" vaddr="0x4_00a_000" perms="r" cached="true"/>
     </protection_domain>
-    <!-- Multiplexor for receive (RX) serial data -->
-    <protection_domain name="serial_virt_rx" priority="100" pp="true">
+
+    <!-- Serial RX Virtualiser -->
+    <protection_domain name="serial_virt_rx" priority="100">
         <program_image path="serial_virt_rx.elf" />
-         <!-- shared memory for driver/virt ring buffer mechanism -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_driver" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_driver" />
-        <!-- Ring buffers between the multiplexor and VMM client  -->
-        <map mr="rx_free_serial_vmm_1" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_client" />
-        <map mr="rx_active_serial_vmm_1" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active_client" />
-        <map mr="rx_free_serial_vmm_2" vaddr="0x5_200_000" perms="rw" cached="true" setvar_vaddr="rx_free_client2" />
-        <map mr="rx_active_serial_vmm_2" vaddr="0x5_400_000" perms="rw" cached="true" setvar_vaddr="rx_active_client2" />
-        <map mr="rx_free_serial_vmm_3" vaddr="0x5_600_000" perms="rw" cached="true" setvar_vaddr="rx_free_client3" />
-        <map mr="rx_active_serial_vmm_3" vaddr="0x5_800_000" perms="rw" cached="true" setvar_vaddr="rx_active_client3" />
+        <map mr="rx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
+        <map mr="rx_queue_serial_vmm_1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
+        <map mr="rx_queue_serial_vmm_2" vaddr="0x4_002_000" perms="rw" cached="true"/>
+        <map mr="rx_queue_serial_vmm_3" vaddr="0x4_003_000" perms="rw" cached="true"/>
 
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
-        <map mr="rx_data_serial_vmm_1" vaddr="0x8_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_client" />
-        <map mr="rx_data_serial_vmm_2" vaddr="0x8_a00_000" perms="rw" cached="true" setvar_vaddr="rx_data_client2" />
-        <map mr="rx_data_serial_vmm_3" vaddr="0x8_e00_000" perms="rw" cached="true" setvar_vaddr="rx_data_client3" />
+        <map mr="rx_data_serial_driver" vaddr="0x4_004_000" perms="r" cached="true" setvar_vaddr="rx_data_drv" />
+        <map mr="rx_data_serial_vmm_1" vaddr="0x4_006_000" perms="rw" cached="true" setvar_vaddr="rx_data_cli0" />
+        <map mr="rx_data_serial_vmm_2" vaddr="0x4_008_000" perms="rw" cached="true"/>
+        <map mr="rx_data_serial_vmm_3" vaddr="0x4_00a_000" perms="rw" cached="true"/>
     </protection_domain>
 
-    <!-- The driver for talking to the hardware serial device, in this case UART -->
-    <protection_domain name="uart_driver" priority="100" pp="true">
+    <!-- Serial Driver -->
+    <protection_domain name="uart" priority="110">
         <program_image path="uart_driver.elf" />
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
-        <!-- Data region -->
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" />
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" />
-        <!-- shared memory for ring buffer mechanism -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-        <!-- UART IRQ -->
-        <irq irq="225" id="1" trigger="edge" />
+
+        <map mr="rx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_serial_driver" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+
+        <map mr="rx_data_serial_driver" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_serial_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+
+        <irq irq="225" id="0" trigger="edge" /> <!-- UART interrupt -->
     </protection_domain>
 
     <channel>
@@ -266,8 +230,8 @@
     </channel>
 
     <channel>
-        <end pd="uart_driver" id="8"/>
-        <end pd="serial_virt_tx" id="9"/>
+        <end pd="uart_driver" id="1"/>
+        <end pd="serial_virt_tx" id="0"/>
     </channel>
 
     <channel>
@@ -286,8 +250,8 @@
     </channel>
 
     <channel>
-        <end pd="uart_driver" id="10"/>
-        <end pd="serial_virt_rx" id="11"/>
+        <end pd="uart_driver" id="2"/>
+        <end pd="serial_virt_rx" id="0"/>
     </channel>
 
     <!-- Sound -->

--- a/examples/virtio-snd/board/odroidc4/virtio-snd.system
+++ b/examples/virtio-snd/board/odroidc4/virtio-snd.system
@@ -201,7 +201,7 @@
     </protection_domain>
 
     <!-- Serial Driver -->
-    <protection_domain name="uart" priority="110">
+    <protection_domain name="uart_driver" priority="110">
         <program_image path="uart_driver.elf" />
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
 

--- a/examples/virtio-snd/board/qemu_arm_virt/virtio-snd.system
+++ b/examples/virtio-snd/board/qemu_arm_virt/virtio-snd.system
@@ -41,13 +41,10 @@
         <program_image path="client_vmm.elf" />
         <map mr="client_vm_ram_1" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         
-        <map mr="rx_free_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_1" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_1" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_1" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-
-        <map mr="tx_data_serial_vmm_1" vaddr="0x8_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_1" vaddr="0x8_600_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_1" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_1" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_1" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
 
         <map mr="snd_data" vaddr="0x9_200_000" perms="rw" cached="true" setvar_vaddr="sound_data"/>
         
@@ -67,13 +64,10 @@
         <program_image path="client_vmm.elf" />
         <map mr="client_vm_ram_2" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         
-        <map mr="rx_free_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_2" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_2" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_2" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-
-        <map mr="tx_data_serial_vmm_2" vaddr="0x8_800_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_2" vaddr="0x8_a00_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_2" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_2" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_2" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
 
         <map mr="snd_data" vaddr="0x9_200_000" perms="rw" cached="true" setvar_vaddr="sound_data"/>
         
@@ -116,13 +110,10 @@
         <program_image path="snd_driver_vmm.elf" />
         <map mr="snd_driver_vm_ram" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
 
-        <map mr="rx_free_serial_vmm_3" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_3" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_3" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_3" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-
-        <map mr="tx_data_serial_vmm_3" vaddr="0x8_c00_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_3" vaddr="0x8_e00_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_3" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_3" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_3" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_3" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
 
         <setvar symbol="sound_data_paddr" region_paddr="snd_data" />
         <map mr="snd_shared" vaddr="0x12_000_000" perms="rw" cached="false" setvar_vaddr="sound_shared_state" />
@@ -148,96 +139,66 @@
         <irq irq="37" id="5" />
     </protection_domain>
 
-    <!-- Serial sDDF regions -->
-    <!-- Shared memory for the actual data transfered -->
-    <memory_region name="tx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_1" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_1" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_3" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_3" size="0x200_000" page_size="0x200_000" />
-    <!-- Regions for the shared ring buffers active by the driver and multiplexor -->
-    <memory_region name="rx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <!--
-        Regions for the shared ring buffers active by the multiplexor and the
-        client (in this case the client is the VMM)
-    -->
-    <memory_region name="tx_free_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
+    <!-- Serial sDDF data regions -->
+    <memory_region name="tx_data_serial_driver" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_driver" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_1" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_1" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_2" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_2" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_3" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_3" size="0x2_000" page_size="0x1_000" />
 
-    <memory_region name="tx_free_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
+    <!-- Serial sDDF queue regions -->
+    <memory_region name="rx_queue_serial_driver" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_driver" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_1" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_1" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_2" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_2" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_3" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_3" size="0x1_000" page_size="0x1_000"/>
 
-    <memory_region name="tx_free_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-
-    <!-- Multiplexor for transmit (TX) serial data -->
-    <protection_domain name="serial_virt_tx" priority="100" pp="true">
+    <!-- Serial TX Virtualiser -->
+    <protection_domain name="serial_virt_tx" priority="100">
         <program_image path="serial_virt_tx.elf" />
-         <!-- shared memory for driver/virt ring buffer mechanism -->
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
-        <!-- shared memory for virt/client ring buffer mechanism -->
-        <!-- Ring buffers between the multiplexor and VMM client  -->
-        <map mr="tx_free_serial_vmm_1" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client" />
-        <map mr="tx_active_serial_vmm_1" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client" />
-        <map mr="tx_free_serial_vmm_2" vaddr="0x5_200_000" perms="rw" cached="true" setvar_vaddr="tx_free_client2" />
-        <map mr="tx_active_serial_vmm_2" vaddr="0x5_400_000" perms="rw" cached="true" setvar_vaddr="tx_active_client2" />
-        <map mr="tx_free_serial_vmm_3" vaddr="0x5_600_000" perms="rw" cached="true" setvar_vaddr="tx_free_client3" />
-        <map mr="tx_active_serial_vmm_3" vaddr="0x5_800_000" perms="rw" cached="true" setvar_vaddr="tx_active_client3" />
-        <!-- Data regions between multiplexor/driver and vmm/mulitplexor -->
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
-        <!-- @ivanv: the virtual address of the data region needs to match what it is in the client as well,
-             this is very fragile and should be fixed. -->
-        <map mr="tx_data_serial_vmm_1" vaddr="0x8_400_000" perms="rw" cached="true" setvar_vaddr="tx_data_client" />
-        <map mr="tx_data_serial_vmm_2" vaddr="0x8_800_000" perms="rw" cached="true" setvar_vaddr="tx_data_client2" />
-        <map mr="tx_data_serial_vmm_3" vaddr="0x8_c00_000" perms="rw" cached="true" setvar_vaddr="tx_data_client3" />
+        <map mr="tx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
+        <map mr="tx_queue_serial_vmm_1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
+        <map mr="tx_queue_serial_vmm_2" vaddr="0x4_002_000" perms="rw" cached="true"/>
+        <map mr="tx_queue_serial_vmm_3" vaddr="0x4_003_000" perms="rw" cached="true"/>
+
+        <map mr="tx_data_serial_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
+        <map mr="tx_data_serial_vmm_1" vaddr="0x4_006_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
+        <map mr="tx_data_serial_vmm_2" vaddr="0x4_008_000" perms="r" cached="true"/>
+        <map mr="tx_data_serial_vmm_3" vaddr="0x4_00a_000" perms="r" cached="true"/>
     </protection_domain>
-    <!-- Multiplexor for receive (RX) serial data -->
-    <protection_domain name="serial_virt_rx" priority="100" pp="true">
+
+    <!-- Serial RX Virtualiser -->
+    <protection_domain name="serial_virt_rx" priority="100">
         <program_image path="serial_virt_rx.elf" />
-         <!-- shared memory for driver/virt ring buffer mechanism -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_driver" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_driver" />
-        <!-- Ring buffers between the multiplexor and VMM client  -->
-        <map mr="rx_free_serial_vmm_1" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_client" />
-        <map mr="rx_active_serial_vmm_1" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active_client" />
-        <map mr="rx_free_serial_vmm_2" vaddr="0x5_200_000" perms="rw" cached="true" setvar_vaddr="rx_free_client2" />
-        <map mr="rx_active_serial_vmm_2" vaddr="0x5_400_000" perms="rw" cached="true" setvar_vaddr="rx_active_client2" />
-        <map mr="rx_free_serial_vmm_3" vaddr="0x5_600_000" perms="rw" cached="true" setvar_vaddr="rx_free_client3" />
-        <map mr="rx_active_serial_vmm_3" vaddr="0x5_800_000" perms="rw" cached="true" setvar_vaddr="rx_active_client3" />
+        <map mr="rx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
+        <map mr="rx_queue_serial_vmm_1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
+        <map mr="rx_queue_serial_vmm_2" vaddr="0x4_002_000" perms="rw" cached="true"/>
+        <map mr="rx_queue_serial_vmm_3" vaddr="0x4_003_000" perms="rw" cached="true"/>
 
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
-        <map mr="rx_data_serial_vmm_1" vaddr="0x8_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_client" />
-        <map mr="rx_data_serial_vmm_2" vaddr="0x8_a00_000" perms="rw" cached="true" setvar_vaddr="rx_data_client2" />
-        <map mr="rx_data_serial_vmm_3" vaddr="0x8_e00_000" perms="rw" cached="true" setvar_vaddr="rx_data_client3" />
+        <map mr="rx_data_serial_driver" vaddr="0x4_004_000" perms="r" cached="true" setvar_vaddr="rx_data_drv" />
+        <map mr="rx_data_serial_vmm_1" vaddr="0x4_006_000" perms="rw" cached="true" setvar_vaddr="rx_data_cli0" />
+        <map mr="rx_data_serial_vmm_2" vaddr="0x4_008_000" perms="rw" cached="true"/>
+        <map mr="rx_data_serial_vmm_3" vaddr="0x4_00a_000" perms="rw" cached="true"/>
     </protection_domain>
 
-    <!-- The driver for talking to the hardware serial device, in this case UART -->
-    <protection_domain name="uart_driver" priority="100" pp="true">
+    <!-- Serial Driver -->
+    <protection_domain name="uart" priority="110">
         <program_image path="uart_driver.elf" />
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
-        <!-- Data region -->
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" />
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" />
-        <!-- shared memory for ring buffer mechanism -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-        <!-- UART IRQ -->
-        <irq irq="33" id="1" />
+
+        <map mr="rx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_serial_driver" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+
+        <map mr="rx_data_serial_driver" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_serial_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+
+        <irq irq="33" id="0" /> <!-- UART interrupt -->
     </protection_domain>
 
     <channel>
@@ -256,8 +217,8 @@
     </channel>
 
     <channel>
-        <end pd="uart_driver" id="8"/>
-        <end pd="serial_virt_tx" id="9"/>
+        <end pd="uart_driver" id="1"/>
+        <end pd="serial_virt_tx" id="0"/>
     </channel>
 
     <channel>
@@ -276,8 +237,8 @@
     </channel>
 
     <channel>
-        <end pd="uart_driver" id="10"/>
-        <end pd="serial_virt_rx" id="11"/>
+        <end pd="uart_driver" id="2"/>
+        <end pd="serial_virt_rx" id="0"/>
     </channel>
 
     <!-- Sound -->

--- a/examples/virtio-snd/board/qemu_arm_virt/virtio-snd.system
+++ b/examples/virtio-snd/board/qemu_arm_virt/virtio-snd.system
@@ -188,7 +188,7 @@
     </protection_domain>
 
     <!-- Serial Driver -->
-    <protection_domain name="uart" priority="110">
+    <protection_domain name="uart_driver" priority="110">
         <program_image path="uart_driver.elf" />
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
 

--- a/examples/virtio-snd/include/serial_config/serial_config.h
+++ b/examples/virtio-snd/include/serial_config/serial_config.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <microkit.h>
+#include <sddf/util/string.h>
+#include <sddf/serial/queue.h>
+#include <stdint.h>
+
+/* Only support transmission and not receive. */
+#define SERIAL_TX_ONLY 0
+
+/* Associate a colour with each client's output. */
+#define SERIAL_WITH_COLOUR 1
+
+/* Control character to switch input stream - ctrl \. To input character input twice. */
+#define SERIAL_SWITCH_CHAR 28
+
+/* Control character to terminate client number input. */
+#define SERIAL_TERMINATE_NUM '\r'
+
+/* Default baud rate of the uart device */
+#define UART_DEFAULT_BAUD 115200
+
+/* String to be printed to start console input */
+#define SERIAL_CONSOLE_BEGIN_STRING "Begin input\n"
+#define SERIAL_CONSOLE_BEGIN_STRING_LEN 13
+
+#define SERIAL_CLI0_NAME "CLIENT_VMM-1"
+#define SERIAL_CLI1_NAME "CLIENT_VMM-2"
+#define SERIAL_CLI2_NAME "SND_DRIVER_VMM"
+#define SERIAL_VIRT_RX_NAME "serial_virt_rx"
+#define SERIAL_VIRT_TX_NAME "serial_virt_tx"
+#define SERIAL_DRIVER_NAME "uart"
+
+#define SERIAL_QUEUE_SIZE                          0x1000
+#define SERIAL_DATA_REGION_SIZE                    0x2000
+
+#define SERIAL_TX_DATA_REGION_SIZE_DRIV            SERIAL_DATA_REGION_SIZE
+#define SERIAL_TX_DATA_REGION_SIZE_CLI0            SERIAL_DATA_REGION_SIZE
+#define SERIAL_TX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
+#define SERIAL_TX_DATA_REGION_SIZE_CLI2            SERIAL_DATA_REGION_SIZE
+
+#define SERIAL_RX_DATA_REGION_SIZE_DRIV            SERIAL_DATA_REGION_SIZE
+#define SERIAL_RX_DATA_REGION_SIZE_CLI0            SERIAL_DATA_REGION_SIZE
+#define SERIAL_RX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
+#define SERIAL_RX_DATA_REGION_SIZE_CLI2            SERIAL_DATA_REGION_SIZE
+
+#define SERIAL_MAX_TX_DATA_SIZE MAX(SERIAL_TX_DATA_REGION_SIZE_DRIV, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI2, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI0, SERIAL_TX_DATA_REGION_SIZE_CLI1)))
+#define SERIAL_MAX_RX_DATA_SIZE MAX(SERIAL_RX_DATA_REGION_SIZE_DRIV, MAX(SERIAL_RX_DATA_REGION_SIZE_CLI2, MAX(SERIAL_RX_DATA_REGION_SIZE_CLI0, SERIAL_RX_DATA_REGION_SIZE_CLI1)))
+#define SERIAL_MAX_DATA_SIZE MAX(SERIAL_MAX_TX_DATA_SIZE, SERIAL_MAX_RX_DATA_SIZE)
+_Static_assert(SERIAL_MAX_DATA_SIZE < UINT32_MAX,
+               "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
+
+static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue_handle,
+                                             serial_queue_t *rx_queue, char *rx_data, serial_queue_handle_t *tx_queue_handle,
+                                             serial_queue_t *tx_queue, char *tx_data)
+{
+    if (!sddf_strcmp(pd_name, SERIAL_CLI0_NAME)) {
+        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, rx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, tx_data);
+    } else if (!sddf_strcmp(pd_name, SERIAL_CLI1_NAME)) {
+        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_CLI1, rx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI1, tx_data);
+    } else if (!sddf_strcmp(pd_name, SERIAL_CLI2_NAME)) {
+        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_CLI2, rx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI2, tx_data);
+    }
+}
+
+static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue_handle,
+                                              uintptr_t cli_queue, uintptr_t cli_data)
+{
+    if (!sddf_strcmp(pd_name, SERIAL_VIRT_RX_NAME)) {
+        serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
+        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
+                          SERIAL_RX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_RX_DATA_REGION_SIZE_CLI0));
+        serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)(cli_queue + 2 * SERIAL_QUEUE_SIZE),
+                          SERIAL_RX_DATA_REGION_SIZE_CLI2, 
+                          (char *)(cli_data + SERIAL_RX_DATA_REGION_SIZE_CLI0 + SERIAL_RX_DATA_REGION_SIZE_CLI1));
+    } else if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
+        serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
+        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0));
+        serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)(cli_queue + 2 * SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_SIZE_CLI2,
+                          (char *)(cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0 + SERIAL_TX_DATA_REGION_SIZE_CLI1));
+    }
+}
+
+#if SERIAL_WITH_COLOUR
+static inline void serial_channel_names_init(char **client_names)
+{
+    client_names[0] = SERIAL_CLI0_NAME;
+    client_names[1] = SERIAL_CLI1_NAME;
+    client_names[2] = SERIAL_CLI2_NAME;
+}
+#endif

--- a/examples/virtio-snd/include/serial_config/serial_config.h
+++ b/examples/virtio-snd/include/serial_config/serial_config.h
@@ -24,12 +24,12 @@
 #define SERIAL_CONSOLE_BEGIN_STRING "Begin input\n"
 #define SERIAL_CONSOLE_BEGIN_STRING_LEN 13
 
-#define SERIAL_CLI0_NAME "CLIENT_VMM-1"
-#define SERIAL_CLI1_NAME "CLIENT_VMM-2"
+#define SERIAL_CLI0_NAME "CLIENT_VMM_1"
+#define SERIAL_CLI1_NAME "CLIENT_VMM_2"
 #define SERIAL_CLI2_NAME "SND_DRIVER_VMM"
 #define SERIAL_VIRT_RX_NAME "serial_virt_rx"
 #define SERIAL_VIRT_TX_NAME "serial_virt_tx"
-#define SERIAL_DRIVER_NAME "uart"
+#define SERIAL_DRIVER_NAME "uart_driver"
 
 #define SERIAL_QUEUE_SIZE                          0x1000
 #define SERIAL_DATA_REGION_SIZE                    0x2000

--- a/examples/virtio-snd/shell.nix
+++ b/examples/virtio-snd/shell.nix
@@ -6,6 +6,7 @@
         alsa-lib
       ];
       nativeInputs = with pkgs; [
+        llvm
         dtc
         qemu
         patchelf

--- a/examples/virtio/Makefile
+++ b/examples/virtio/Makefile
@@ -114,9 +114,15 @@ CLIENT_VM_2_DTB := $(BUILD_DIR)/client_vm_2.dtb
 SDDF_BLK_COMPONENTS := $(SDDF_DIR)/blk/components
 SDDF_BLK_UTIL := $(SDDF_DIR)/blk/util
 
-SDDF_SERIAL_DRIVER_qemu_arm_virt := $(SDDF_DIR)/drivers/serial/arm
-SDDF_SERIAL_DRIVER_odroidc4 := $(SDDF_DIR)/drivers/serial/meson
-SDDF_SERIAL_DRIVER := ${SDDF_SERIAL_DRIVER_${BOARD}}
+ifeq ($(strip $(BOARD)), odroidc4)
+	export UART_DRIVER_DIR := meson
+else ifeq ($(strip $(BOARD)), qemu_arm_virt)
+	export UART_DRIVER_DIR := arm
+else
+$(error Unsupported BOARD given)
+endif
+SDDF_SERIAL_DRIVER := $(SDDF_DIR)/drivers/serial/$(UART_DRIVER_DIR)
+
 SERIAL_CONFIG_INCLUDE:= include/serial_config
 
 ELFS := client_vmm_1.elf client_vmm_2.elf blk_driver_vmm.elf serial_virt_tx.elf serial_virt_rx.elf uart_driver.elf blk_virt.elf

--- a/examples/virtio/Makefile
+++ b/examples/virtio/Makefile
@@ -240,9 +240,8 @@ directories:
 
 SDDF_LIB_UTIL_DBG_OBJS := cache.o sddf_printf.o newlibc.o assert.o putchar_debug.o bitarray.o fsmalloc.o
 
-TOOLCHAIN ?= aarch64-none-elf
-AR := $(TOOLCHAIN)-ar
-RANLIB := ${TOOLCHAIN}-ranlib
+AR := llvm-ar
+RANLIB := llvm-ranlib
 
 $(BUILD_DIR)/libsddf_util_debug.a: $(addprefix ${BUILD_DIR}/util/, ${SDDF_LIB_UTIL_DBG_OBJS})
 	${AR} rv $@ $^

--- a/examples/virtio/Makefile
+++ b/examples/virtio/Makefile
@@ -32,6 +32,9 @@ DTC := dtc
 CC := clang
 CC_USERLEVEL := zig cc
 LD := ld.lld
+AR := llvm-ar
+RANLIB := llvm-ranlib
+
 MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
 
 # @ivanv: need to have a step for putting in the initrd node into the DTB,
@@ -239,9 +242,6 @@ directories:
 	$(shell mkdir -p $(BUILD_DIR)/serial)
 
 SDDF_LIB_UTIL_DBG_OBJS := cache.o sddf_printf.o newlibc.o assert.o putchar_debug.o bitarray.o fsmalloc.o
-
-AR := llvm-ar
-RANLIB := llvm-ranlib
 
 $(BUILD_DIR)/libsddf_util_debug.a: $(addprefix ${BUILD_DIR}/util/, ${SDDF_LIB_UTIL_DBG_OBJS})
 	${AR} rv $@ $^

--- a/examples/virtio/Makefile
+++ b/examples/virtio/Makefile
@@ -263,7 +263,7 @@ $(BUILD_DIR)/serial_virt_%.elf: $(BUILD_DIR)/serial/virt_%.o
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 $(BUILD_DIR)/serial/virt_%.o: ${SDDF_DIR}/serial/components/virt_%.c 
-	${CC} ${CFLAGS} -DSERIAL_NUM_CLIENTS=3 -o $@ -c $<
+	${CC} ${CFLAGS} -o $@ -c $<
 
 $(BUILD_DIR)/storage:
 	$(VMM_TOOLS)/mkvirtdisk $@ $(NUM_PART) $(BLK_SIZE) $(BLK_MEM)

--- a/examples/virtio/Makefile
+++ b/examples/virtio/Makefile
@@ -108,16 +108,13 @@ CLIENT_VM_2_DTS_OVERLAYS_odroidc4 :=	$(CLIENT_VM_2_DTS_DIR)/init.dts \
 CLIENT_VM_2_DTS_OVERLAYS := ${CLIENT_VM_2_DTS_OVERLAYS_${BOARD}}
 CLIENT_VM_2_DTB := $(BUILD_DIR)/client_vm_2.dtb
 
-SDDF_UTIL := $(SDDF_DIR)/util
-
 SDDF_BLK_COMPONENTS := $(SDDF_DIR)/blk/components
 SDDF_BLK_UTIL := $(SDDF_DIR)/blk/util
-
-SDDF_SERIAL_COMPONENTS := $(SDDF_DIR)/serial/components
 
 SDDF_SERIAL_DRIVER_qemu_arm_virt := $(SDDF_DIR)/drivers/serial/arm
 SDDF_SERIAL_DRIVER_odroidc4 := $(SDDF_DIR)/drivers/serial/meson
 SDDF_SERIAL_DRIVER := ${SDDF_SERIAL_DRIVER_${BOARD}}
+SERIAL_CONFIG_INCLUDE:= include/serial_config
 
 ELFS := client_vmm_1.elf client_vmm_2.elf blk_driver_vmm.elf serial_virt_tx.elf serial_virt_rx.elf uart_driver.elf blk_virt.elf
 
@@ -161,9 +158,7 @@ CLIENT_VMM_1_OBJS := $(VMM_OBJS) \
 					console.o \
 					block.o \
 					mmio.o \
-					sddf_blk_bitarray.o \
-					sddf_blk_fsmalloc.o \
-					sddf_printf.o sddf_putchar_debug.o \
+					libsddf_util_debug.a 
 
 CLIENT_VMM_2_OBJS := $(VMM_OBJS) \
 					client_images_2.o \
@@ -171,23 +166,15 @@ CLIENT_VMM_2_OBJS := $(VMM_OBJS) \
 					console.o \
 					block.o \
 					mmio.o \
-					sddf_blk_bitarray.o \
-					sddf_blk_fsmalloc.o \
-					sddf_printf.o sddf_putchar_debug.o \
+					libsddf_util_debug.a 
 
 BLK_DRIVER_VMM_OBJS := $(VMM_OBJS) \
 					blk_driver_images.o \
 					blk_driver_vmm.o \
 					console.o \
-					mmio.o \
+					mmio.o 
 
-
-# sddf_printf.o sdd_putchar_debug.o only needed during debug mode
-SERIAL_VIRT_TX_OBJS := virt_tx.o sddf_printf.o sddf_putchar_debug.o
-SERIAL_VIRT_RX_OBJS := virt_rx.o sddf_printf.o sddf_putchar_debug.o
-SERIAL_DRIVER_OBJS := uart.o sddf_printf.o sddf_putchar_debug.o
-
-BLK_VIRT_OBJS := sddf_blk_virt.o sddf_cache.o sddf_blk_fsmalloc.o sddf_blk_bitarray.o sddf_blk_util.o sddf_printf.o sddf_putchar_debug.o 
+BLK_VIRT_OBJS := sddf_blk_virt.o libsddf_util_debug.a
 UIO_BLK_DRIVER_OBJS := blk.o libuio.o
 
 # Toolchain flags
@@ -205,8 +192,8 @@ CFLAGS := -mstrict-align \
 		  -Wno-unused-command-line-argument \
 		  -Wall -Wno-unused-function -Werror \
 		  -I$(VMM_SRC_DIR)/arch/aarch64 -I$(VMM_SRC_DIR) -I$(VMM_SRC_DIR)/util -I$(BOARD_DIR)/include \
-		  -I$(SDDF_SERIAL_DRIVER)/include \
 		  -I$(SDDF_DIR)/include \
+		  -I$(SERIAL_CONFIG_INCLUDE) \
 		  -DBOARD_$(BOARD) \
 		  -DCONFIG_$(CONFIG) \
 		  -target aarch64-none-elf
@@ -221,7 +208,7 @@ CFLAGS_LINUX :=	-g3 \
 				-target aarch64-linux-gnu
 
 LDFLAGS := -L$(BOARD_DIR)/lib
-LIBS := -lmicrokit -Tmicrokit.ld
+LIBS := -lmicrokit -Tmicrokit.ld $(BUILD_DIR)/libsddf_util_debug.a
 
 ifeq ($(BOARD), qemu_arm_virt)
 	NUM_PART = 2
@@ -248,6 +235,36 @@ qemu: all $(BUILD_DIR)/storage
 
 directories:
 	$(shell mkdir -p $(BUILD_DIR))
+	$(shell mkdir -p $(BUILD_DIR)/util)
+	$(shell mkdir -p $(BUILD_DIR)/serial)
+
+SDDF_LIB_UTIL_DBG_OBJS := cache.o sddf_printf.o newlibc.o assert.o putchar_debug.o bitarray.o fsmalloc.o
+
+TOOLCHAIN ?= aarch64-none-elf
+AR := $(TOOLCHAIN)-ar
+RANLIB := ${TOOLCHAIN}-ranlib
+
+$(BUILD_DIR)/libsddf_util_debug.a: $(addprefix ${BUILD_DIR}/util/, ${SDDF_LIB_UTIL_DBG_OBJS})
+	${AR} rv $@ $^
+	${RANLIB} $@
+
+$(BUILD_DIR)/util/sddf_printf.o: ${SDDF_DIR}/util/printf.c
+	${CC} ${CFLAGS} -c -o $@ $<
+
+$(BUILD_DIR)/util/%.o: ${SDDF_DIR}/util/%.c
+	${CC} ${CFLAGS} -c -o $@ $<
+
+$(BUILD_DIR)/uart_driver.elf: $(BUILD_DIR)/serial/uart_driver.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+$(BUILD_DIR)/serial/uart_driver.o: ${SDDF_SERIAL_DRIVER}/uart.c
+	$(CC) -c $(CFLAGS) -I${SDDF_SERIAL_DRIVER}/include -o $@ $< 
+
+$(BUILD_DIR)/serial_virt_%.elf: $(BUILD_DIR)/serial/virt_%.o
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+$(BUILD_DIR)/serial/virt_%.o: ${SDDF_DIR}/serial/components/virt_%.c 
+	${CC} ${CFLAGS} -DSERIAL_NUM_CLIENTS=3 -o $@ -c $<
 
 $(BUILD_DIR)/storage:
 	$(VMM_TOOLS)/mkvirtdisk $@ $(NUM_PART) $(BLK_SIZE) $(BLK_MEM)
@@ -325,15 +342,6 @@ $(BUILD_DIR)/%.o: $(VMM_SRC_DIR)/arch/aarch64/vgic/%.c Makefile
 $(BUILD_DIR)/%.o: $(VMM_SRC_DIR)/virtio/%.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
-$(BUILD_DIR)/sddf_%.o: $(SDDF_UTIL)/%.c Makefile
-	$(CC) -c $(CFLAGS) $< -o $@
-
-$(BUILD_DIR)/%.o: $(SDDF_SERIAL_COMPONENTS)/%.c Makefile
-	$(CC) -c $(CFLAGS) -DSERIAL_NUM_CLIENTS=3 -DSERIAL_TRANSFER_WITH_COLOUR=1 $< -o $@
-
-$(BUILD_DIR)/%.o: $(SDDF_SERIAL_DRIVER)/%.c Makefile
-	$(CC) -c $(CFLAGS) $< -o $@
-
 $(BUILD_DIR)/sddf_blk_%.o: $(SDDF_BLK_COMPONENTS)/%.c Makefile
 	$(CC) -c $(CFLAGS) -DBLK_NUM_CLIENTS=2 $< -o $@
 
@@ -350,15 +358,6 @@ $(BUILD_DIR)/blk_driver_vmm.elf: $(addprefix $(BUILD_DIR)/, $(BLK_DRIVER_VMM_OBJ
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 $(BUILD_DIR)/blk_virt.elf: $(addprefix $(BUILD_DIR)/, $(BLK_VIRT_OBJS))
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
-$(BUILD_DIR)/serial_virt_tx.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_VIRT_TX_OBJS))
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
-$(BUILD_DIR)/serial_virt_rx.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_VIRT_RX_OBJS))
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
-$(BUILD_DIR)/uart_driver.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_DRIVER_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 $(BUILD_DIR)/postmark: $(LINUX_BLK_DIR)/postmark.c

--- a/examples/virtio/README.md
+++ b/examples/virtio/README.md
@@ -4,9 +4,20 @@ This example shows off the virtIO support that libvmm provides using the
 [seL4 Device Driver Framework](https://github.com/au-ts/sddf) to talk to the
 actual hardware.
 
-The system has two Linux guests that are exactly the same, but we have separate sets of
-Linux images and initrd for both to ease experimentation when you want to only modify
-a single client.
+This example makes use of the following virtIO devices emulated by libvmm:
+* console
+* block
+
+The console device is emulated by using a native driver for the hardware's UART
+device from sDDF.
+
+The block device is emulated by a virtualised driver in a separate Linux
+virtual machine.
+
+The system has two Linux guests that act as clients of the virtIO devices.
+They are the same and have the same resources, but have separate sets of
+Linux images and root file systems to ease experimentation when you only
+wish to modify a single client.
 
 The example currently works on the following platforms:
 * QEMU ARM virt
@@ -94,6 +105,7 @@ local storage device. The ramdisk file supplied to QEMU is formatted during buil
 time to contain a FAT filesystem for both partitions.
 
 ### Hardware set up
-When running on the odroidc4, the system expects to read and write from the SD card.
-You will need to format the SD card yourself on the odroidc4 system.
+
+When running on one of the supported hardware platforms, the system expects to read
+and write from the SD card. You will need to format the SD card prior to booting.
 

--- a/examples/virtio/blk_driver_vmm.c
+++ b/examples/virtio/blk_driver_vmm.c
@@ -14,6 +14,8 @@
 #include <tcb.h>
 #include <vcpu.h>
 #include "virtio/console.h"
+#include <sddf/serial/queue.h>
+#include <serial_config.h>
 
 #define GUEST_RAM_SIZE 0x6000000
 
@@ -51,20 +53,18 @@ uintptr_t guest_ram_vaddr;
 #define UIO_CH 3
 
 /* Serial */
-#define SERIAL_MUX_TX_CH 4
-#define SERIAL_MUX_RX_CH 5
+#define SERIAL_VIRT_TX_CH 4
+#define SERIAL_VIRT_RX_CH 5
 
 #define VIRTIO_CONSOLE_IRQ (74)
 #define VIRTIO_CONSOLE_BASE (0x130000)
 #define VIRTIO_CONSOLE_SIZE (0x1000)
 
-uintptr_t serial_rx_free;
-uintptr_t serial_rx_active;
-uintptr_t serial_tx_free;
-uintptr_t serial_tx_active;
+serial_queue_t *serial_rx_queue;
+serial_queue_t *serial_tx_queue;
 
-uintptr_t serial_rx_data;
-uintptr_t serial_tx_data;
+char *serial_rx_data;
+char *serial_tx_data;
 
 static struct virtio_console_device virtio_console;
 
@@ -105,53 +105,21 @@ void init(void)
 
     assert(serial_rx_data);
     assert(serial_tx_data);
-    assert(serial_rx_active);
-    assert(serial_rx_free);
-    assert(serial_tx_active);
-    assert(serial_tx_free);
+    assert(serial_rx_queue);
+    assert(serial_tx_queue);
 
     /* Initialise our sDDF ring buffers for the serial device */
-    serial_queue_handle_t rxq, txq;
-    serial_queue_init(&rxq,
-                      (serial_queue_t *)serial_rx_free,
-                      (serial_queue_t *)serial_rx_active,
-                      true,
-                      NUM_ENTRIES,
-                      NUM_ENTRIES);
-    for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-        int ret = serial_enqueue_free(&rxq,
-                               serial_rx_data + (i * BUFFER_SIZE),
-                               BUFFER_SIZE);
-        if (ret != 0) {
-            microkit_dbg_puts(microkit_name);
-            microkit_dbg_puts(": server rx buffer population, unable to enqueue buffer\n");
-        }
-    }
-    serial_queue_init(&txq,
-                      (serial_queue_t *)serial_tx_free,
-                      (serial_queue_t *)serial_tx_active,
-                      true,
-                      NUM_ENTRIES,
-                      NUM_ENTRIES);
-    for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-        // Have to start at the memory region left of by the rx ring
-        int ret = serial_enqueue_free(&txq,
-                               serial_tx_data + ((i + NUM_ENTRIES) * BUFFER_SIZE),
-                               BUFFER_SIZE);
-        assert(ret == 0);
-        if (ret != 0) {
-            microkit_dbg_puts(microkit_name);
-            microkit_dbg_puts(": server tx buffer population, unable to enqueue buffer\n");
-        }
-    }
+    serial_queue_handle_t serial_rxq, serial_txq;
+    serial_cli_queue_init_sys(microkit_name, &serial_rxq, serial_rx_queue, serial_rx_data, &serial_txq, serial_tx_queue, serial_tx_data);
+
 
     /* Initialise virtIO console device */
     success = virtio_mmio_console_init(&virtio_console,
                                   VIRTIO_CONSOLE_BASE,
                                   VIRTIO_CONSOLE_SIZE,
                                   VIRTIO_CONSOLE_IRQ,
-                                  &rxq, &txq,
-                                  SERIAL_MUX_TX_CH);
+                                  &serial_rxq, &serial_txq,
+                                  SERIAL_VIRT_TX_CH);
     assert(success);
 
     /* Register the UIO IRQ */
@@ -186,7 +154,7 @@ void notified(microkit_channel ch)
         handled = true;
         break;
     }
-    case SERIAL_MUX_RX_CH:
+    case SERIAL_VIRT_RX_CH:
         virtio_console_handle_rx(&virtio_console);
         break;
     }

--- a/examples/virtio/board/odroidc4/virtio.system
+++ b/examples/virtio/board/odroidc4/virtio.system
@@ -109,7 +109,7 @@
     </protection_domain>
 
     <!-- Serial Driver -->
-    <protection_domain name="uart" priority="105">
+    <protection_domain name="uart_driver" priority="105">
         <program_image path="uart_driver.elf" />
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
 

--- a/examples/virtio/board/odroidc4/virtio.system
+++ b/examples/virtio/board/odroidc4/virtio.system
@@ -21,14 +21,10 @@
         <map mr="client_vm_ram_1" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         
         <!-- sDDF related regions for virtIO console -->
-        <!-- shared memory for queues -->
-        <map mr="rx_free_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_1" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_1" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_1" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-        <!-- sDDF data region -->
-        <map mr="tx_data_serial_vmm_1" vaddr="0x8_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_1" vaddr="0x8_600_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_1" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_1" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_1" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
         
         <!-- sDDF related regions for virtIO block -->
         <map mr="blk_config_vmm_1" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
@@ -47,14 +43,10 @@
         <map mr="client_vm_ram_2" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         
         <!-- sDDF related regions for virtIO console -->
-        <!-- shared memory for queues -->
-        <map mr="rx_free_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_2" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_2" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_2" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-        <!-- sDDF data region -->
-        <map mr="tx_data_serial_vmm_2" vaddr="0x8_800_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_2" vaddr="0x8_a00_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_2" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_2" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_2" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
         
         <!-- sDDF related regions for virtIO block -->
         <map mr="blk_config_vmm_2" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
@@ -68,96 +60,66 @@
         </virtual_machine>
     </protection_domain>
 
-    <!-- Serial sDDF regions -->
-    <!-- Shared memory for the actual data transfered -->
-    <memory_region name="tx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_1" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_1" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_3" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_3" size="0x200_000" page_size="0x200_000" />
-    <!-- Regions for the shared queues used by the driver and virtualiser -->
-    <memory_region name="rx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <!--
-        Regions for the shared queues used by the virtualiser and the
-        client (in this case the client is the VMM)
-    -->
-    <memory_region name="tx_free_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
+    <!-- Serial sDDF data regions -->
+    <memory_region name="tx_data_serial_driver" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_driver" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_1" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_1" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_2" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_2" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_3" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_3" size="0x2_000" page_size="0x1_000" />
 
-    <memory_region name="tx_free_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
+    <!-- Serial sDDF queue regions -->
+    <memory_region name="rx_queue_serial_driver" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_driver" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_1" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_1" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_2" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_2" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_3" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_3" size="0x1_000" page_size="0x1_000"/>
 
-    <memory_region name="tx_free_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-
-    <!-- Virtualiser for transmit (TX) serial data -->
-    <protection_domain name="serial_virt_tx" priority="100" pp="true">
+    <!-- Serial TX Virtualiser -->
+    <protection_domain name="serial_virt_tx" priority="104">
         <program_image path="serial_virt_tx.elf" />
-         <!-- shared memory for driver/virt queues -->
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
-        <!-- shared memory for virt/client queues -->
-        <!-- Queues between the virtualiser and VMM client  -->
-        <map mr="tx_free_serial_vmm_1" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client" />
-        <map mr="tx_active_serial_vmm_1" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client" />
-        <map mr="tx_free_serial_vmm_2" vaddr="0x5_200_000" perms="rw" cached="true" setvar_vaddr="tx_free_client2" />
-        <map mr="tx_active_serial_vmm_2" vaddr="0x5_400_000" perms="rw" cached="true" setvar_vaddr="tx_active_client2" />
-        <map mr="tx_free_serial_vmm_3" vaddr="0x5_600_000" perms="rw" cached="true" setvar_vaddr="tx_free_client3" />
-        <map mr="tx_active_serial_vmm_3" vaddr="0x5_800_000" perms="rw" cached="true" setvar_vaddr="tx_active_client3" />
-        <!-- Data regions between virtualiser/driver and vmm/virtualiser -->
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
-        <!-- @ivanv: the virtual address of the data region needs to match what it is in the client as well,
-             this is very fragile and should be fixed. -->
-        <map mr="tx_data_serial_vmm_1" vaddr="0x8_400_000" perms="rw" cached="true" setvar_vaddr="tx_data_client" />
-        <map mr="tx_data_serial_vmm_2" vaddr="0x8_800_000" perms="rw" cached="true" setvar_vaddr="tx_data_client2" />
-        <map mr="tx_data_serial_vmm_3" vaddr="0x8_c00_000" perms="rw" cached="true" setvar_vaddr="tx_data_client3" />
+        <map mr="tx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
+        <map mr="tx_queue_serial_vmm_1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
+        <map mr="tx_queue_serial_vmm_2" vaddr="0x4_002_000" perms="rw" cached="true"/>
+        <map mr="tx_queue_serial_vmm_3" vaddr="0x4_003_000" perms="rw" cached="true"/>
+
+        <map mr="tx_data_serial_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
+        <map mr="tx_data_serial_vmm_1" vaddr="0x4_006_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
+        <map mr="tx_data_serial_vmm_2" vaddr="0x4_008_000" perms="r" cached="true"/>
+        <map mr="tx_data_serial_vmm_3" vaddr="0x4_00a_000" perms="r" cached="true"/>
     </protection_domain>
-    <!-- Virtualiser for receive (RX) serial data -->
-    <protection_domain name="serial_virt_rx" priority="100" pp="true">
+
+    <!-- Serial RX Virtualiser -->
+    <protection_domain name="serial_virt_rx" priority="103">
         <program_image path="serial_virt_rx.elf" />
-         <!-- shared memory for driver/virt queues -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_driver" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_driver" />
-        <!-- Queues between the virtualiser and VMM client  -->
-        <map mr="rx_free_serial_vmm_1" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_client" />
-        <map mr="rx_active_serial_vmm_1" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active_client" />
-        <map mr="rx_free_serial_vmm_2" vaddr="0x5_200_000" perms="rw" cached="true" setvar_vaddr="rx_free_client2" />
-        <map mr="rx_active_serial_vmm_2" vaddr="0x5_400_000" perms="rw" cached="true" setvar_vaddr="rx_active_client2" />
-        <map mr="rx_free_serial_vmm_3" vaddr="0x5_600_000" perms="rw" cached="true" setvar_vaddr="rx_free_client3" />
-        <map mr="rx_active_serial_vmm_3" vaddr="0x5_800_000" perms="rw" cached="true" setvar_vaddr="rx_active_client3" />
+        <map mr="rx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
+        <map mr="rx_queue_serial_vmm_1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
+        <map mr="rx_queue_serial_vmm_2" vaddr="0x4_002_000" perms="rw" cached="true"/>
+        <map mr="rx_queue_serial_vmm_3" vaddr="0x4_003_000" perms="rw" cached="true"/>
 
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
-        <map mr="rx_data_serial_vmm_1" vaddr="0x8_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_client" />
-        <map mr="rx_data_serial_vmm_2" vaddr="0x8_a00_000" perms="rw" cached="true" setvar_vaddr="rx_data_client2" />
-        <map mr="rx_data_serial_vmm_3" vaddr="0x8_e00_000" perms="rw" cached="true" setvar_vaddr="rx_data_client3" />
+        <map mr="rx_data_serial_driver" vaddr="0x4_004_000" perms="r" cached="true" setvar_vaddr="rx_data_drv" />
+        <map mr="rx_data_serial_vmm_1" vaddr="0x4_006_000" perms="rw" cached="true" setvar_vaddr="rx_data_cli0" />
+        <map mr="rx_data_serial_vmm_2" vaddr="0x4_008_000" perms="rw" cached="true"/>
+        <map mr="rx_data_serial_vmm_3" vaddr="0x4_00a_000" perms="rw" cached="true"/>
     </protection_domain>
 
-    <!-- The driver for talking to the hardware serial device, in this case UART -->
-    <protection_domain name="uart_driver" priority="100" pp="true">
+    <!-- Serial Driver -->
+    <protection_domain name="uart" priority="105">
         <program_image path="uart_driver.elf" />
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
-        <!-- Data region -->
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" />
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" />
-        <!-- shared memory for queues -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-        <!-- UART IRQ -->
-        <irq irq="225" id="1" trigger="edge" />
+
+        <map mr="rx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_serial_driver" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+
+        <map mr="rx_data_serial_driver" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_serial_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+
+        <irq irq="225" id="0" trigger="edge" /> <!-- UART interrupt -->
     </protection_domain>
 
     <channel>
@@ -176,8 +138,8 @@
     </channel>
 
     <channel>
-        <end pd="uart_driver" id="8"/>
-        <end pd="serial_virt_tx" id="9"/>
+        <end pd="uart_driver" id="1"/>
+        <end pd="serial_virt_tx" id="0"/>
     </channel>
 
     <channel>
@@ -196,8 +158,8 @@
     </channel>
 
     <channel>
-        <end pd="uart_driver" id="10"/>
-        <end pd="serial_virt_rx" id="11"/>
+        <end pd="uart_driver" id="2"/>
+        <end pd="serial_virt_rx" id="0"/>
     </channel>
 
     <!-- Block sDDF regions -->
@@ -223,13 +185,10 @@
         <program_image path="blk_driver_vmm.elf" />
         <map mr="blk_driver_vm_ram" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
 
-        <map mr="rx_free_serial_vmm_3" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_3" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_3" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_3" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-
-        <map mr="tx_data_serial_vmm_3" vaddr="0x8_c00_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_3" vaddr="0x8_e00_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_3" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_3" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_3" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_3" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
 
         <virtual_machine name="blk_driver_linux" id="0" priority="200">
             <map mr="blk_driver_vm_ram" vaddr="0x20000000" perms="rwx" />

--- a/examples/virtio/board/odroidc4/virtio.system
+++ b/examples/virtio/board/odroidc4/virtio.system
@@ -19,13 +19,13 @@
     <protection_domain name="CLIENT_VMM-1" priority="100">
         <program_image path="client_vmm_1.elf" />
         <map mr="client_vm_ram_1" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
-        
+
         <!-- sDDF related regions for virtIO console -->
         <map mr="tx_queue_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
         <map mr="rx_queue_serial_vmm_1" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
         <map mr="tx_data_serial_vmm_1" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
         <map mr="rx_data_serial_vmm_1" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
-        
+
         <!-- sDDF related regions for virtIO block -->
         <map mr="blk_config_vmm_1" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
         <map mr="req_blk_vmm_1" vaddr="0x103_800_000" perms="rw" cached="false" setvar_vaddr="blk_req_queue" />
@@ -41,13 +41,13 @@
     <protection_domain name="CLIENT_VMM-2" priority="100">
         <program_image path="client_vmm_2.elf" />
         <map mr="client_vm_ram_2" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
-        
+
         <!-- sDDF related regions for virtIO console -->
         <map mr="tx_queue_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
         <map mr="rx_queue_serial_vmm_2" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
         <map mr="tx_data_serial_vmm_2" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
         <map mr="rx_data_serial_vmm_2" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
-        
+
         <!-- sDDF related regions for virtIO block -->
         <map mr="blk_config_vmm_2" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
         <map mr="req_blk_vmm_2" vaddr="0x103_800_000" perms="rw" cached="false" setvar_vaddr="blk_req_queue" />
@@ -167,12 +167,12 @@
     <memory_region name="req_blk_driver" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="resp_blk_driver" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="data_blk_driver" size="0x200_000" page_size="0x200_000" />
-    
+
     <memory_region name="blk_config_vmm_1" size="0x1000" page_size="0x1000" />
     <memory_region name="req_blk_vmm_1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="resp_blk_vmm_1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="data_blk_vmm_1" size="0x200_000" page_size="0x200_000" />
-    
+
     <memory_region name="blk_config_vmm_2" size="0x1000" page_size="0x1000" />
     <memory_region name="data_blk_vmm_2" size="0x200_000" page_size="0x200_000" />
     <memory_region name="req_blk_vmm_2" size="0x200_000" page_size="0x200_000"/>
@@ -180,7 +180,7 @@
 
     <!-- UIO irq status page -->
     <memory_region name="uio_irq_status" size="0x1000" page_size="0x1000" />
-    
+
     <protection_domain name="BLK_DRIVER_VMM" priority="200" budget="100" period="400">
         <program_image path="blk_driver_vmm.elf" />
         <map mr="blk_driver_vm_ram" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
@@ -221,12 +221,12 @@
         <map mr="req_blk_driver" vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue_driver" />
         <map mr="resp_blk_driver" vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue_driver" />
         <map mr="data_blk_driver" vaddr="0x40800000" perms="rw" cached="true" setvar_vaddr="blk_data_driver" />
-        
+
         <map mr="blk_config_vmm_1" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
         <map mr="req_blk_vmm_1" vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue" />
         <map mr="resp_blk_vmm_1" vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
         <map mr="data_blk_vmm_1" vaddr="0x30600000" perms="rw" cached="true" setvar_vaddr="blk_data" />
-        
+
         <map mr="blk_config_vmm_2" vaddr="0x31000000" perms="rw" cached="false" setvar_vaddr="blk_config2" />
         <map mr="req_blk_vmm_2" vaddr="0x31200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue2" />
         <map mr="resp_blk_vmm_2" vaddr="0x31400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue2" />

--- a/examples/virtio/board/qemu_arm_virt/virtio.system
+++ b/examples/virtio/board/qemu_arm_virt/virtio.system
@@ -15,13 +15,13 @@
     <protection_domain name="CLIENT_VMM-1" priority="100">
         <program_image path="client_vmm_1.elf" />
         <map mr="client_vm_ram_1" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
-        
+
         <!-- sDDF related regions for virtIO console -->
         <map mr="tx_queue_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
         <map mr="rx_queue_serial_vmm_1" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
         <map mr="tx_data_serial_vmm_1" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
         <map mr="rx_data_serial_vmm_1" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
-        
+
         <!-- sDDF related regions for virtIO block -->
         <map mr="blk_config_vmm_1" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
         <map mr="req_blk_vmm_1" vaddr="0x103_800_000" perms="rw" cached="false" setvar_vaddr="blk_req_queue" />
@@ -37,13 +37,13 @@
     <protection_domain name="CLIENT_VMM-2" priority="100">
         <program_image path="client_vmm_2.elf" />
         <map mr="client_vm_ram_2" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
-        
+
         <!-- sDDF related regions for virtIO console -->
         <map mr="tx_queue_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
         <map mr="rx_queue_serial_vmm_2" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
         <map mr="tx_data_serial_vmm_2" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
         <map mr="rx_data_serial_vmm_2" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
-        
+
         <!-- sDDF related regions for virtIO block -->
         <!-- blk config region -->
         <map mr="blk_config_vmm_2" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
@@ -166,12 +166,12 @@
     <memory_region name="req_blk_driver" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="resp_blk_driver" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="data_blk_driver" size="0x200_000" page_size="0x200_000" />
-    
+
     <memory_region name="blk_config_vmm_1" size="0x1000" page_size="0x1000" />
     <memory_region name="req_blk_vmm_1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="resp_blk_vmm_1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="data_blk_vmm_1" size="0x200_000" page_size="0x200_000" />
-    
+
     <memory_region name="blk_config_vmm_2" size="0x1000" page_size="0x1000" />
     <memory_region name="data_blk_vmm_2" size="0x200_000" page_size="0x200_000" />
     <memory_region name="req_blk_vmm_2" size="0x200_000" page_size="0x200_000"/>
@@ -214,18 +214,18 @@
         <map mr="req_blk_driver" vaddr="0x20200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue_driver" />
         <map mr="resp_blk_driver" vaddr="0x20400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue_driver" />
         <map mr="data_blk_driver" vaddr="0x20800000" perms="rw" cached="true" setvar_vaddr="blk_data_driver" />
-        
+
         <map mr="blk_config_vmm_1" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
         <map mr="req_blk_vmm_1" vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue" />
         <map mr="resp_blk_vmm_1" vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
         <map mr="data_blk_vmm_1" vaddr="0x30600000" perms="rw" cached="true" setvar_vaddr="blk_data" />
-        
+
         <map mr="blk_config_vmm_2" vaddr="0x31000000" perms="rw" cached="false" setvar_vaddr="blk_config2" />
         <map mr="req_blk_vmm_2" vaddr="0x31200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue2" />
         <map mr="resp_blk_vmm_2" vaddr="0x31400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue2" />
         <map mr="data_blk_vmm_2" vaddr="0x31600000" perms="rw" cached="true" setvar_vaddr="blk_data2" />
     </protection_domain>
-    
+
     <channel>
         <end pd="CLIENT_VMM-1" id="3"/>
         <end pd="BLK_VIRT" id="3"/>

--- a/examples/virtio/board/qemu_arm_virt/virtio.system
+++ b/examples/virtio/board/qemu_arm_virt/virtio.system
@@ -17,14 +17,10 @@
         <map mr="client_vm_ram_1" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         
         <!-- sDDF related regions for virtIO console -->
-        <!-- shared memory for queues -->
-        <map mr="rx_free_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_1" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_1" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_1" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-        <!-- sDDF data region -->
-        <map mr="tx_data_serial_vmm_1" vaddr="0x8_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_1" vaddr="0x8_600_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_1" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_1" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_1" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_1" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
         
         <!-- sDDF related regions for virtIO block -->
         <map mr="blk_config_vmm_1" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config" />
@@ -43,14 +39,10 @@
         <map mr="client_vm_ram_2" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         
         <!-- sDDF related regions for virtIO console -->
-        <!-- shared memory for queues -->
-        <map mr="rx_free_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_2" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_2" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_2" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-        <!-- sDDF data region -->
-        <map mr="tx_data_serial_vmm_2" vaddr="0x8_800_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_2" vaddr="0x8_a00_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_2" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_2" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_2" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_2" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
         
         <!-- sDDF related regions for virtIO block -->
         <!-- blk config region -->
@@ -67,96 +59,66 @@
         </virtual_machine>
     </protection_domain>
 
-    <!-- Serial sDDF regions -->
-    <!-- Shared memory for the actual data transfered -->
-    <memory_region name="tx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_1" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_1" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_serial_vmm_3" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_serial_vmm_3" size="0x200_000" page_size="0x200_000" />
-    <!-- Regions for the queues used by the driver and virtualiser -->
-    <memory_region name="rx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
-    <!--
-        Regions for the shared queues used by the virtualiser and the
-        client (in this case the client is the VMM)
-    -->
-    <memory_region name="tx_free_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_1" size="0x200_000" page_size="0x200_000"/>
+    <!-- Serial sDDF data regions -->
+    <memory_region name="tx_data_serial_driver" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_driver" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_1" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_1" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_2" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_2" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="tx_data_serial_vmm_3" size="0x2_000" page_size="0x1_000" />
+    <memory_region name="rx_data_serial_vmm_3" size="0x2_000" page_size="0x1_000" />
 
-    <memory_region name="tx_free_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_2" size="0x200_000" page_size="0x200_000"/>
+    <!-- Serial sDDF queue regions -->
+    <memory_region name="rx_queue_serial_driver" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_driver" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_1" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_1" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_2" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_2" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="tx_queue_serial_vmm_3" size="0x1_000" page_size="0x1_000"/>
+    <memory_region name="rx_queue_serial_vmm_3" size="0x1_000" page_size="0x1_000"/>
 
-    <memory_region name="tx_free_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_vmm_3" size="0x200_000" page_size="0x200_000"/>
-
-    <!-- Virtualiser for transmit (TX) serial data -->
-    <protection_domain name="serial_virt_tx" priority="100" pp="true">
+    <!-- Serial TX Virtualiser -->
+    <protection_domain name="serial_virt_tx" priority="104">
         <program_image path="serial_virt_tx.elf" />
-         <!-- shared memory for driver/virt queues -->
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
-        <!-- shared memory for virt/client queues -->
-        <!-- Queues between the virtualiser and VMM client  -->
-        <map mr="tx_free_serial_vmm_1" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client" />
-        <map mr="tx_active_serial_vmm_1" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client" />
-        <map mr="tx_free_serial_vmm_2" vaddr="0x5_200_000" perms="rw" cached="true" setvar_vaddr="tx_free_client2" />
-        <map mr="tx_active_serial_vmm_2" vaddr="0x5_400_000" perms="rw" cached="true" setvar_vaddr="tx_active_client2" />
-        <map mr="tx_free_serial_vmm_3" vaddr="0x5_600_000" perms="rw" cached="true" setvar_vaddr="tx_free_client3" />
-        <map mr="tx_active_serial_vmm_3" vaddr="0x5_800_000" perms="rw" cached="true" setvar_vaddr="tx_active_client3" />
-        <!-- Data regions between virtualiser/driver and vmm/virtualiser -->
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
-        <!-- @ivanv: the virtual address of the data region needs to match what it is in the client as well,
-             this is very fragile and should be fixed. -->
-        <map mr="tx_data_serial_vmm_1" vaddr="0x8_400_000" perms="rw" cached="true" setvar_vaddr="tx_data_client" />
-        <map mr="tx_data_serial_vmm_2" vaddr="0x8_800_000" perms="rw" cached="true" setvar_vaddr="tx_data_client2" />
-        <map mr="tx_data_serial_vmm_3" vaddr="0x8_c00_000" perms="rw" cached="true" setvar_vaddr="tx_data_client3" />
+        <map mr="tx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
+        <map mr="tx_queue_serial_vmm_1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
+        <map mr="tx_queue_serial_vmm_2" vaddr="0x4_002_000" perms="rw" cached="true"/>
+        <map mr="tx_queue_serial_vmm_3" vaddr="0x4_003_000" perms="rw" cached="true"/>
+
+        <map mr="tx_data_serial_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
+        <map mr="tx_data_serial_vmm_1" vaddr="0x4_006_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
+        <map mr="tx_data_serial_vmm_2" vaddr="0x4_008_000" perms="r" cached="true"/>
+        <map mr="tx_data_serial_vmm_3" vaddr="0x4_00a_000" perms="r" cached="true"/>
     </protection_domain>
-    <!-- Virtualiser for receive (RX) serial data -->
-    <protection_domain name="serial_virt_rx" priority="100" pp="true">
+
+    <!-- Serial RX Virtualiser -->
+    <protection_domain name="serial_virt_rx" priority="103">
         <program_image path="serial_virt_rx.elf" />
-         <!-- shared memory for driver/virt queues -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_driver" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_driver" />
-        <!-- Queues between the virtualiser and VMM client  -->
-        <map mr="rx_free_serial_vmm_1" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_client" />
-        <map mr="rx_active_serial_vmm_1" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active_client" />
-        <map mr="rx_free_serial_vmm_2" vaddr="0x5_200_000" perms="rw" cached="true" setvar_vaddr="rx_free_client2" />
-        <map mr="rx_active_serial_vmm_2" vaddr="0x5_400_000" perms="rw" cached="true" setvar_vaddr="rx_active_client2" />
-        <map mr="rx_free_serial_vmm_3" vaddr="0x5_600_000" perms="rw" cached="true" setvar_vaddr="rx_free_client3" />
-        <map mr="rx_active_serial_vmm_3" vaddr="0x5_800_000" perms="rw" cached="true" setvar_vaddr="rx_active_client3" />
+        <map mr="rx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
+        <map mr="rx_queue_serial_vmm_1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
+        <map mr="rx_queue_serial_vmm_2" vaddr="0x4_002_000" perms="rw" cached="true"/>
+        <map mr="rx_queue_serial_vmm_3" vaddr="0x4_003_000" perms="rw" cached="true"/>
 
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
-        <map mr="rx_data_serial_vmm_1" vaddr="0x8_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_client" />
-        <map mr="rx_data_serial_vmm_2" vaddr="0x8_a00_000" perms="rw" cached="true" setvar_vaddr="rx_data_client2" />
-        <map mr="rx_data_serial_vmm_3" vaddr="0x8_e00_000" perms="rw" cached="true" setvar_vaddr="rx_data_client3" />
+        <map mr="rx_data_serial_driver" vaddr="0x4_004_000" perms="r" cached="true" setvar_vaddr="rx_data_drv" />
+        <map mr="rx_data_serial_vmm_1" vaddr="0x4_006_000" perms="rw" cached="true" setvar_vaddr="rx_data_cli0" />
+        <map mr="rx_data_serial_vmm_2" vaddr="0x4_008_000" perms="rw" cached="true"/>
+        <map mr="rx_data_serial_vmm_3" vaddr="0x4_00a_000" perms="rw" cached="true"/>
     </protection_domain>
 
-    <!-- The driver for talking to the hardware serial device, in this case UART -->
-    <protection_domain name="uart_driver" priority="100" pp="true">
+    <!-- Serial Driver -->
+    <protection_domain name="uart_driver" priority="105">
         <program_image path="uart_driver.elf" />
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
-        <!-- Data region -->
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" />
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" />
-        <!-- shared memory for queues -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-        <!-- UART IRQ -->
-        <irq irq="33" id="1" />
+
+        <map mr="rx_queue_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_serial_driver" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+
+        <map mr="rx_data_serial_driver" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_serial_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+
+        <irq irq="33" id="0" /> <!-- UART interrupt -->
     </protection_domain>
 
     <channel>
@@ -175,8 +137,8 @@
     </channel>
 
     <channel>
-        <end pd="uart_driver" id="8"/>
-        <end pd="serial_virt_tx" id="9"/>
+        <end pd="uart_driver" id="1"/>
+        <end pd="serial_virt_tx" id="0"/>
     </channel>
 
     <channel>
@@ -195,8 +157,8 @@
     </channel>
 
     <channel>
-        <end pd="uart_driver" id="10"/>
-        <end pd="serial_virt_rx" id="11"/>
+        <end pd="uart_driver" id="2"/>
+        <end pd="serial_virt_rx" id="0"/>
     </channel>
 
     <!-- Block sDDF regions -->
@@ -222,13 +184,10 @@
         <program_image path="blk_driver_vmm.elf" />
         <map mr="blk_driver_vm_ram" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
 
-        <map mr="rx_free_serial_vmm_3" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_3" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_3" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_3" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-
-        <map mr="tx_data_serial_vmm_3" vaddr="0x8_c00_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_3" vaddr="0x8_e00_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_3" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_3" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_3" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_3" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
 
         <virtual_machine name="blk_driver_linux" id="0" priority="200">
             <map mr="blk_driver_vm_ram" vaddr="0x40000000" perms="rwx" />

--- a/examples/virtio/include/serial_config/serial_config.h
+++ b/examples/virtio/include/serial_config/serial_config.h
@@ -5,6 +5,9 @@
 #include <sddf/serial/queue.h>
 #include <stdint.h>
 
+/* Number of clients */
+#define SERIAL_NUM_CLIENTS 3
+
 /* Only support transmission and not receive. */
 #define SERIAL_TX_ONLY 0
 

--- a/examples/virtio/include/serial_config/serial_config.h
+++ b/examples/virtio/include/serial_config/serial_config.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <microkit.h>
+#include <sddf/util/string.h>
+#include <sddf/serial/queue.h>
+#include <stdint.h>
+
+/* Only support transmission and not receive. */
+#define SERIAL_TX_ONLY 0
+
+/* Associate a colour with each client's output. */
+#define SERIAL_WITH_COLOUR 1
+
+/* Control character to switch input stream - ctrl \. To input character input twice. */
+#define SERIAL_SWITCH_CHAR 28
+
+/* Control character to terminate client number input. */
+#define SERIAL_TERMINATE_NUM '\r'
+
+/* Default baud rate of the uart device */
+#define UART_DEFAULT_BAUD 115200
+
+/* String to be printed to start console input */
+#define SERIAL_CONSOLE_BEGIN_STRING "Begin input\n"
+#define SERIAL_CONSOLE_BEGIN_STRING_LEN 13
+
+#define SERIAL_CLI0_NAME "CLIENT_VMM-1"
+#define SERIAL_CLI1_NAME "CLIENT_VMM-2"
+#define SERIAL_CLI2_NAME "BLK_DRIVER_VMM"
+#define SERIAL_VIRT_RX_NAME "serial_virt_rx"
+#define SERIAL_VIRT_TX_NAME "serial_virt_tx"
+#define SERIAL_DRIVER_NAME "uart"
+
+#define SERIAL_QUEUE_SIZE                          0x1000
+#define SERIAL_DATA_REGION_SIZE                    0x2000
+
+#define SERIAL_TX_DATA_REGION_SIZE_DRIV            SERIAL_DATA_REGION_SIZE
+#define SERIAL_TX_DATA_REGION_SIZE_CLI0            SERIAL_DATA_REGION_SIZE
+#define SERIAL_TX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
+#define SERIAL_TX_DATA_REGION_SIZE_CLI2            SERIAL_DATA_REGION_SIZE
+
+#define SERIAL_RX_DATA_REGION_SIZE_DRIV            SERIAL_DATA_REGION_SIZE
+#define SERIAL_RX_DATA_REGION_SIZE_CLI0            SERIAL_DATA_REGION_SIZE
+#define SERIAL_RX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
+#define SERIAL_RX_DATA_REGION_SIZE_CLI2            SERIAL_DATA_REGION_SIZE
+
+#define SERIAL_MAX_TX_DATA_SIZE MAX(SERIAL_TX_DATA_REGION_SIZE_DRIV, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI2, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI0, SERIAL_TX_DATA_REGION_SIZE_CLI1)))
+#define SERIAL_MAX_RX_DATA_SIZE MAX(SERIAL_RX_DATA_REGION_SIZE_DRIV, MAX(SERIAL_RX_DATA_REGION_SIZE_CLI2, MAX(SERIAL_RX_DATA_REGION_SIZE_CLI0, SERIAL_RX_DATA_REGION_SIZE_CLI1)))
+#define SERIAL_MAX_DATA_SIZE MAX(SERIAL_MAX_TX_DATA_SIZE, SERIAL_MAX_RX_DATA_SIZE)
+_Static_assert(SERIAL_MAX_DATA_SIZE < UINT32_MAX,
+               "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
+
+static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue_handle,
+                                             serial_queue_t *rx_queue, char *rx_data, serial_queue_handle_t *tx_queue_handle,
+                                             serial_queue_t *tx_queue, char *tx_data)
+{
+    if (!sddf_strcmp(pd_name, SERIAL_CLI0_NAME)) {
+        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, rx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, tx_data);
+    } else if (!sddf_strcmp(pd_name, SERIAL_CLI1_NAME)) {
+        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_CLI1, rx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI1, tx_data);
+    } else if (!sddf_strcmp(pd_name, SERIAL_CLI2_NAME)) {
+        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_CLI2, rx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI2, tx_data);
+    }
+}
+
+static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue_handle,
+                                              uintptr_t cli_queue, uintptr_t cli_data)
+{
+    if (!sddf_strcmp(pd_name, SERIAL_VIRT_RX_NAME)) {
+        serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
+        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
+                          SERIAL_RX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_RX_DATA_REGION_SIZE_CLI0));
+        serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)(cli_queue + 2 * SERIAL_QUEUE_SIZE),
+                          SERIAL_RX_DATA_REGION_SIZE_CLI2, 
+                          (char *)(cli_data + SERIAL_RX_DATA_REGION_SIZE_CLI0 + SERIAL_RX_DATA_REGION_SIZE_CLI1));
+    } else if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
+        serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
+        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0));
+        serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)(cli_queue + 2 * SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_SIZE_CLI2,
+                          (char *)(cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0 + SERIAL_TX_DATA_REGION_SIZE_CLI1));
+    }
+}
+
+#if SERIAL_WITH_COLOUR
+static inline void serial_channel_names_init(char **client_names)
+{
+    client_names[0] = SERIAL_CLI0_NAME;
+    client_names[1] = SERIAL_CLI1_NAME;
+    client_names[2] = SERIAL_CLI2_NAME;
+}
+#endif

--- a/examples/virtio/include/serial_config/serial_config.h
+++ b/examples/virtio/include/serial_config/serial_config.h
@@ -29,7 +29,7 @@
 #define SERIAL_CLI2_NAME "BLK_DRIVER_VMM"
 #define SERIAL_VIRT_RX_NAME "serial_virt_rx"
 #define SERIAL_VIRT_TX_NAME "serial_virt_tx"
-#define SERIAL_DRIVER_NAME "uart"
+#define SERIAL_DRIVER_NAME "uart_driver"
 
 #define SERIAL_QUEUE_SIZE                          0x1000
 #define SERIAL_DATA_REGION_SIZE                    0x2000

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -23,7 +23,9 @@
 #define SEL4_USER_CONTEXT_SIZE 0x24
 #endif
 
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
+#endif
 
 #define CTZ(x) __builtin_ctz(x)
 
@@ -53,6 +55,7 @@ static void assert_fail(
 /* Convenience function to print memory region in hex */
 void print_mem_hex(uintptr_t addr, size_t size);
 
+#ifndef assert
 #ifndef CONFIG_DEBUG_BUILD
 
 #define _unused(x) ((void)(x))
@@ -67,4 +70,5 @@ void print_mem_hex(uintptr_t addr, size_t size);
         } \
     } while(0)
 
+#endif
 #endif

--- a/src/virtio/block.h
+++ b/src/virtio/block.h
@@ -33,7 +33,7 @@
 #pragma once
 
 #include <stdint.h>
-#include <sddf/blk/fsmalloc.h>
+#include <sddf/util/fsmalloc.h>
 #include <sddf/util/ialloc.h>
 #include <sddf/blk/queue.h>
 #include "virtio/mmio.h"

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -185,7 +185,7 @@ int virtio_console_handle_rx(struct virtio_console_device *console)
             char c;
             while (bytes_written < desc.len && !serial_dequeue(&console->rxq, &console->rxq.queue->head, &c)) {
                 *(char *)(desc.addr + bytes_written) = c;
-                bytes_written ++;
+                bytes_written++;
             }
 
             struct virtq_used_elem used_elem = {desc_head, bytes_written};

--- a/tools/linux/uio/blk.c
+++ b/tools/linux/uio/blk.c
@@ -131,7 +131,7 @@ int driver_init(void **maps, uintptr_t *maps_phys, int num_maps, int argc, char 
     }
 
     /* May need to barrier all writes before this point of setting ready = true */
-    blk_config->ready = true;
+    __atomic_store_n(&blk_config->ready, true, __ATOMIC_RELEASE);
 
     LOG_UIO_BLOCK("Driver initialized\n");
 

--- a/tools/mkvirtdisk
+++ b/tools/mkvirtdisk
@@ -4,6 +4,8 @@
 # It aligns the partitions to both the sDDF transfer size and the device's logical size.
 # It creates a FAT filesystem on each partition.
 
+set -e
+
 # Usage instructions
 if [ $# -ne 4 ]; then
     echo "Usage: $0 <virtual_disk_name> <num_partitions> <logical_size> <memsize>"

--- a/tools/mkvirtdisk
+++ b/tools/mkvirtdisk
@@ -1,42 +1,45 @@
 #!/bin/bash
 
-# This bash script creates a virtual disk image with an msdos partition table
+# This bash script creates a virtual disk image with an msdos partition table.
+# It aligns the partitions to both the sDDF transfer size and the device's logical size.
+# It creates a FAT filesystem on each partition.
 
 # Usage instructions
 if [ $# -ne 4 ]; then
-    echo "Usage: $0 <virtual_disk_name> <num_partitions> <blocksize> <memsize>"
+    echo "Usage: $0 <virtual_disk_name> <num_partitions> <logical_size> <memsize>"
     exit 1
 fi
 
 DISK_IMAGE=$1
 NUM_PARTITIONS=$2
-BLOCKSIZE=$3
+LSIZE=$3
 MEMSIZE=$4
 
-if [ $((BLOCKSIZE % 512)) -ne 0 ] || [ $BLOCKSIZE -lt 512 ]; then
-    echo "BLOCKSIZE must be a multiple of 512 and greater than or equal to 512"
+SDDF_TRANSFER_SIZE=4096
+FDISK_LSIZE=512
+
+if [ $(( LSIZE & (LSIZE - 1) )) -ne 0 ] || [ $LSIZE -lt $FDISK_LSIZE ]; then
+    echo "LSIZE must be greater than $FDISK_LSIZE and a power of 2"
     exit 1
 fi
 
 BUILD_DIR=$(dirname $DISK_IMAGE)
 
-SDDF_TRANSFER_SIZE=4096
-SECTORSIZE=512
-MULTIPLE=$(( SDDF_TRANSFER_SIZE / SECTORSIZE ))
+# Since LSIZE is always a power of 2, the least common multiple of LSIZE and SDDF_TRANSFER_SIZE is simply the bigger one
+LCM=$(( SDDF_TRANSFER_SIZE > LSIZE ? SDDF_TRANSFER_SIZE : LSIZE ))
 
-COUNT=$(( MEMSIZE / SECTORSIZE ))
-COUNT=$(( (COUNT / MULTIPLE) * MULTIPLE )) # Ensures that the disk size is a multiple of $MULTIPLE blocks
+# Since we are using fdisk, COUNT uses the logical size provided by fdisk which is always 512 bytes (FDISK_LSIZE)
+MULTIPLE=$(( LCM / FDISK_LSIZE ))
+COUNT=$(( MEMSIZE / FDISK_LSIZE ))
+COUNT=$(( COUNT / MULTIPLE * MULTIPLE)) # Ensure COUNT is a multiple of sDDF transfer size and logical size
+
+# Create a file to act as a virtual disk
+dd if=/dev/zero of=$DISK_IMAGE bs=$FDISK_LSIZE count=$COUNT
 
 POFFSET=$MULTIPLE
 
-# Create a file to act as a virtual disk
-dd if=/dev/zero of=$DISK_IMAGE bs=$SECTORSIZE count=$COUNT
-
 FS_COUNT=$(( (COUNT - POFFSET - 1) / NUM_PARTITIONS ))
-FS_COUNT=$(( (FS_COUNT / MULTIPLE) * MULTIPLE )) # Ensures that both FAT filesystems are a multiple of $MULTIPLE blocks
-FS_COUNT_ADD=$(( FS_COUNT - 1 ))
-
-FS_COUNT_BLOCKSIZE=$(( FS_COUNT / (BLOCKSIZE / SECTORSIZE) ))
+FS_COUNT=$(( FS_COUNT / MULTIPLE * MULTIPLE )) # Ensures that both filesystems are a multiple of sDDF transfer size and logical size
 
 # Create MBR partition table
 PREV=$POFFSET
@@ -52,8 +55,8 @@ do
         echo $i # Partition number
     fi
     echo $PREV # First sector
-    echo +$FS_COUNT_ADD # Last sector
-    PREV=$(( PREV + FS_COUNT_ADD + 1 ))
+    echo +$(( FS_COUNT - 1 )) # Last sector
+    PREV=$(( PREV + FS_COUNT ))
 done
 
 echo w # Write changes
@@ -63,11 +66,11 @@ fdisk -l $DISK_IMAGE
 
 # Create the FAT filesystem
 rm -f $BUILD_DIR/fat.img
-mkfs.fat -C $BUILD_DIR/fat.img -S $BLOCKSIZE $(( (FS_COUNT_BLOCKSIZE * BLOCKSIZE) / 1024 ))
+mkfs.fat -C $BUILD_DIR/fat.img $(( (FS_COUNT * FDISK_LSIZE) / 1024 ))
 
 # Copy the FAT filesystem to the virtual disk
 for i in $(seq 0 $(( NUM_PARTITIONS - 1 )))
 do
-    echo "Copying FAT filesystem to partition $i, seek $((POFFSET + i * FS_COUNT)), count $FS_COUNT, blocksize $SECTORSIZE"
-    dd if=$BUILD_DIR/fat.img of=$DISK_IMAGE bs=$SECTORSIZE seek="$((POFFSET + i * FS_COUNT))" count=$FS_COUNT
+    echo "Copying FAT filesystem to partition $i, seek=$((POFFSET + i * FS_COUNT)), count=$FS_COUNT, bs=$FDISK_LSIZE"
+    dd if=$BUILD_DIR/fat.img of=$DISK_IMAGE bs=$FDISK_LSIZE seek="$((POFFSET + i * FS_COUNT))" count=$FS_COUNT
 done


### PR DESCRIPTION
This PR updates the sDDF dependency to a more recent commit which has major serial subsystem and makefile changes.

The main changes in this PR are:

### Using atomic operations to load and store shared booleans
This has been changed in
- examples/virtio/client_vmm.c
- tools/linux/uio/blk.c

### Major updates to console.c to use the latest serial interface:
- Just changed the `handle_tx` and `handle_rx` functions
- Updated the processing loops to use the new serial interfaces: no more buffers - data regions instead, utilise new signalling protocol
- Seemed to me like there was a number of virtio bugs (e.g. inserting the used buffers in the wrong index, incorrectly copying data from descriptors into sDDF buffers, incorrectly looping through available virtio buffers). I believe I fixed this based on the virtio blk implementation and the virtio paper
- Changed the code style to reduce the redefining of new variables where possible as I thought it made the code simpler

### Updated both the VirtIO and VirtIO-snd examples which use the serial subsystem
This involved changes to serial initialisation and data structures in:
- examples/virtio/blk_driver_vmm.c
- examples/virtio/client_vmm.c
- examples/virtio-snd/snd_driver_vmm.c
- examples/virtio-snd/client_vmm.c
I also added a serial config file to both examples and updated the system files for qemu and odroidc4 for both examples.

### Makefile Updates
I updated the makefile for both examples as well, mainly how the serial components are built, but I also used `libsddf_util_debug` where possible instead of explicitly building the sDDF util resources needed. I attempted to use the sDDF make snippets however found these to be incompatible with the current makefile scheme (since they are assumed to be run from the build directory. Instead, I inserted the contents of the snippets into each makefile.

I assume Peter will be making a PR to update the makefiles sometime soon, so I did not put much effort into ensuring dependencies were tracked correctly.

### Action Points that still need to be done!
- [ ] I could only test the _VirtIO_ example on _qemu_ - the VirtIO-snd example will need to be tested, as well as both examples on the odroidc4!
- [x] It is probably worth updating `mkvirtdisk` to have a more obvious failure message if the `fdisk` command doesn't work - since the default mac `fdisk` will not create the storage file needed by the example and will instead crash later down the line which was confusing.
- [x] I have used the `aarch64-none-elf` toolchain for archiving `libsddf_util_debug`. It seems that when I switched to `llvm` it caused some IRQ issues when running the example. Maybe this is something to look into.
- [ ] If console.c is invoked too early to handle the receiving of characters, this can cause the VMM to crash - I think it is happening if the VMM accesses the virt queues before they are properly initialised. May be wise to introduce a mechanism to synchronise this.
- [ ] I could not build the sound examples as my nix shell took far too long to download and build all the dependencies. Best to look into a way this can be improved in the future...
