### PR TITLE
build.zig: override MICROKIT_SDK environment varaible

### DIFF
--- a/examples/simple/build.zig
+++ b/examples/simple/build.zig
@@ -200,6 +200,7 @@ pub fn build(b: *std.Build) void {
        b.getInstallPath(.prefix, "./report.txt")
     });
     microkit_tool_cmd.step.dependOn(b.getInstallStep());
+    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk);
     // Add the "microkit" step, and make it the default step when we execute `zig build`
     const microkit_step = b.step("microkit", "Compile and build the final bootable image");
     microkit_step.dependOn(&microkit_tool_cmd.step);

--- a/examples/zig/build.zig
+++ b/examples/zig/build.zig
@@ -115,6 +115,7 @@ pub fn build(b: *std.Build) void {
        b.getInstallPath(.prefix, "./report.txt")
     });
     microkit_tool_cmd.step.dependOn(b.getInstallStep());
+    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk);
     // Add the "microkit" step, and make it the default step when we execute `zig build`
     const microkit_step = b.step("microkit", "Compile and build the final bootable image");
     microkit_step.dependOn(&microkit_tool_cmd.step);


### PR DESCRIPTION
We always have to provide -Dsdk=<sdk> when using build.zig and we don't want the Microkit tool to be using incorrect artifacts if the MICROKIT_SDK environment variable is set.