### PR TITLE
mkvirtdisk fixes + macos support

### DIFF
--- a/tools/mkvirtdisk
+++ b/tools/mkvirtdisk
@@ -6,7 +6,7 @@
 
 # This bash script creates a virtual disk image with an msdos partition table.
 # It aligns the partitions to both the sDDF transfer size and the device's logical size.
-# It creates a FAT filesystem on each partition.
+# It creates a FAT 12 filesystem on each partition.
 
 set -e
 
@@ -25,6 +25,11 @@ fi
 if ! command -v mkfs.fat &> /dev/null
 then
     echo "mkfs.fat could not be found, please install dosfstools"
+    exit 1
+fi
+
+if [[ "$OSTYPE" != "linux"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "This script is not supported on your OS"
     exit 1
 fi
 
@@ -71,29 +76,55 @@ FS_COUNT=$(( (COUNT - POFFSET - 1) / NUM_PARTITIONS ))
 FS_COUNT=$(( FS_COUNT / MULTIPLE * MULTIPLE )) # Ensures that both filesystems are a multiple of sDDF transfer size and logical size
 
 # Create MBR partition table
-PREV=$POFFSET
-{
-echo o # Create a new empty DOS partition table
+if [[ "$OSTYPE" == "linux"* ]]; then
+    PREV=$POFFSET
+    {
+    echo o # Create a new empty DOS partition table
 
-# Loop to create each partition
-for i in $(seq 1 $NUM_PARTITIONS)
-do
-    echo n # Add a new partition
-    echo p # Primary partition
-    if [ $i != 4 ]; then
-        echo $i # Partition number
-    fi
-    echo $PREV # First sector
-    echo +$(( FS_COUNT - 1 )) # Last sector
-    PREV=$(( PREV + FS_COUNT ))
-done
+    # Loop to create each partition
+    for i in $(seq 1 $NUM_PARTITIONS)
+    do
+        echo n # Add a new partition
+        echo p # Primary partition
+        if [ $i != 4 ]; then
+            echo $i # Partition number
+        fi
+        echo $PREV # First sector
+        echo +$(( FS_COUNT - 1 )) # Last sector
+        PREV=$(( PREV + FS_COUNT ))
+    done
 
-echo w # Write changes
-} | fdisk $DISK_IMAGE
+    echo w # Write changes
+    } | fdisk $DISK_IMAGE
+    fdisk -l $DISK_IMAGE # Print the partition table
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    PREV=$POFFSET
+    {
+    echo y # Answer yes to create a new empty DOS partition table
+
+    # Loop to create each partition
+    for i in $(seq 1 $NUM_PARTITIONS)
+    do
+        echo edit $i
+        echo 01 # Set partition type to FAT12
+        echo n # No to editing in CHS mode
+        echo $PREV # First sector
+        echo $FS_COUNT # Number of sectors in partition
+        PREV=$(( PREV + FS_COUNT ))
+    done
+
+    echo write # Write changes
+    echo quit # Save and quit fdisk
+    } | fdisk -e $DISK_IMAGE
+    fdisk $DISK_IMAGE # Print the partition table
+else
+    echo "This script is not supported on your OS"
+    exit 1
+fi
 
 # Create the FAT filesystem
 rm -f $BUILD_DIR/fat.img
-mkfs.fat -C $BUILD_DIR/fat.img $(( (FS_COUNT * FDISK_LSIZE) / 1024 ))
+mkfs.fat -C $BUILD_DIR/fat.img $(( (FS_COUNT * FDISK_LSIZE) / 1024 )) -F 12 -S $LSIZE
 
 # Copy the FAT filesystem to the virtual disk
 for i in $(seq 0 $(( NUM_PARTITIONS - 1 )))

--- a/tools/mkvirtdisk
+++ b/tools/mkvirtdisk
@@ -22,6 +22,12 @@ if [ $# -ne 4 ]; then
     exit 1
 fi
 
+if ! command -v mkfs.fat &> /dev/null
+then
+    echo "mkfs.fat could not be found, please install dosfstools"
+    exit 1
+fi
+
 DISK_IMAGE=$1
 NUM_PARTITIONS=$2
 LSIZE=$3

--- a/tools/mkvirtdisk
+++ b/tools/mkvirtdisk
@@ -10,6 +10,12 @@
 
 set -e
 
+function cleanup {
+    rm -f $BUILD_DIR/fat.img
+}
+
+trap cleanup EXIT
+
 # Usage instructions
 if [ $# -ne 4 ]; then
     echo "Usage: $0 <virtual_disk_name> <num_partitions> <logical_size> <memsize>"
@@ -25,7 +31,12 @@ SDDF_TRANSFER_SIZE=4096
 FDISK_LSIZE=512
 
 if [ $(( LSIZE & (LSIZE - 1) )) -ne 0 ] || [ $LSIZE -lt $FDISK_LSIZE ]; then
-    echo "LSIZE must be greater than $FDISK_LSIZE and a power of 2"
+    echo "LSIZE must be greater than $FDISK_LSIZE and must be a power of 2"
+    exit 1
+fi
+
+if [ $((MEMSIZE)) -lt 114688 ]; then
+    echo "MEMSIZE must be greater than 114688(112 * 1024), sizes smaller than that break either fdisk or mkfs.fat"
     exit 1
 fi
 
@@ -37,12 +48,18 @@ LCM=$(( SDDF_TRANSFER_SIZE > LSIZE ? SDDF_TRANSFER_SIZE : LSIZE ))
 # Since we are using fdisk, COUNT uses the logical size provided by fdisk which is always 512 bytes (FDISK_LSIZE)
 MULTIPLE=$(( LCM / FDISK_LSIZE ))
 COUNT=$(( MEMSIZE / FDISK_LSIZE ))
-COUNT=$(( COUNT / MULTIPLE * MULTIPLE)) # Ensure COUNT is a multiple of sDDF transfer size and logical size
+
+# Determine starting partition offset
+if [ $COUNT -gt $(( 2048 * 4 )) ]; then
+    POFFSET=2048
+else
+    POFFSET=$MULTIPLE
+fi
+
+COUNT=$(( COUNT / MULTIPLE * MULTIPLE)) # Now ensure the real COUNT is a multiple of sDDF transfer size and logical size
 
 # Create a file to act as a virtual disk
 dd if=/dev/zero of=$DISK_IMAGE bs=$FDISK_LSIZE count=$COUNT 2> /dev/null
-
-POFFSET=$MULTIPLE
 
 FS_COUNT=$(( (COUNT - POFFSET - 1) / NUM_PARTITIONS ))
 FS_COUNT=$(( FS_COUNT / MULTIPLE * MULTIPLE )) # Ensures that both filesystems are a multiple of sDDF transfer size and logical size
@@ -67,8 +84,6 @@ done
 
 echo w # Write changes
 } | fdisk $DISK_IMAGE
-
-fdisk -l $DISK_IMAGE
 
 # Create the FAT filesystem
 rm -f $BUILD_DIR/fat.img

--- a/tools/mkvirtdisk
+++ b/tools/mkvirtdisk
@@ -40,7 +40,7 @@ COUNT=$(( MEMSIZE / FDISK_LSIZE ))
 COUNT=$(( COUNT / MULTIPLE * MULTIPLE)) # Ensure COUNT is a multiple of sDDF transfer size and logical size
 
 # Create a file to act as a virtual disk
-dd if=/dev/zero of=$DISK_IMAGE bs=$FDISK_LSIZE count=$COUNT
+dd if=/dev/zero of=$DISK_IMAGE bs=$FDISK_LSIZE count=$COUNT 2> /dev/null
 
 POFFSET=$MULTIPLE
 
@@ -78,5 +78,5 @@ mkfs.fat -C $BUILD_DIR/fat.img $(( (FS_COUNT * FDISK_LSIZE) / 1024 ))
 for i in $(seq 0 $(( NUM_PARTITIONS - 1 )))
 do
     echo "Copying FAT filesystem to partition $i, seek=$((POFFSET + i * FS_COUNT)), count=$FS_COUNT, bs=$FDISK_LSIZE"
-    dd if=$BUILD_DIR/fat.img of=$DISK_IMAGE bs=$FDISK_LSIZE seek="$((POFFSET + i * FS_COUNT))" count=$FS_COUNT
+    dd if=$BUILD_DIR/fat.img of=$DISK_IMAGE bs=$FDISK_LSIZE seek="$((POFFSET + i * FS_COUNT))" count=$FS_COUNT 2> /dev/null
 done


### PR DESCRIPTION
- Added support for macOS. fdisk behaves differently there.
- Added check for dosfstools needed for mkfs.fat
- Specifies FAT12 for the filesystem in each partition, when previously it was using the default in mkfs.fat
- Now handles the problem of beginning sector being either 1 or 2048 depending on the size of the disk (a restriction only in the linux case).
- Added a check for minimum size in disk that would break either tool of fdisk or mkfs.fat.
- Silence dd stderr. It seems to direct logging there, causing the zig build system #65 to report an error.