### PR TITLE
Move manual dependencies into separate Nix shell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,9 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Create nix-shell and build PDF
-        run: nix-shell --pure -p texlive.combined.scheme-full pandoc librsvg --run "cd docs && pandoc MANUAL.md -o MANUAL.pdf"
+        run: |
+          cd docs
+          nix-shell --run "pandoc MANUAL.md -o MANUAL.pdf"
       - name: Upload manual PDF
         uses: actions/upload-artifact@v4
         with:

--- a/docs/shell.nix
+++ b/docs/shell.nix
@@ -1,0 +1,10 @@
+let
+    pkgs = import <nixpkgs> {};
+in
+  pkgs.mkShell {
+    buildInputs = with pkgs.buildPackages; [
+        texlive.combined.scheme-full
+        pandoc
+        librsvg
+    ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -6,11 +6,6 @@ let
     linux_aarch64_cross = import <nixpkgs> {
         crossSystem = { config = "aarch64-unknown-linux-gnu"; };
     };
-    manual_deps = with pkgs.buildPackages; [
-        texliveFull
-        pandoc
-        librsvg
-    ];
 in
   pkgs.mkShell {
     buildInputs = with pkgs.buildPackages; [
@@ -28,7 +23,7 @@ in
         expect
         # For when we need to build user-space applications for Linux guests
         linux_aarch64_cross.buildPackages.gcc
-    ] ++ manual_deps;
+    ];
     hardeningDisable = [ "all" ];
     # Need to specify this when using Rust with bindgen
     LIBCLANG_PATH = "${llvm.libclang.lib}/lib";


### PR DESCRIPTION
They are large and not necessary for most people who are just building the library/examples.

Closes https://github.com/au-ts/libvmm/issues/72.