### PR TITLE
Fix: `example/virtio-snd` doesn't build on OdroidC4

### DIFF
--- a/examples/virtio-snd/board/odroidc4/virtio-snd.system
+++ b/examples/virtio-snd/board/odroidc4/virtio-snd.system
@@ -115,13 +115,10 @@
         <program_image path="snd_driver_vmm.elf" />
         <map mr="snd_driver_vm_ram" vaddr="0x20000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
 
-        <map mr="rx_free_serial_vmm_3" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_rx_free" />
-        <map mr="rx_active_serial_vmm_3" vaddr="0x6_200_000" perms="rw" cached="true" setvar_vaddr="serial_rx_active" />
-        <map mr="tx_free_serial_vmm_3" vaddr="0x103_400_000" perms="rw" cached="true" setvar_vaddr="serial_tx_free" />
-        <map mr="tx_active_serial_vmm_3" vaddr="0x103_600_000" perms="rw" cached="true" setvar_vaddr="serial_tx_active" />
-
-        <map mr="tx_data_serial_vmm_3" vaddr="0x8_c00_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        <map mr="rx_data_serial_vmm_3" vaddr="0x8_e00_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
+        <map mr="tx_queue_serial_vmm_3" vaddr="0x6_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="rx_queue_serial_vmm_3" vaddr="0x6_001_000" perms="rw" cached="true" setvar_vaddr="serial_rx_queue" />
+        <map mr="tx_data_serial_vmm_3" vaddr="0x6_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        <map mr="rx_data_serial_vmm_3" vaddr="0x6_004_000" perms="rw" cached="true" setvar_vaddr="serial_rx_data" />
 
         <setvar symbol="sound_data_paddr" region_paddr="snd_data" />
         <map mr="snd_shared" vaddr="0x12_000_000" perms="rw" cached="false" setvar_vaddr="sound_shared_state" />


### PR DESCRIPTION
When the serial system was updated, the regions weren't correctly renamed. Maybe we should add `examples/virtio-snd` to the CI?