### PR TITLE
Cleanup vGIC fault handling code

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -33,7 +33,6 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
 
     const libmicrokit_include_opt = b.option([]const u8, "libmicrokit_include", "Path to the libmicrokit include directory") orelse null;
-    const microkit_board_opt = b.option([]const u8, "microkit_board", "Name of Microkit board") orelse null;
 
     // Default to vGIC version 2
     const arm_vgic_version = b.option(usize, "arm_vgic_version", "ARM vGIC version to emulate") orelse null;
@@ -69,7 +68,6 @@ pub fn build(b: *std.Build) void {
             "-Wno-unused-function",
             "-mstrict-align",
             "-fno-sanitize=undefined", // @ivanv: ideally we wouldn't have to turn off UBSAN
-            b.fmt("-DBOARD_{s}", .{ microkit_board_opt.? }) // @ivanv: shouldn't be needed as the library should not depend on the board
         }
     });
 

--- a/examples/simple/build.zig
+++ b/examples/simple/build.zig
@@ -103,7 +103,6 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .libmicrokit_include = @as([]const u8, libmicrokit_include),
         .arm_vgic_version = arm_vgic_version,
-        .microkit_board = @as([]const u8, microkit_board),
     });
     const libvmm = libvmm_dep.artifact("vmm");
 

--- a/examples/zig/build.zig
+++ b/examples/zig/build.zig
@@ -54,8 +54,8 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .libmicrokit_include = @as([]const u8, libmicrokit_include),
         // Because we only support QEMU virt AArch64, vGIC version is 2.
+        // Because we only support QEMU virt AArch64, vGIC version is always 2.
         .arm_vgic_version = @as(usize, 2),
-        .microkit_board = @as([]const u8, microkit_board),
     });
     const libvmm = libvmm_dep.artifact("vmm");
 

--- a/include/libvmm/arch/aarch64/vgic/vgic.h
+++ b/include/libvmm/arch/aarch64/vgic/vgic.h
@@ -10,16 +10,13 @@
 #include <stdint.h>
 #include <libvmm/virq.h>
 
-// @ivanv: this should all come from the DTS!
-// @ivanv: either this should all be compile time or all runtime
-// as in initialising the vgic should depend on the runtime values
-#if defined(BOARD_qemu_virt_aarch64)
+#if defined(CONFIG_PLAT_QEMU_ARM_VIRT)
 #define GIC_V2
 #define GIC_DIST_PADDR      0x8000000
-#elif defined(BOARD_odroidc4)
+#elif defined(CONFIG_PLAT_ODROIDC4)
 #define GIC_V2
 #define GIC_DIST_PADDR      0xffc01000
-#elif defined(BOARD_maaxboard)
+#elif defined(CONFIG_PLAT_MAAXBOARD)
 #define GIC_V3
 #define GIC_DIST_PADDR      0x38800000
 #define GIC_REDIST_PADDR    0x38880000
@@ -54,7 +51,7 @@
 
 void vgic_init();
 bool fault_handle_vgic_maintenance(size_t vcpu_id);
-bool handle_vgic_dist_fault(size_t vcpu_id, uint64_t fault_addr, uint64_t fsr, seL4_UserContext *regs);
-bool handle_vgic_redist_fault(size_t vcpu_id, uint64_t fault_addr, uint64_t fsr, seL4_UserContext *regs);
+bool handle_vgic_dist_fault(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data);
+bool handle_vgic_redist_fault(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data);
 bool vgic_register_irq(size_t vcpu_id, int virq_num, virq_ack_fn_t ack_fn, void *ack_data);
 bool vgic_inject_irq(size_t vcpu_id, int irq);

--- a/src/arch/aarch64/fault.c
+++ b/src/arch/aarch64/fault.c
@@ -376,7 +376,7 @@ bool fault_handle_vm_exception(size_t vcpu_id)
         tcb_print_regs(vcpu_id);
         vcpu_print_regs(vcpu_id);
     } else {
-        fault_advance_vcpu(vcpu_id, &regs);
+        return fault_advance_vcpu(vcpu_id, &regs);
     }
 
     return success;

--- a/src/arch/aarch64/vgic/vgic.c
+++ b/src/arch/aarch64/vgic/vgic.c
@@ -97,13 +97,8 @@ bool vgic_inject_irq(size_t vcpu_id, int irq)
 }
 
 // @ivanv: revisit this whole function
-bool handle_vgic_dist_fault(size_t vcpu_id, uint64_t fault_addr, uint64_t fsr, seL4_UserContext *regs)
+bool handle_vgic_dist_fault(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data)
 {
-    /* Make sure that the fault address actually lies within the GIC distributor region. */
-    assert(fault_addr >= GIC_DIST_PADDR);
-    assert(fault_addr - GIC_DIST_PADDR < GIC_DIST_SIZE);
-
-    uint64_t offset = fault_addr - GIC_DIST_PADDR;
     bool success = false;
     if (fault_is_read(fsr)) {
         // printf("VGIC|INFO: Read dist\n");


### PR DESCRIPTION
* Make virq_controller_init for the vGIC register the vGIC region with the appropriate callbacks using the library's API instead of hard-coding it in the fault handling code.
* Don't use `BOARD_` defines, instead just use seL4 based defines since we eventually want the library to be Microkit agnostic.

Still not satisfied with the vGIC/fault handling code, there's still lots of improvements to be made.