### PR TITLE
examples/rust: update to latest rust-sel4

### DIFF
--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -409,7 +409,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sel4"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "cfg-if",
  "sel4-config",
@@ -419,12 +419,12 @@ dependencies = [
 [[package]]
 name = "sel4-bitfield-ops"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 
 [[package]]
 name = "sel4-bitfield-parser"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "pest",
  "pest_derive",
@@ -434,12 +434,12 @@ dependencies = [
 [[package]]
 name = "sel4-build-env"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 
 [[package]]
 name = "sel4-config"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "sel4-config-data",
  "sel4-config-generic",
@@ -450,7 +450,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-data"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "lazy_static",
  "sel4-build-env",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-generic"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "fallible-iterator",
  "proc-macro2",
@@ -473,7 +473,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-generic-types"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "serde",
 ]
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "sel4-config-data",
  "sel4-config-generic",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "sel4-dlmalloc"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "dlmalloc",
  "lock_api",
@@ -499,22 +499,22 @@ dependencies = [
 [[package]]
 name = "sel4-elf-header"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 
 [[package]]
 name = "sel4-immediate-sync-once-cell"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 
 [[package]]
 name = "sel4-immutable-cell"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 
 [[package]]
 name = "sel4-initialize-tls"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "cfg-if",
 ]
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "sel4-microkit"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "cfg-if",
  "sel4",
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "sel4-microkit-base"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "sel4",
  "sel4-immutable-cell",
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "sel4-microkit-macros"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "sel4-panicking"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "cfg-if",
  "rustc_version",
@@ -570,12 +570,12 @@ dependencies = [
 [[package]]
 name = "sel4-panicking-env"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 
 [[package]]
 name = "sel4-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "cfg-if",
  "sel4",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "sel4-rustfmt-helper"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "which",
 ]
@@ -597,12 +597,12 @@ dependencies = [
 [[package]]
 name = "sel4-stack"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 
 [[package]]
 name = "sel4-sync"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "lock_api",
  "sel4",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "sel4-sync-trivial"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "lock_api",
 ]
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "sel4-sys"
 version = "0.1.0"
-source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#43c251d395ebb4066a4f70f446640c268ccba196"
+source = "git+https://github.com/Ivan-Velickovic/rust-seL4?branch=dev#cdf71617c26b8ed5d51c8575201e7717c84bc4f0"
 dependencies = [
  "bindgen",
  "glob",

--- a/examples/rust/src/vmm.rs
+++ b/examples/rust/src/vmm.rs
@@ -113,7 +113,7 @@ impl Handler for VmmHandler {
 
     fn fault(&mut self, id: Child, msg_info: MessageInfo) -> Result<Option<MessageInfo>, Self::Error> {
         unsafe {
-            if fault_handle(0, msg_info) {
+            if fault_handle(id.index(), msg_info) {
                 Ok(Some(MessageInfo::new(0, 0)))
             } else {
                 unreachable!()


### PR DESCRIPTION
Fixed two issues I encountered when previously updating to the latest rust-sel4 version.

There's still one remaining issue which prevents us from switching to the mainline rust-sel4.