### PR TITLE
Make -I from SDDF and LIBVMM conditional

### DIFF
--- a/vmm.mk
+++ b/vmm.mk
@@ -39,7 +39,7 @@ ifeq ($(findstring ${SDDF}/include, ${CFLAGS}),)
 CFLAGS += -I${SDDF}/include
 endif
 ifeq ($(findstring ${LIBVMM_DIR}/include,${CFLAGS}),)
-CFLAGS +=-I${LIBVMM_DIR}/include
+CFLAGS += -I${LIBVMM_DIR}/include
 endif
 
 ARCH_INDEP_FILES := src/util/printf.c \


### PR DESCRIPTION
Only add them if they're not already there, to
allow higher level makefiles to adjust their order if necessary.

Plus move objects into a subdir called 'libvmm' instead of 'src' --- the latter is too general.