### PR TITLE
packrootfs: add cpio installation status check

### DIFF
--- a/tools/packrootfs
+++ b/tools/packrootfs
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-set -e
-
 # Copyright 2024, UNSW
 #
 # SPDX-License-Identifier: BSD-2-Clause
+
+set -e
 
 if [ $# -lt 2 ]; then
     echo "Usage: $0 <rootfs> <tmpdir> [-o output_rootfs] [--startup files...] [--home files...] [--etc files...]"

--- a/tools/packrootfs
+++ b/tools/packrootfs
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Copyright 2024, UNSW
 #
 # SPDX-License-Identifier: BSD-2-Clause
@@ -11,7 +13,7 @@ fi
 
 which cpio >/dev/null
 if [ "$?" != 0 ]; then
-    echo "packrootfs: Please install CPIO"
+    echo "packrootfs: Please install cpio utility."
     exit 1
 fi
 

--- a/tools/packrootfs
+++ b/tools/packrootfs
@@ -9,6 +9,12 @@ if [ $# -lt 2 ]; then
     exit 1
 fi
 
+which cpio >/dev/null
+if [ "$?" != 0 ]; then
+    echo "packrootfs: Please install CPIO"
+    exit 1
+fi
+
 rootfs=$1
 tmpdir=$2
 startup_files=()


### PR DESCRIPTION
The `packrootfs` script currently lacks a check for whether `cpio` is installed. Which leads to an insidious bug down the line where errors from unsuccessfully executing `cpio` does not bubble up from the subshell on line 100. So the script returns 0 and allow other build steps to continue even though the rootfs have not been repackaged correctly with the desired init script and user-level program.

This manifests as the guest booting with the original rootfs instead of the repackaged one.

I've been able to reproduce this bug reliably on `bash` and `zsh`.