### PR TITLE
`examples/virtio`: remove unused `GUEST_RAM_SIZE`

### DIFF
--- a/examples/virtio/client_vmm.c
+++ b/examples/virtio/client_vmm.c
@@ -17,8 +17,6 @@
 #include <serial_config.h>
 #include <blk_config.h>
 
-#define GUEST_RAM_SIZE 0x6000000
-
 #if defined(BOARD_qemu_arm_virt)
 #define GUEST_DTB_VADDR 0x47f00000
 #define GUEST_INIT_RAM_DISK_VADDR 0x47000000


### PR DESCRIPTION
`GUEST_RAM_SIZE` is unused and also does not match `0x8_000_000` as found in the system file