### PR TITLE
Update CI and `vmm.mk` in preparation for Makefile changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Build and run examples
-        run: nix-shell --pure --run "./ci/examples.sh ${PWD}/microkit-sdk-1.2.6"
+        run: nix-shell --run "./ci/examples.sh ${PWD}/microkit-sdk-1.2.6"
       - name: Upload built system images
         uses: actions/upload-artifact@v4
         with:

--- a/vmm.mk
+++ b/vmm.mk
@@ -50,7 +50,7 @@ CFLAGS += -MD
 # Force rebuid if CFLAGS changes.
 # This will pick up (among other things} changes
 # to Microkit BOARD and CONFIG.
-CHECK_LIBVMM_CFLAGS:=.libvmm_cflags.$(shell echo ${CFLAGS}|md5sum -|sed 's/ *-$$//')
+CHECK_LIBVMM_CFLAGS:=.libvmm_cflags.$(shell echo ${CFLAGS} | shasum | sed 's/ *-$$//')
 .libvmm_cflags.%:
 	rm -f .libvmm_cflags.*
 	echo ${CFLAGS} > $@


### PR DESCRIPTION
I want to move these changes out of https://github.com/au-ts/libvmm/pull/77 so that https://github.com/au-ts/libvmm/pull/79 can be based off main.