### PR TITLE
blk: rename size to capacity

### DIFF
--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -485,7 +485,7 @@ static void virtio_blk_config_init(struct virtio_blk_device *blk_dev)
 {
     blk_storage_info_t *storage_info = blk_dev->storage_info;
 
-    blk_dev->config.capacity = (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE) * storage_info->size;
+    blk_dev->config.capacity = (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE) * storage_info->capacity;
     if (storage_info->block_size != 0) {
         blk_dev->config.blk_size = storage_info->block_size * BLK_TRANSFER_SIZE;
     } else {

--- a/tools/linux/uio_drivers/blk/blk.c
+++ b/tools/linux/uio_drivers/blk/blk.c
@@ -113,7 +113,7 @@ int driver_init(void **maps, uintptr_t *maps_phys, int num_maps, int argc, char 
         LOG_UIO_BLOCK_ERR("Failed to get storage drive size: %s\n", strerror(errno));
         return -1;
     }
-    blk_config->size = size / BLK_TRANSFER_SIZE;
+    blk_config->capacity = size / BLK_TRANSFER_SIZE;
 
     LOG_UIO_BLOCK("Raw block device: read_only=%d, sector_size=%d, size=%ld\n", (int)blk_config->read_only,
                     blk_config->sector_size, blk_config->size);


### PR DESCRIPTION
This is required for libvmm to compile with latest version of sDDF