### PR TITLE
examples/simple: utilise overlays

### DIFF
--- a/examples/simple/board/odroidc4/linux.dts
+++ b/examples/simple/board/odroidc4/linux.dts
@@ -19,11 +19,7 @@
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		ranges;
-        linux,stdout-path = "/soc/bus@ff800000/serial@3000";
-        stdout-path = "/soc/bus@ff800000/serial@3000";
-		linux,initrd-end = <0x00000000 0x2e000000>;
-        linux,initrd-start = <0x00000000 0x2d700000>;
-        bootargs = "console=ttyAML0,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi earlyprintk=serial maxcpus=1";
+		stdout-path = "serial0:115200n8";
 
 		framebuffer-cvbs {
 			compatible = "amlogic,simple-framebuffer\0simple-framebuffer";
@@ -114,9 +110,8 @@
 		linux,cma {
 			compatible = "shared-dma-pool";
 			reusable;
-			size = <0x00 0x1000000>;
+			size = <0x00 0x10000000>;
 			alignment = <0x00 0x400000>;
-			alloc-ranges = <0x00 0x8000000 0x10000000>;
 			linux,cma-default;
 		};
 	};
@@ -124,7 +119,6 @@
 	secure-monitor {
 		compatible = "amlogic,meson-gxbb-sm";
 		phandle = <0x04>;
-		status = "disabled";
 	};
 
 	soc {
@@ -166,7 +160,7 @@
 			clock-names = "stmmaceth\0clkin0\0clkin1\0timing-adjustment";
 			rx-fifo-depth = <0x1000>;
 			tx-fifo-depth = <0x800>;
-			status = "disabled";
+			status = "okay";
 			power-domains = <0x03 0x06>;
 			pinctrl-0 = <0x07 0x08>;
 			pinctrl-names = "default";
@@ -2385,7 +2379,6 @@
 				reg = <0x00 0x140 0x00 0x140>;
 				amlogic,has-chip-id;
 				phandle = <0x10>;
-				status = "disabled";
 			};
 
 			cec@280 {
@@ -2466,7 +2459,7 @@
 				interrupts = <0x00 0xc8 0x01>;
 				clocks = <0x11 0x19 0x08 0x19 0x12 0x19 0x10>;
 				clock-names = "clkin\0core\0adc_clk\0adc_sel";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 
@@ -2493,7 +2486,6 @@
 			#size-cells = <0x00>;
 			amlogic,canvas = <0x20>;
 			power-domains = <0x03 0x00>;
-			status = "disabled";
 
 			port@0 {
 				reg = <0x00>;
@@ -3016,7 +3008,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00 0x20000000 0x00 0x10000000>;
+		reg = <0x00 0x00 0x00 0x40000000>;
 	};
 
 	emmc-pwrseq {

--- a/examples/simple/board/odroidc4/overlay.dts
+++ b/examples/simple/board/odroidc4/overlay.dts
@@ -3,3 +3,53 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
+/ {
+    memory@0 {
+        device_type = "memory";
+        reg = <0x00 0x20000000 0x00 0x10000000>;
+    };
+
+    /* Give Linux a smaller amount of memory for DMA than normal since we only have 256MB of RAM */
+    reserved-memory {
+        linux,cma {
+            compatible = "shared-dma-pool";
+            reusable;
+            size = <0x00 0x1000000>;
+            alignment = <0x00 0x400000>;
+            alloc-ranges = <0x00 0x8000000 0x10000000>;
+            linux,cma-default;
+        };
+    };
+
+    secure-monitor {
+        status = "disabled";
+    };
+
+    soc {
+        ethernet@ff3f0000 {
+            status = "disabled";
+        };
+
+        bus@ff800000 {
+            ao-secure@140 {
+                status = "disabled";
+            };
+
+            adc@9000 {
+                status = "disabled";
+            };
+        };
+
+        vpu@ff900000 {
+            status = "disabled";
+        };
+    };
+
+    chosen {
+        linux,stdout-path = "/soc/bus@ff800000/serial@3000";
+        stdout-path = "/soc/bus@ff800000/serial@3000";
+        linux,initrd-end = <0x00000000 0x2e000000>;
+        linux,initrd-start = <0x00000000 0x2d700000>;
+        bootargs = "console=ttyAML0,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi earlyprintk=serial maxcpus=1";
+    };
+};

--- a/examples/simple/board/qemu_virt_aarch64/linux.dts
+++ b/examples/simple/board/qemu_virt_aarch64/linux.dts
@@ -6,10 +6,6 @@
 	#address-cells = <0x02>;
 	compatible = "linux,dummy-virt";
 
-	aliases {
-		serial0 = "/pl011@9000000";
-	};
-
 	psci {
 		migrate = <0xc4000005>;
 		cpu_on = <0xc4000003>;
@@ -20,7 +16,7 @@
 	};
 
 	memory@40000000 {
-		reg = <0x00 0x40000000 0x00 0x10000000>;
+		reg = <0x00 0x40000000 0x00 0x80000000>;
 		device_type = "memory";
 	};
 
@@ -61,7 +57,6 @@
 		bank-width = <0x04>;
 		reg = <0x00 0x00 0x00 0x4000000 0x00 0x4000000 0x00 0x4000000>;
 		compatible = "cfi-flash";
-		status = "disabled";
 	};
 
 	cpus {
@@ -91,9 +86,7 @@
 
 	chosen {
 		stdout-path = "/pl011@9000000";
-		bootargs = "earlycon=pl011,0x9000000 earlyprintk=serial debug loglevel=8";
-		linux,stdout-path = "/pl011@9000000";
-		linux,initrd-start = <0x4d700000>;
-		linux,initrd-end = <0x4d800000>;
+		rng-seed = <0x8f0ee46 0xecbe7263 0xc724a577 0x271cf683 0xdd190daf 0x103bff62 0x5f2496fb 0xee0cf760>;
+		kaslr-seed = <0x198a65b3 0x8b3cef37>;
 	};
 };

--- a/examples/simple/board/qemu_virt_aarch64/overlay.dts
+++ b/examples/simple/board/qemu_virt_aarch64/overlay.dts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/ {
+    /* Need to specify how much RAM the guest will have */
+    memory@40000000 {
+        device_type = "memory";
+        reg = <0x00 0x40000000 0x00 0x10000000>;
+    };
+
+    flash@0 {
+        status = "disabled";
+    };
+
+    chosen {
+        stdout-path = "/pl011@9000000";
+        bootargs = "earlycon=pl011,0x9000000 earlyprintk=serial debug loglevel=8";
+        linux,stdout-path = "/pl011@9000000";
+        linux,initrd-start = <0x4d700000>;
+        linux,initrd-end = <0x4d800000>;
+    };
+};


### PR DESCRIPTION
For QEMU virt AArch64 and Odroid-C4, what we did in the past is take the original DTS intended for booting Linux natively and adapt it to work in a virtualised environment.

This patch gets those two platforms in line with the current convention for other platforms and examples which is to have `linux.dts` be the unmodified DTS from Linux source and then use the overlay to disable certain devices, change the amount and address of RAM, etc.