### PR TITLE
Virtio console fix

### DIFF
--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -140,7 +140,7 @@ static bool virtio_console_handle_tx(struct virtio_device *dev)
                     transferred = true;
                 }
 
-                memcpy(console->txq.data_region + (console->txq.queue->tail % console->txq.size),
+                memcpy(console->txq.data_region + (console->txq.queue->tail % console->txq.capacity),
                        (char *)(desc.addr + (desc.len - bytes_remain)), to_transfer);
 
                 serial_update_visible_tail(&console->txq, console->txq.queue->tail + to_transfer);


### PR DESCRIPTION
In the latest sDDF, member `size` of struct `serial_queue_handle_t` has been renamed to `capacity`. This change has not been propagated to `virtio/console.c` which leads to a compile error if the latest sDDF is used.