### PR TITLE
Add filesystem UIO driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = dep/sddf
 	url = https://github.com/au-ts/sddf
 	branch = main
+[submodule "dep/liburing"]
+	path = dep/liburing
+	url = https://github.com/axboe/liburing.git

--- a/tools/linux/fs/board/qemu_virt_aarch64/fs_driver_init
+++ b/tools/linux/fs/board/qemu_virt_aarch64/fs_driver_init
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+BLOCK_DEVICE='/dev/vda'
+MOUNT_POINT='/mnt'
+
+chmod +x /root/uio_fs_driver && /root/uio_fs_driver "$BLOCK_DEVICE" "$MOUNT_POINT"

--- a/tools/linux/fs/fs_init.mk
+++ b/tools/linux/fs/fs_init.mk
@@ -1,0 +1,17 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Generates fs_driver_init scripts
+#
+
+ifeq ($(strip $(MICROKIT_BOARD)),)
+$(error MICROKIT_BOARD must be specified)
+endif
+
+fs_driver_init: $(LIBVMM_DIR)/tools/linux/fs/board/$(MICROKIT_BOARD)/fs_driver_init
+	cp $^ $@
+
+clobber::
+	rm -f fs_driver_init

--- a/tools/linux/include/uio/fs.h
+++ b/tools/linux/include/uio/fs.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+/* All of these details must match up with the DTS overlay and Sys Desc File. */
+
+#define UIO_IRQ_NUM 71
+
+#define UIO_LENGTH_FS_COMMAND_QUEUE 0x8000
+#define UIO_PATH_FS_COMMAND_QUEUE_AND_IRQ "/dev/uio0"
+
+#define UIO_LENGTH_FS_COMPLETION_QUEUE 0x8000
+#define UIO_PATH_FS_COMPLETION_QUEUE "/dev/uio1"
+
+#define UIO_LENGTH_FS_DATA 0x200000
+#define UIO_PATH_FS_DATA "/dev/uio2"
+
+#define GUEST_TO_VMM_NOTIFY_FAULT_ADDR 0x10000000
+#define UIO_LENGTH_GUEST_TO_VMM_NOTIFY_FAULT 0x1000
+#define UIO_PATH_GUEST_TO_VMM_NOTIFY_FAULT "/dev/uio3"

--- a/tools/linux/include/uio/fs.h
+++ b/tools/linux/include/uio/fs.h
@@ -8,7 +8,7 @@
 
 /* All of these details must match up with the DTS overlay and Sys Desc File. */
 
-#define UIO_IRQ_NUM 71
+#define UIO_FS_IRQ_NUM 71
 
 #define UIO_LENGTH_FS_COMMAND_QUEUE 0x8000
 #define UIO_PATH_FS_COMMAND_QUEUE_AND_IRQ "/dev/uio0"

--- a/tools/linux/include/uio/fs.h
+++ b/tools/linux/include/uio/fs.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <blk_config.h>
+
 /* All of these details must match up with the DTS overlay and Sys Desc File. */
 
 #define UIO_FS_IRQ_NUM 71
@@ -16,7 +18,7 @@
 #define UIO_LENGTH_FS_COMPLETION_QUEUE 0x8000
 #define UIO_PATH_FS_COMPLETION_QUEUE "/dev/uio1"
 
-#define UIO_LENGTH_FS_DATA 0x200000
+#define UIO_LENGTH_FS_DATA BLK_REGION_SIZE
 #define UIO_PATH_FS_DATA "/dev/uio2"
 
 #define GUEST_TO_VMM_NOTIFY_FAULT_ADDR 0x10000000

--- a/tools/linux/uio_drivers/fs/log.h
+++ b/tools/linux/uio_drivers/fs/log.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdio.h>
+
+#define DEBUG_FS
+
+#if defined(DEBUG_FS)
+#define LOG_FS(...) do{ fprintf(stderr, "UIO(FS): "); fprintf(stderr, __VA_ARGS__); }while(0)
+#else
+#define LOG_FS(...) do{}while(0)
+#endif
+
+#define LOG_FS_ERR(...) do{ fprintf(stderr, "UIO(FS)|ERROR: "); fprintf(stderr, __VA_ARGS__); }while(0)
+#define LOG_FS_WARN(...) do{ fprintf(stderr, "UIO(FS)|WARN: "); fprintf(stderr, __VA_ARGS__); }while(0)

--- a/tools/linux/uio_drivers/fs/log.h
+++ b/tools/linux/uio_drivers/fs/log.h
@@ -16,5 +16,12 @@
 #define LOG_FS(...) do{}while(0)
 #endif
 
+#define DEBUG_FS_OPS
+#if defined(DEBUG_FS_OPS)
+#define LOG_FS_OPS(...) do{ fprintf(stderr, "UIO(FS ops): "); fprintf(stderr, __VA_ARGS__); }while(0)
+#else
+#define LOG_FS_OPS(...) do{}while(0)
+#endif
+
 #define LOG_FS_ERR(...) do{ fprintf(stderr, "UIO(FS)|ERROR: "); fprintf(stderr, __VA_ARGS__); }while(0)
 #define LOG_FS_WARN(...) do{ fprintf(stderr, "UIO(FS)|WARN: "); fprintf(stderr, __VA_ARGS__); }while(0)

--- a/tools/linux/uio_drivers/fs/log.h
+++ b/tools/linux/uio_drivers/fs/log.h
@@ -16,7 +16,7 @@
 #define LOG_FS(...) do{}while(0)
 #endif
 
-#define DEBUG_FS_OPS
+// #define DEBUG_FS_OPS
 #if defined(DEBUG_FS_OPS)
 #define LOG_FS_OPS(...) do{ fprintf(stderr, "UIO(FS ops): "); fprintf(stderr, __VA_ARGS__); }while(0)
 #else

--- a/tools/linux/uio_drivers/fs/main.c
+++ b/tools/linux/uio_drivers/fs/main.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "log.h"
+
+#define ARGC_REQURED 3
+
+int main(int argc, char **argv)
+{
+    if (argc != ARGC_REQURED) {
+        LOG_ERR_FS("usage: ./uio_fs_driver <blk_device> <mount_point>");
+        exit(EXIT_FAILURE);
+    } else {
+        LOG_FS("*** Starting up\n");
+        LOG_FS("Block device: %s\n", argv[1]);
+        LOG_FS("Mount point: %s\n", argv[2]);
+    }
+    char *blk_device = argv[1];
+    char *mnt_point = argv[2];
+
+    LOG_FS("*** Starting up\n");
+
+    LOG_FS_WARN("Exit\n");
+    return EXIT_SUCCESS;
+}

--- a/tools/linux/uio_drivers/fs/main.c
+++ b/tools/linux/uio_drivers/fs/main.c
@@ -40,10 +40,12 @@ int blk_device_len;
 char mnt_point[PATH_MAX];
 int mnt_point_len;
 
+/* Shared queues and data to native client via UIO */
 struct fs_queue *cmd_queue;
 struct fs_queue *comp_queue;
 char *fs_data;
 
+/* Guest -> VMM fault address via UIO, unmapped in SDF */
 char *vmm_notify_fault;
 
 struct io_uring ring;
@@ -106,6 +108,9 @@ void uio_interrupt_ack(int uiofd)
 void bring_up_io_uring(void) {
     /* An optimisation hint to Linux as we only have one userland thread submitting jobs. */
     unsigned int flags = IORING_SETUP_SINGLE_ISSUER;
+
+    /* More optimisation:  */
+    flags |= IORING_SETUP_COOP_TASKRUN;
 
     /* I believe there are more useful flags to us: https://man7.org/linux/man-pages/man2/io_uring_setup.2.html */
     int err = io_uring_queue_init(BLK_QUEUE_CAPACITY_DRIV, &ring, flags);

--- a/tools/linux/uio_drivers/fs/main.c
+++ b/tools/linux/uio_drivers/fs/main.c
@@ -169,11 +169,13 @@ int main(int argc, char **argv)
     // Because any native FS clients would've finished initialising way before our Linux kernel get to
     // userland.
     process_fs_commands();
-    // Only notify when we have consumed every commands.
-    notify_vmm();
 
     LOG_FS("*** All initialisation successful!\n");
     LOG_FS("*** You won't see any output from UIO FS anymore. Unless there is a warning or error.\n");
+
+    // Only notify when we have consumed every commands.
+    // After printing our finish message to not mess up Micropython.
+    notify_vmm();
 
     while (1) {
         int n_events = epoll_wait(epoll_fd, events, MAX_EVENTS, -1);
@@ -194,6 +196,7 @@ int main(int argc, char **argv)
 
             if (events[i].data.fd == cmd_uio_fd) {
                 process_fs_commands();
+                uio_interrupt_ack(cmd_uio_fd);
                 notify_vmm();
             } else {
                 LOG_FS_WARN("epoll_wait() returned event on unknown fd %d\n", events[i].data.fd);

--- a/tools/linux/uio_drivers/fs/main.c
+++ b/tools/linux/uio_drivers/fs/main.c
@@ -5,15 +5,82 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/epoll.h>
+
+#include <lions/fs/protocol.h>
+#include <uio/fs.h>
 
 #include "log.h"
 
 #define ARGC_REQURED 3
 
+/* Event queue for polling */
+#define MAX_EVENTS 16 // Arbitrary length
+struct epoll_event events[MAX_EVENTS];
+
+int create_epoll(void)
+{
+    int epoll_fd = epoll_create1(0);
+    if (epoll_fd == -1) {
+        perror("create_epoll(): epoll_create1()");
+        LOG_FS_ERR("can't create the epoll fd.\n");
+        exit(EXIT_FAILURE);
+    }
+    return epoll_fd;
+}
+
+void bind_fd_to_epoll(int fd, int epollfd)
+{
+    struct epoll_event event;
+    event.events = EPOLLIN;
+    event.data.fd = fd;
+    if (epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &event) == -1) {
+        perror("bind_fd_to_epoll(): epoll_ctl()");
+        LOG_FS_ERR("can't register fd %d to epoll fd %d.\n", fd, epollfd);
+        exit(EXIT_FAILURE);
+    }
+}
+
+int open_uio(const char *abs_path)
+{
+    int fd = open(abs_path, O_RDWR);
+    if (fd == -1) {
+        perror("open_uio(): open()");
+        LOG_FS_ERR("can't open uio @ %s.\n", abs_path);
+        exit(EXIT_FAILURE);
+    }
+    return fd;
+}
+
+char *map_uio(uint64_t length, int uiofd)
+{
+    void *base = (char *) mmap(NULL, length, PROT_READ | PROT_WRITE, MAP_SHARED, uiofd, 0);
+    if (base == MAP_FAILED) {
+        perror("map_uio(): mmap()");
+        LOG_FS_ERR("can't mmap uio fd %d\n", uiofd);
+        exit(EXIT_FAILURE);
+    }
+    return (char *) base;
+}
+
+void uio_interrupt_ack(int uiofd)
+{
+    uint32_t enable = 1;
+    if (write(uiofd, &enable, sizeof(uint32_t)) != sizeof(uint32_t)) {
+        perror("uio_interrupt_ack(): write()");
+        LOG_FS_ERR("Failed to write enable/ack interrupts on uio fd %d\n", uiofd);
+        exit(EXIT_FAILURE);
+    }
+}
+
 int main(int argc, char **argv)
 {
     if (argc != ARGC_REQURED) {
-        LOG_ERR_FS("usage: ./uio_fs_driver <blk_device> <mount_point>");
+        LOG_FS_ERR("usage: ./uio_fs_driver <blk_device> <mount_point>");
         exit(EXIT_FAILURE);
     } else {
         LOG_FS("*** Starting up\n");
@@ -23,7 +90,60 @@ int main(int argc, char **argv)
     char *blk_device = argv[1];
     char *mnt_point = argv[2];
 
-    LOG_FS("*** Starting up\n");
+    LOG_FS("*** Setting up command queue via UIO\n");
+    int cmd_uio_fd = open_uio(UIO_PATH_FS_COMMAND_QUEUE_AND_IRQ);
+    struct fs_queue *cmd_queue = (struct fs_queue *) map_uio(UIO_LENGTH_FS_COMMAND_QUEUE, cmd_uio_fd);
+    
+    LOG_FS("*** Setting up completion queue via UIO\n");
+    int comp_uio_fd = open_uio(UIO_PATH_FS_COMPLETION_QUEUE);
+    struct fs_queue *comp_queue = (struct fs_queue *) map_uio(UIO_LENGTH_FS_COMPLETION_QUEUE, comp_uio_fd);
+    
+    LOG_FS("*** Setting up FS data region via UIO\n");
+    int fs_data_uio_fd = open_uio(UIO_PATH_FS_DATA);
+    char *fs_data = map_uio(UIO_LENGTH_FS_DATA, fs_data_uio_fd);
+
+    LOG_FS("*** Setting up fault region via UIO\n");
+    // For Guest -> VMM notifications
+    int fault_uio_fd = open_uio(UIO_PATH_GUEST_TO_VMM_NOTIFY_FAULT);
+    char *vmm_notify_fault = map_uio(UIO_LENGTH_GUEST_TO_VMM_NOTIFY_FAULT, fault_uio_fd);
+
+    LOG_FS("*** Enabling UIO interrupt on command queue\n");
+    uio_interrupt_ack(cmd_uio_fd);
+
+    LOG_FS("*** Creating epoll object\n");
+    int epoll_fd = create_epoll();
+
+    LOG_FS("*** Binding command queue IRQ to epoll\n");
+    bind_fd_to_epoll(cmd_uio_fd, epoll_fd);
+
+    LOG_FS("*** All initialisation successful!\n");
+    LOG_FS("*** You won't see any output from UIO FS anymore. Unless there is a warning or error.\n");
+
+    while (1) {
+        int n_events = epoll_wait(epoll_fd, events, MAX_EVENTS, -1);
+        if (n_events == -1) {
+            perror("main(): epoll_wait():");
+            LOG_FS("epoll wait failed\n");
+            exit(EXIT_FAILURE);
+        }
+        if (n_events == MAX_EVENTS) {
+            LOG_FS_WARN("epoll_wait() returned MAX_EVENTS, there maybe dropped events!\n");
+        }
+
+        for (int i = 0; i < n_events; i++) {
+            if (!(events[i].events & EPOLLIN)) {
+                LOG_FS_WARN("got non EPOLLIN event on fd %d\n", events[i].data.fd);
+                continue;
+            }
+
+            if (events[i].data.fd == cmd_uio_fd) {
+                // Got command!
+                continue; // for now
+            } else {
+                LOG_FS_WARN("epoll_wait() returned event on unknown fd %d\n", events[i].data.fd);
+            }
+        }
+    }
 
     LOG_FS_WARN("Exit\n");
     return EXIT_SUCCESS;

--- a/tools/linux/uio_drivers/fs/op.c
+++ b/tools/linux/uio_drivers/fs/op.c
@@ -73,14 +73,15 @@ void handle_initialise(fs_cmd_t cmd)
     }
 
     /* Use the shell to mount the filesystem */
-    uint64_t cmd_size = sizeof(char) * ((PATH_MAX * 2) + 16);
+    uint64_t cmd_size = sizeof(char) * ((PATH_MAX * 2) + 32);
     char *sh_mount_cmd = malloc(cmd_size);
     if (!sh_mount_cmd) {
         LOG_FS_ERR("handle_initialise(): out of memory\n");
         exit(EXIT_FAILURE);
     }
 
-    snprintf(sh_mount_cmd, cmd_size, "mount %s %s", blk_device, mnt_point);
+    /* Mount without caching! */
+    snprintf(sh_mount_cmd, cmd_size, "mount -o sync %s %s", blk_device, mnt_point);
     LOG_FS_OPS("handle_initialise(): mounting with shell command: %s\n", sh_mount_cmd);
 
     if (system(sh_mount_cmd) == 0) {

--- a/tools/linux/uio_drivers/fs/op.c
+++ b/tools/linux/uio_drivers/fs/op.c
@@ -9,8 +9,14 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <string.h>
 #include <sys/mount.h>
 #include <linux/limits.h>
+#include <linux/types.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <sys/syscall.h>
 
 #include <lions/fs/protocol.h>
 
@@ -18,34 +24,40 @@
 #include "op.h"
 #include "util.h"
 
+#define NAME_MAX_LEN 256
+
 extern char blk_device[PATH_MAX];
 extern char mnt_point[PATH_MAX];
 extern char *fs_data;
 
 bool mounted = false;
 
-void fs_op_reply_success(uint64_t cmd_id, fs_cmpl_data_t result) {
-    fs_queue_reply((fs_cmpl_t){ 
-        .id = cmd_id,
-        .status = FS_STATUS_SUCCESS,
-        .data = result
-    });
-}
-
-void fs_op_reply_failure(uint64_t cmd_id, uint64_t status, fs_cmpl_data_t result) {
-    fs_queue_reply((fs_cmpl_t){ 
-        .id = cmd_id,
-        .status = status,
-        .data = result
-    });
+/* Error checking wrapper around fs_malloc_create_path. Atomic to failures. */
+char *prepare_path(uint64_t cmd_id, fs_buffer_t client_path) {
+    size_t path_total_len;
+    if (client_path.size > PATH_MAX) {
+        fs_op_reply_failure(cmd_id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0});
+        return NULL;
+    }
+    char *path = fs_malloc_create_path(client_path, &path_total_len);
+    if (!path) {
+        fs_op_reply_failure(cmd_id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0});
+        return NULL;
+    }
+    if (path_total_len > PATH_MAX) {
+        fs_op_reply_failure(cmd_id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0});
+        free(path);
+        return NULL;
+    }
+    return path;
 }
 
 void handle_initialise(fs_cmd_t cmd)
 {
-    LOG_FS_OPS("handle_initialise()\n");
+    LOG_FS_OPS("handle_initialise(): entry\n");
     
     if (mounted) {
-        LOG_FS_OPS("already mounted!\n");
+        LOG_FS_OPS("handle_initialise(): already mounted!\n");
         fs_queue_reply((fs_cmpl_t){ 
             .id = cmd.id,
             .status = FS_STATUS_ERROR,
@@ -53,24 +65,22 @@ void handle_initialise(fs_cmd_t cmd)
         });
     }
 
-    uint64_t status = FS_STATUS_ERROR;
-
     uint64_t cmd_size = sizeof(char) * ((PATH_MAX * 2) + 16);
     char *sh_mount_cmd = malloc(cmd_size);
     if (!sh_mount_cmd) {
-        LOG_FS_ERR("out of memory\n");
+        LOG_FS_ERR("handle_initialise(): out of memory\n");
         exit(EXIT_FAILURE);
     }
 
     snprintf(sh_mount_cmd, cmd_size, "mount %s %s", blk_device, mnt_point);
-    LOG_FS_OPS("mounting with shell command: %s\n", sh_mount_cmd);
+    LOG_FS_OPS("handle_initialise(): mounting with shell command: %s\n", sh_mount_cmd);
 
     if (system(sh_mount_cmd) == 0) {
         mounted = true;
-        LOG_FS_OPS("block device at %s mounted at %s\n", blk_device, mnt_point);
+        LOG_FS_OPS("handle_initialise(): block device at %s mounted at %s\n", blk_device, mnt_point);
         fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
     } else {
-        LOG_FS_OPS("failed to mount block device at %s\n", blk_device);
+        LOG_FS_OPS("handle_initialise(): failed to mount block device at %s\n", blk_device);
         fs_op_reply_failure(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0});
     }
 
@@ -79,77 +89,331 @@ void handle_initialise(fs_cmd_t cmd)
 
 void handle_deinitialise(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_deinitialise(): entry\n");
 
 }
+
 void handle_open(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_open(): entry\n");
 
+    struct fs_cmd_params_file_open params = cmd.params.file_open;
+    char *path = malloc((sizeof(char) * params.path.size) + 1);
+    if (!path) {
+        LOG_FS_ERR("handle_open(): out of memory\n");
+        exit(EXIT_FAILURE);
+    }
+    fs_memcpy(path, fs_get_buffer(params.path), params.path.size);
+    path[params.path.size] = '\0';
+
+    LOG_FS_OPS("handle_open(): got path %s\n", path);
+
+    free(path);
 }
+
 void handle_stat(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_stat(): entry\n");
 
+    size_t path_total_len;
+    fs_cmd_params_stat_t params = cmd.params.stat;
+    if (params.path.size > PATH_MAX) {
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0});
+        return;
+    }
+    char *path = fs_malloc_create_path(params.path, &path_total_len);
+    if (!path) {
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0});
+        return;
+    }
+    if (path_total_len > PATH_MAX) {
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0});
+        return;
+    }
+
+    LOG_FS_OPS("handle_stat(): got concatenated path %s\n", path);
+
+    struct stat stat_data;
+    int err = stat(path, &stat_data);
+
+    if (err != -1) {
+        // TODO
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_stat(): fail with errno %d\n", err_num);
+        if (err_num == ENOENT) {
+            fs_op_reply_failure(cmd.id, FS_STATUS_INVALID_PATH, (fs_cmpl_data_t){0});
+        }
+    }
+
+    free(path);
 }
+
 void handle_fsize(fs_cmd_t cmd)
 {
-
+    LOG_FS_OPS("handle_fsize(): entry\n");
 }
+
 void handle_close(fs_cmd_t cmd)
 {
-
+    LOG_FS_OPS("handle_close(): entry\n");
 }
+
 void handle_read(fs_cmd_t cmd)
 {
-
+    LOG_FS_OPS("handle_read(): entry\n");
 }
+
 void handle_write(fs_cmd_t cmd)
 {
-
+    LOG_FS_OPS("handle_write(): entry\n");
 }
+
 void handle_rename(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_rename(): entry\n");
+    fs_cmd_params_rename_t params = cmd.params.rename;
 
+    char *src_path = prepare_path(cmd.id, params.old_path);
+    char *dst_path = prepare_path(cmd.id, params.new_path);
+    if (!src_path || !dst_path) {
+        return;
+    }
+
+    if (rename(src_path, dst_path) == 0) {
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_rename(): fail with errno %d\n", err_num);
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    }
+
+    free(src_path);
+    free(dst_path);
 }
+
 void handle_unlink(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_unlink(): entry\n");
+    fs_cmd_params_file_remove_t params = cmd.params.file_remove;
+    char *path = prepare_path(cmd.id, params.path);
+    if (!path) {
+        return;
+    }
 
+    LOG_FS_OPS("handle_unlink(): got concatenated path %s\n", path);
+
+    if (unlink(path) == 0) {
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_unlink(): fail with errno %d\n", err_num);
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    }
+
+    free(path);
 }
+
 void handle_truncate(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_truncate(): entry\n");
 
+    fs_cmd_params_file_truncate_t params = cmd.params.file_truncate;
+    uint64_t fd = params.fd;
+    uint64_t len = params.length;
+
+    if (ftruncate(fd, len) == 0) {
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_truncate(): fail with errno %d\n", err_num);
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    }
 }
+
 void handle_mkdir(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_mkdir(): entry\n");
+    /* Concatenate the client provided path with the mount point. */
+    fs_cmd_params_dir_remove_t params = cmd.params.dir_remove;
+    char *path = prepare_path(cmd.id, params.path);
+    if (!path) {
+        return;
+    }
 
+    LOG_FS_OPS("handle_mkdir(): got concatenated path %s\n", path);
+
+    if (mkdir(path, 0) == 0) {
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_mkdir(): fail with errno %d\n", err_num);
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    }
+
+    free(path);
 }
+
 void handle_rmdir(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_rmdir(): entry\n");
 
+    /* Concatenate the client provided path with the mount point. */
+    fs_cmd_params_dir_remove_t params = cmd.params.dir_remove;
+    char *path = prepare_path(cmd.id, params.path);
+    if (!path) {
+        return;
+    }
+
+    LOG_FS_OPS("handle_rmdir(): got concatenated path %s\n", path);
+
+    if (rmdir(path) == 0) {
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_opendir(): fail with errno %d\n", err_num);
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    }
+
+    free(path);
 }
+
 void handle_opendir(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_opendir(): entry\n");
 
+    /* Concatenate the client provided path with the mount point. */
+    fs_cmd_params_dir_open_t params = cmd.params.dir_open;
+    char *path = prepare_path(cmd.id, params.path);
+    if (!path) {
+        return;
+    }
+
+    LOG_FS_OPS("handle_opendir(): got concatenated path %s\n", path);
+
+    /* Using opendir instead of open for better portability. */
+    DIR *dir_stream = opendir(path);
+    if (dir_stream) {
+        LOG_FS_OPS("handle_opendir(): ok\n");
+        fs_cmpl_data_t result;
+        /* This is very sketchy, setting the "fd" as the pointer to dir_stream. */
+        result.dir_open.fd = (uint64_t) dir_stream;
+        fs_op_reply_success(cmd.id, result);
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_opendir(): fail with errno %d\n", err_num);
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    }
+
+    free(path);
 }
+
 void handle_closedir(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_closedir(): entry\n");
+    fs_cmd_params_dir_close_t params = cmd.params.dir_close;
+    DIR *dir_stream = (DIR *) params.fd;
 
+    if (closedir(dir_stream) == 0) {
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_closedir(): fail with errno %d\n", err_num);
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    }
 }
+
 void handle_readdir(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_readdir(): entry\n");
+    fs_cmd_params_dir_read_t params = cmd.params.dir_read;
+    DIR *dir_stream = (DIR *) params.fd;
+    char *path = fs_get_buffer(params.buf);
 
+    if (params.buf.size < NAME_MAX_LEN) {
+        LOG_FS_OPS("handle_readdir(): client buf not big enough: %d < %d\n", params.buf.size, NAME_MAX_LEN);
+        fs_op_reply_failure(cmd.id, FS_STATUS_INVALID_BUFFER, (fs_cmpl_data_t){0});
+    }
+
+    errno = 0;
+    struct dirent *entry = readdir(dir_stream);
+    if (!entry) {
+        if (errno == 0) {
+            fs_op_reply_failure(cmd.id, FS_STATUS_END_OF_DIRECTORY, (fs_cmpl_data_t){0});
+            return;
+        } else {
+            int err_num = errno;
+            LOG_FS_OPS("handle_readdir(): fail with errno %d\n", err_num);
+            fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+            return;
+        }
+    }
+
+    size_t name_len = strlen(entry->d_name);
+    strcpy(path, entry->d_name);
+
+    fs_cmpl_data_t result;
+    memset(&result, 0, sizeof(result));
+    result.dir_read.path_len = name_len;
+    fs_op_reply_success(cmd.id, result);
 }
+
 void handle_fsync(fs_cmd_t cmd)
 {
-
+    LOG_FS_OPS("handle_fsync(): entry\n");
 }
+
 void handle_seekdir(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_seekdir(): entry\n");
 
+    fs_cmd_params_dir_seek_t params = cmd.params.dir_seek;
+    DIR *dir_stream = (DIR *) params.fd;
+    int64_t loc = params.loc;
+
+    errno = 0;
+    seekdir(dir_stream, loc);
+
+    if (errno == 0) {
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
+    }
 }
+
 void handle_telldir(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_telldir(): entry\n");
 
+    fs_cmd_params_dir_tell_t params = cmd.params.dir_tell;
+    DIR *dir_stream = (DIR *) params.fd;
+
+    long pos = telldir(dir_stream);
+    if (pos != -1) {
+        fs_cmpl_data_t result;
+        memset(&result, 0, sizeof(result));
+        result.dir_tell.location = pos;
+        fs_op_reply_success(cmd.id, result);
+    } else {
+        int err_num = errno;
+        LOG_FS_OPS("handle_telldir(): fail with errno %d\n", err_num);
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    }
 }
+
 void handle_rewinddir(fs_cmd_t cmd)
 {
+    LOG_FS_OPS("handle_rewinddir(): entry\n");
 
+    fs_cmd_params_dir_rewind_t params = cmd.params.dir_rewind;
+    DIR *dir_stream = (DIR *) params.fd;
+
+    errno = 0;
+    rewinddir(dir_stream);
+
+    if (errno == 0) {
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
+    }
 }

--- a/tools/linux/uio_drivers/fs/op.c
+++ b/tools/linux/uio_drivers/fs/op.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -25,116 +26,138 @@
 #include "op.h"
 #include "util.h"
 
+#include <liburing.h>
+
 #define NAME_MAX_LEN 256
 
 /* From main.c */
 extern char blk_device[PATH_MAX];
+extern int blk_device_len;
 extern char mnt_point[PATH_MAX];
+extern int mnt_point_len;
 extern char *fs_data;
+extern struct io_uring ring;
 
 /* Metadata with the mounted FS */
 bool mounted = false;
-/* Each read/write is bounded by the data share region size */
-char inflight_data[UIO_LENGTH_FS_DATA];
-
-/* A simple macro to abort FS operations if the FS isn't mounted */
-#define CHECK_MOUNTED(cmd_id) {if(!mounted){fs_op_reply_failure(cmd_id, FS_STATUS_ERROR, (fs_cmpl_data_t){0});return;}}
+/* Our copy of the client data share, it is unsafe to give their address directly
+   to kernel as the underlying block device may DMA. Another reason is that UIO map
+   the memory as device memory, which cause weird behaviours with syscalls. */
+char our_data_region[UIO_LENGTH_FS_DATA];
 
 #define TIMESPEC_TO_NS(ts) ((long long)ts.tv_sec * 1000000000LL + ts.tv_nsec)
 
-/* Error checking wrapper around fs_malloc_create_path. Atomic to failures. */
-char *prepare_path(uint64_t cmd_id, fs_buffer_t client_path) {
-    size_t path_total_len;
-    if (client_path.size > PATH_MAX) {
-        fs_op_reply_failure(cmd_id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0});
-        return NULL;
+#define CREATE_COMP(cmd_id, status_code, return_data) \
+    (fs_cmpl_t){ .id = (cmd_id), .status = (status_code), .data = (return_data) }
+
+#define CHECK_MOUNTED(cmd_id, comp_idx) \
+    do { \
+        if (!mounted) { \
+            fs_queue_enqueue_reply(CREATE_COMP((cmd_id), FS_STATUS_ERROR, (fs_cmpl_data_t){0}), (comp_idx)); \
+            return; \
+        } \
+    } while (0)
+
+/* Thin error checking wrapper around fs_malloc_create_path. Prepend the
+   the mount point with the client path */
+char *malloc_prepare_path(fs_buffer_t their_path, uint64_t cmd_id, uint64_t *comp_idx) {
+    size_t expected_path_total_len = mnt_point_len + their_path.size;
+    if (expected_path_total_len > PATH_MAX) {
+        fs_queue_enqueue_reply(CREATE_COMP(cmd_id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0}), comp_idx);
     }
-    char *path = fs_malloc_create_path(client_path, &path_total_len);
+    size_t got_path_total_len;
+    char *path = fs_malloc_create_path(their_path, &got_path_total_len);
     if (!path) {
-        fs_op_reply_failure(cmd_id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0});
-        return NULL;
+        fs_queue_enqueue_reply(CREATE_COMP(cmd_id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        LOG_FS_ERR("malloc_prepare_path(): ENOMEM, bail!");
+        exit(EXIT_FAILURE);
     }
-    if (path_total_len > PATH_MAX) {
-        fs_op_reply_failure(cmd_id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0});
-        free(path);
-        return NULL;
-    }
+    assert(expected_path_total_len == got_path_total_len);
     return path;
 }
 
-void handle_initialise(fs_cmd_t cmd)
+uint64_t concat_2_32_bits(uint32_t lhs, uint32_t rhs) {
+    uint64_t res = rhs;
+    res = res >> 32;
+    res |= lhs;
+    return res;
+}
+
+/* Mounting */
+void handle_initialise(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_initialise(): entry\n");
     
     if (mounted) {
         LOG_FS_OPS("handle_initialise(): already mounted!\n");
-        fs_op_reply_failure(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0});
-        return;
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
     }
 
     /* Use the shell to mount the filesystem */
-    uint64_t cmd_size = sizeof(char) * ((PATH_MAX * 2) + 32);
+    uint64_t cmd_size = sizeof(char) * (16 + blk_device_len + mnt_point_len);
     char *sh_mount_cmd = malloc(cmd_size);
     if (!sh_mount_cmd) {
-        LOG_FS_ERR("handle_initialise(): out of memory\n");
+        LOG_FS_ERR("handle_initialise(): out of memory, bail.\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
         exit(EXIT_FAILURE);
     }
 
     /* Mount without caching! */
     snprintf(sh_mount_cmd, cmd_size, "mount -o sync %s %s", blk_device, mnt_point);
     LOG_FS_OPS("handle_initialise(): mounting with shell command: %s\n", sh_mount_cmd);
+    int ret = system(sh_mount_cmd);
+    free(sh_mount_cmd);
 
-    if (system(sh_mount_cmd) == 0) {
+    if (ret == 0) {
         mounted = true;
         LOG_FS_OPS("handle_initialise(): block device at %s mounted at %s\n", blk_device, mnt_point);
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
     } else {
         LOG_FS_OPS("handle_initialise(): failed to mount block device at %s\n", blk_device);
-        fs_op_reply_failure(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
     }
-
-    free(sh_mount_cmd);
 }
 
-void handle_deinitialise(fs_cmd_t cmd)
+/* Unmounting */
+void handle_deinitialise(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_deinitialise(): entry\n");
 
-    CHECK_MOUNTED(cmd.id);
+    CHECK_MOUNTED(cmd.id, comp_idx);
 
     /* Use the shell to unmount the filesystem */
     uint64_t cmd_size = sizeof(char) * ((PATH_MAX) + 16);
     char *sh_umount_cmd = malloc(cmd_size);
     if (!sh_umount_cmd) {
-        LOG_FS_ERR("handle_deinitialise(): out of memory\n");
+        LOG_FS_ERR("handle_deinitialise(): out of memory, bail.\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
         exit(EXIT_FAILURE);
     }
 
     snprintf(sh_umount_cmd, cmd_size, "umount %s", mnt_point);
-    LOG_FS_OPS("handle_deinitialise(): mounting with shell command: %s\n", sh_umount_cmd);
-
+    LOG_FS_OPS("handle_deinitialise(): unmounting with shell command: %s\n", sh_umount_cmd);
     int umount_exit_code = system(sh_umount_cmd);
-    switch(umount_exit_code) {
-        case EXIT_SUCCESS: {
-            mounted = false;
-            LOG_FS_OPS("handle_deinitialise(): filesystem at %s, with backing block device at %s UNMOUNTED.\n", mnt_point, blk_device);
-            fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
-        }
-        default: {
-            // Assume that this is due to inflight operations. 
-            fs_op_reply_failure(cmd.id, FS_STATUS_OUTSTANDING_OPERATIONS, (fs_cmpl_data_t){0});
-        }
-    }
-
     free(sh_umount_cmd);
+
+    if (umount_exit_code == 0) {
+        mounted = false;
+        LOG_FS_OPS("handle_deinitialise(): filesystem at %s, with backing block device at %s UNMOUNTED.\n", mnt_point, blk_device);
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+    }
 }
 
-void handle_open(fs_cmd_t cmd)
+/* Open */
+void handle_open(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_open(): entry\n");
 
     struct fs_cmd_params_file_open params = cmd.params.file_open;
-    char *path = prepare_path(cmd.id, params.path);
+    char *path = malloc_prepare_path(params.path, cmd.id, comp_idx);
+    if (!path) {
+        return;
+    }
 
     LOG_FS_OPS("handle_open(): got path %s\n", path);
     int flags = 0;
@@ -150,116 +173,267 @@ void handle_open(fs_cmd_t cmd)
         flags |= O_WRONLY;
     }
 
-    int fd = open(path, flags);
-    if (fd != -1) {
-        fs_cmpl_data_t result;
-        result.file_open.fd = fd;
-        fs_op_reply_success(cmd.id, result);
-    } else {
-        fs_op_reply_failure(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0});
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_open(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
     }
 
-    free(path);
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_open(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Now fill in and enqueue an open operation. */
+    io_uring_prep_open(sqe, path, flags, 0);
+
+    /* Prepare the callback data structure */
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_FILE_OPEN;
+    cb_data->malloced_data_1 = path;
+    cb_data->malloced_data_2 = (char *) NULL;
+    sqe->user_data = (uint64_t) cb_data;
 }
 
-void handle_stat(fs_cmd_t cmd)
+void cb_open(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    int fd = cqe->res;
+
+    if (fd >= 0) {
+        fs_cmpl_data_t result;
+        result.file_open.fd = fd;
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, result), comp_idx);
+        LOG_FS_OPS("cb_open(): success\n");
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-fd), (fs_cmpl_data_t){0}), comp_idx);
+        LOG_FS_OPS("cb_open(): fail: %d %s\n", -cqe->res, strerror(-cqe->res));
+    }
+
+    assert(cb_data->malloced_data_1);
+    free(cb_data->malloced_data_1);
+    assert(!cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Stat */
+void handle_stat(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_stat(): entry\n");
-
-    size_t path_total_len;
     fs_cmd_params_stat_t params = cmd.params.stat;
-    if (params.path.size > PATH_MAX) {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0});
-        return;
-    }
-    char *path = fs_malloc_create_path(params.path, &path_total_len);
-    if (!path) {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0});
-        return;
-    }
-    if (path_total_len > PATH_MAX) {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0});
-        free(path);
-        return;
-    }
+
     if (params.buf.size < sizeof(fs_stat_t)) {
-        fs_op_reply_failure(cmd.id, FS_STATUS_INVALID_BUFFER, (fs_cmpl_data_t){0});
-        free(path);
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(EFAULT), (fs_cmpl_data_t){0}), comp_idx);
+        return;
+    }
+
+    char *path = malloc_prepare_path(params.path, cmd.id, comp_idx);
+    if (!path) {
+        return;
+    }
+
+    struct statx *stx = malloc(sizeof(struct statx));
+    if (!stx) {
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0}), comp_idx);
         return;
     }
 
     LOG_FS_OPS("handle_stat(): got concatenated path %s\n", path);
 
-    struct stat stat_data;
-    int err = stat(path, &stat_data);
-
-    if (err != -1) {
-        fs_stat_t *resp_stat = (fs_stat_t *) fs_get_buffer(params.buf);
-        resp_stat->dev = stat_data.st_dev;
-        resp_stat->ino = stat_data.st_ino;
-        resp_stat->mode = stat_data.st_mode;
-        resp_stat->nlink = stat_data.st_nlink;
-        resp_stat->uid = stat_data.st_uid;
-        resp_stat->gid = stat_data.st_gid;
-        resp_stat->rdev = stat_data.st_rdev;
-        resp_stat->size = stat_data.st_size;
-        resp_stat->blksize = stat_data.st_blksize;
-        resp_stat->blocks = stat_data.st_blocks;
-
-        resp_stat->atime = stat_data.st_atim.tv_sec;
-        resp_stat->mtime = stat_data.st_mtim.tv_sec;
-        resp_stat->ctime = stat_data.st_ctim.tv_sec;
-
-        resp_stat->atime_nsec = TIMESPEC_TO_NS(stat_data.st_atim);
-        resp_stat->mtime_nsec = TIMESPEC_TO_NS(stat_data.st_mtim);
-        resp_stat->ctime_nsec = TIMESPEC_TO_NS(stat_data.st_ctim);
-
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
-    } else {
-        int err_num = errno;
-        LOG_FS_OPS("handle_stat(): fail with errno %d\n", err_num);
-        if (err_num == ENOENT) {
-            fs_op_reply_failure(cmd.id, FS_STATUS_INVALID_PATH, (fs_cmpl_data_t){0});
-        }
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_stat(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
     }
 
-    free(path);
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_stat(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Now fill in and enqueue a statx operation. */
+    io_uring_prep_statx(sqe, AT_FDCWD, path, 0, STATX_BASIC_STATS, stx);
+
+    /* Prepare the callback data structure */
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_STAT;
+    cb_data->resp_buf = params.buf;
+    cb_data->malloced_data_1 = path;
+    cb_data->malloced_data_2 = (char *) stx;
+    sqe->user_data = (uint64_t) cb_data;
 }
 
-void handle_fsize(fs_cmd_t cmd)
+void cb_stat(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    assert(cb_data->malloced_data_1);
+    assert(cb_data->malloced_data_2);
+
+    if (cqe->res == 0) {
+        struct statx *stat_data = (struct statx *) cb_data->malloced_data_2;
+        fs_stat_t *resp_stat = (fs_stat_t *) fs_get_buffer(cb_data->resp_buf);
+
+        resp_stat->dev = concat_2_32_bits(stat_data->stx_dev_major, stat_data->stx_dev_minor);
+        resp_stat->ino = stat_data->stx_ino;
+        resp_stat->mode = stat_data->stx_mode;
+        resp_stat->nlink = stat_data->stx_nlink;
+        resp_stat->uid = stat_data->stx_uid;
+        resp_stat->gid = stat_data->stx_gid;
+        resp_stat->rdev = concat_2_32_bits(stat_data->stx_rdev_major, stat_data->stx_rdev_minor);
+        resp_stat->size = stat_data->stx_size;
+        resp_stat->blksize = stat_data->stx_blksize;
+        resp_stat->blocks = stat_data->stx_blocks;
+
+        resp_stat->atime = stat_data->stx_atime.tv_sec;
+        resp_stat->mtime = stat_data->stx_mtime.tv_sec;
+        resp_stat->ctime = stat_data->stx_ctime.tv_sec;
+
+        resp_stat->atime_nsec = TIMESPEC_TO_NS(stat_data->stx_atime);
+        resp_stat->mtime_nsec = TIMESPEC_TO_NS(stat_data->stx_mtime);
+        resp_stat->ctime_nsec = TIMESPEC_TO_NS(stat_data->stx_ctime);
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
+        LOG_FS_OPS("cb_stat(): success\n");
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-cqe->res), (fs_cmpl_data_t){0}), comp_idx);
+        LOG_FS_OPS("cb_stat(): fail: %d %s\n", -cqe->res, strerror(-cqe->res));
+    }
+    
+    free(cb_data->malloced_data_1);
+    free(cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Fsize */
+
+void handle_fsize(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_fsize(): entry\n");
     fs_cmd_params_file_size_t params = cmd.params.file_size;
     uint64_t fd = params.fd;
 
-    off_t sz = lseek(fd, 0L, SEEK_END);
-    if (sz > -1) {
-        fs_cmpl_data_t result;
-        result.file_size.size = sz;
-        fs_op_reply_success(cmd.id, result);
-    } else {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
+    struct statx *stx = malloc(sizeof(struct statx));
+    if (!stx) {
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENAMETOOLONG), (fs_cmpl_data_t){0}), comp_idx);
+        return;
     }
+
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_fsize(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_fsize(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH, STATX_SIZE, stx);
+
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_FILE_SIZE;
+    cb_data->malloced_data_1 = (char *) stx;
+    cb_data->malloced_data_2 = (char *) NULL;
+    sqe->user_data = (uint64_t) cb_data;
 }
 
-void handle_close(fs_cmd_t cmd)
+void cb_fsize(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    assert(cb_data->malloced_data_1);
+
+    if (cqe->res == 0) {
+        struct statx *stat_data = (struct statx *) cb_data->malloced_data_1;
+        fs_cmpl_data_t result;
+        result.file_size.size = stat_data->stx_size;
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, result), comp_idx);
+        LOG_FS_OPS("cb_fsize(): success\n");
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-cqe->res), (fs_cmpl_data_t){0}), comp_idx);
+        LOG_FS_OPS("cb_fsize(): fail: %d %s\n", -cqe->res, strerror(-cqe->res));
+    }
+
+    free(cb_data->malloced_data_1);
+    assert(!cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Close */
+
+void handle_close(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_close(): entry\n");
 
     fs_cmd_params_file_close_t params = cmd.params.file_close;
     uint64_t fd = params.fd;
 
-    errno = 0;
-    close(fd);
-
-    if (errno == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
-    } else {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_close(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
     }
+
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_close(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    io_uring_prep_close(sqe, fd);
+
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_FILE_CLOSE;
+    cb_data->malloced_data_1 = (char *) NULL;
+    cb_data->malloced_data_2 = (char *) NULL;
+    sqe->user_data = (uint64_t) cb_data;
 }
 
-void handle_read(fs_cmd_t cmd)
+void cb_close(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    int err = cqe->res;
+
+    if (err == 0) {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-err), (fs_cmpl_data_t){0}), comp_idx);
+    }
+
+    assert(!cb_data->malloced_data_1);
+    assert(!cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Read */
+
+void handle_read(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_read(): entry\n");
     fs_cmd_params_file_read_t params = cmd.params.file_read;
@@ -268,18 +442,57 @@ void handle_read(fs_cmd_t cmd)
     uint64_t count = params.buf.size;
     uint64_t off = params.offset;
 
-    ssize_t bytes_read = pread(fd, inflight_data, count, off);
-    if (bytes_read > -1) {
-        fs_memcpy(fs_get_buffer(params.buf), inflight_data, bytes_read);
-        fs_cmpl_data_t result;
-        result.file_read.len_read = bytes_read;
-        fs_op_reply_success(cmd.id, result);
-    } else {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_read(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
     }
+
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_read(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    io_uring_prep_read(sqe, fd, (char *) ((uint64_t) our_data_region + params.buf.offset), count, off);
+
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_FILE_READ;
+    /* This isn't malloced! Bit hacky */
+    cb_data->resp_buf = params.buf;
+    cb_data->malloced_data_1 = (char *) ((uint64_t) our_data_region + params.buf.offset);
+    cb_data->malloced_data_2 = (char *) NULL;
+    sqe->user_data = (uint64_t) cb_data;
 }
 
-void handle_write(fs_cmd_t cmd)
+void cb_read(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    int nbytes = cqe->res;
+    assert(cb_data->malloced_data_1);
+
+    if (nbytes >= 0) {
+        fs_memcpy(fs_get_buffer(cb_data->resp_buf), cb_data->malloced_data_1, nbytes);
+        fs_cmpl_data_t result;
+        result.file_read.len_read = nbytes;
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, result), comp_idx);
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-nbytes), (fs_cmpl_data_t){0}), comp_idx);
+    }
+
+    assert(!cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Write */
+
+void handle_write(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_write(): entry\n");
     fs_cmd_params_file_write_t params = cmd.params.file_write;
@@ -288,64 +501,179 @@ void handle_write(fs_cmd_t cmd)
     uint64_t count = params.buf.size;
     uint64_t off = params.offset;
 
-    LOG_FS_OPS("count = %p, off = %p, buff = %p\n", count, off, fs_get_buffer(params.buf));
-    fs_memcpy(inflight_data, fs_get_buffer(params.buf), count);
-    ssize_t bytes_written = pwrite(fd, inflight_data, count, off);
-    if (bytes_written > -1) {
-        fs_cmpl_data_t result;
-        result.file_write.len_written = bytes_written;
-        fs_op_reply_success(cmd.id, result);
-    } else {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
+    LOG_FS_OPS("count = %lu, off = %lu, buff = %p\n", count, off, fs_get_buffer(params.buf));
+    
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_write(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
     }
+
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_write(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+    
+    /* Copy the client's data into our buffer due to UIO being treated as device memory... */
+    fs_memcpy((char *) ((uint64_t) our_data_region + params.buf.offset), fs_get_buffer(params.buf), count);
+
+    io_uring_prep_write(sqe, fd, (char *) ((uint64_t) our_data_region + params.buf.offset), count, off);
+
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_FILE_WRITE;
+    /* This isn't malloced! Bit hacky */
+    cb_data->malloced_data_1 = (char *) ((uint64_t) our_data_region + params.buf.offset);
+    cb_data->malloced_data_2 = (char *) NULL;
+    sqe->user_data = (uint64_t) cb_data;
 }
 
-void handle_rename(fs_cmd_t cmd)
+void cb_write(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    int nbytes = cqe->res;
+    assert(cb_data->malloced_data_1);
+
+    if (nbytes >= 0) {
+        fs_cmpl_data_t result;
+        result.file_write.len_written = nbytes;
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, result), comp_idx);
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-nbytes), (fs_cmpl_data_t){0}), comp_idx);
+    }
+
+    assert(!cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Rename */
+
+void handle_rename(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_rename(): entry\n");
     fs_cmd_params_rename_t params = cmd.params.rename;
 
-    char *src_path = prepare_path(cmd.id, params.old_path);
-    char *dst_path = prepare_path(cmd.id, params.new_path);
-    if (!src_path || !dst_path) {
+    char *src_path = malloc_prepare_path(params.old_path, cmd.id, comp_idx);
+    if (!src_path) {
         return;
     }
-
-    if (rename(src_path, dst_path) == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
-    } else {
-        int err_num = errno;
-        LOG_FS_OPS("handle_rename(): fail with errno %d\n", err_num);
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    char *dst_path = malloc_prepare_path(params.new_path, cmd.id, comp_idx);
+    if (!dst_path) {
+        free(src_path);
+        return;
+    }
+    
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_fsize(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
     }
 
-    free(src_path);
-    free(dst_path);
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_fsize(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    io_uring_prep_rename(sqe, src_path, dst_path);
+
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_RENAME;
+    cb_data->malloced_data_1 = src_path;
+    cb_data->malloced_data_2 = dst_path;
+    sqe->user_data = (uint64_t) cb_data;
 }
 
-void handle_unlink(fs_cmd_t cmd)
+void cb_rename(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    int err = cqe->res;
+
+    if (err == 0) {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-err), (fs_cmpl_data_t){0}), comp_idx);
+    }
+
+    assert(cb_data->malloced_data_1);
+    free(cb_data->malloced_data_1);
+    assert(cb_data->malloced_data_2);
+    free(cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Unlink */
+
+void handle_unlink(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_unlink(): entry\n");
     fs_cmd_params_file_remove_t params = cmd.params.file_remove;
-    char *path = prepare_path(cmd.id, params.path);
+    char *path = malloc_prepare_path(params.path, cmd.id, comp_idx);
     if (!path) {
         return;
     }
 
     LOG_FS_OPS("handle_unlink(): got concatenated path %s\n", path);
 
-    if (unlink(path) == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
-    } else {
-        int err_num = errno;
-        LOG_FS_OPS("handle_unlink(): fail with errno %d\n", err_num);
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_fsize(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
     }
 
-    free(path);
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_fsize(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    io_uring_prep_unlink(sqe, path, 0);
+
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_FILE_REMOVE;
+    cb_data->malloced_data_1 = path;
+    cb_data->malloced_data_2 = (char *) NULL;
+    sqe->user_data = (uint64_t) cb_data;
 }
 
-void handle_truncate(fs_cmd_t cmd)
+void cb_unlink(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    int err = cqe->res;
+
+    if (err == 0) {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-err), (fs_cmpl_data_t){0}), comp_idx);
+    }
+
+    assert(cb_data->malloced_data_1);
+    free(cb_data->malloced_data_1);
+    assert(!cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Truncate */
+
+void handle_truncate(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_truncate(): entry\n");
 
@@ -353,21 +681,84 @@ void handle_truncate(fs_cmd_t cmd)
     uint64_t fd = params.fd;
     uint64_t len = params.length;
 
+    if (!io_uring_sqe_queue_empty(&ring)) {
+        flush_and_wait_io_uring_sqes(&ring, comp_idx);
+    }
+
     if (ftruncate(fd, len) == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
     } else {
         int err_num = errno;
         LOG_FS_OPS("handle_truncate(): fail with errno %d\n", err_num);
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0}), comp_idx);
     }
 }
 
-void handle_mkdir(fs_cmd_t cmd)
+/* Fsync */
+
+void handle_fsync(fs_cmd_t cmd, uint64_t *comp_idx)
+{
+    LOG_FS_OPS("handle_fsync(): entry\n");
+
+    fs_cmd_params_file_sync_t params = cmd.params.file_sync;
+    uint64_t fd = params.fd;
+
+    /* Ensure memory for the callback structure. */
+    io_uring_comp_callback_t *cb_data = malloc(sizeof(io_uring_comp_callback_t));
+    if (!cb_data) {
+        LOG_FS_ERR("handle_fsize(): out of memory for callback structure\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(ENOMEM), (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Get a submission queue entry (sqe).
+       This should never fail because the io_uring queue is the same capacity as client queue. */
+    struct io_uring_sqe *sqe;
+    sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+        LOG_FS_ERR("handle_fsize(): io_uring_get_sqe(): cannot get an SQE\n");
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0}), comp_idx);
+        exit(EXIT_FAILURE);
+    }
+
+    io_uring_prep_fsync(sqe, fd, 0);
+
+    cb_data->cmd_id = cmd.id;
+    cb_data->cmd_type = FS_CMD_FILE_SYNC;
+    cb_data->malloced_data_1 = (char *) NULL;
+    cb_data->malloced_data_2 = (char *) NULL;
+    sqe->user_data = (uint64_t) cb_data;
+}
+
+void cb_fsync(struct io_uring_cqe *cqe, uint64_t *comp_idx)
+{
+    io_uring_comp_callback_t *cb_data = cb_dat_from_cqe(cqe);
+    int err = cqe->res;
+
+    if (err == 0) {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
+    } else {
+        fs_queue_enqueue_reply(CREATE_COMP(cb_data->cmd_id, errno_to_lions_status(-err), (fs_cmpl_data_t){0}), comp_idx);
+    }
+
+    assert(!cb_data->malloced_data_1);
+    assert(!cb_data->malloced_data_2);
+    free(cb_data);
+}
+
+/* Mkdir */
+
+void handle_mkdir(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_mkdir(): entry\n");
+
+    if (!io_uring_sqe_queue_empty(&ring)) {
+        flush_and_wait_io_uring_sqes(&ring, comp_idx);
+    }
+
     /* Concatenate the client provided path with the mount point. */
     fs_cmd_params_dir_remove_t params = cmd.params.dir_remove;
-    char *path = prepare_path(cmd.id, params.path);
+    char *path = malloc_prepare_path(params.path, cmd.id, comp_idx);
     if (!path) {
         return;
     }
@@ -375,23 +766,28 @@ void handle_mkdir(fs_cmd_t cmd)
     LOG_FS_OPS("handle_mkdir(): got concatenated path %s\n", path);
 
     if (mkdir(path, 0) == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
     } else {
         int err_num = errno;
         LOG_FS_OPS("handle_mkdir(): fail with errno %d\n", err_num);
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0}), comp_idx);
     }
 
     free(path);
 }
 
-void handle_rmdir(fs_cmd_t cmd)
+/* Rmdir */
+void handle_rmdir(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_rmdir(): entry\n");
 
+    if (!io_uring_sqe_queue_empty(&ring)) {
+        flush_and_wait_io_uring_sqes(&ring, comp_idx);
+    }
+
     /* Concatenate the client provided path with the mount point. */
     fs_cmd_params_dir_remove_t params = cmd.params.dir_remove;
-    char *path = prepare_path(cmd.id, params.path);
+    char *path = malloc_prepare_path(params.path, cmd.id, comp_idx);
     if (!path) {
         return;
     }
@@ -399,23 +795,25 @@ void handle_rmdir(fs_cmd_t cmd)
     LOG_FS_OPS("handle_rmdir(): got concatenated path %s\n", path);
 
     if (rmdir(path) == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
     } else {
         int err_num = errno;
         LOG_FS_OPS("handle_opendir(): fail with errno %d\n", err_num);
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0}), comp_idx);
     }
 
     free(path);
 }
 
-void handle_opendir(fs_cmd_t cmd)
+/* Opendir */
+
+void handle_opendir(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_opendir(): entry\n");
 
     /* Concatenate the client provided path with the mount point. */
     fs_cmd_params_dir_open_t params = cmd.params.dir_open;
-    char *path = prepare_path(cmd.id, params.path);
+    char *path = malloc_prepare_path(params.path, cmd.id, comp_idx);
     if (!path) {
         return;
     }
@@ -429,32 +827,36 @@ void handle_opendir(fs_cmd_t cmd)
         fs_cmpl_data_t result;
         /* This is very sketchy, setting the "fd" as the pointer to dir_stream. */
         result.dir_open.fd = (uint64_t) dir_stream;
-        fs_op_reply_success(cmd.id, result);
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, result), comp_idx);
     } else {
         int err_num = errno;
         LOG_FS_OPS("handle_opendir(): fail with errno %d\n", err_num);
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0}), comp_idx);
     }
 
     free(path);
 }
 
-void handle_closedir(fs_cmd_t cmd)
+/* Closedir */
+
+void handle_closedir(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_closedir(): entry\n");
     fs_cmd_params_dir_close_t params = cmd.params.dir_close;
     DIR *dir_stream = (DIR *) params.fd;
 
     if (closedir(dir_stream) == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
     } else {
         int err_num = errno;
         LOG_FS_OPS("handle_closedir(): fail with errno %d\n", err_num);
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0}), comp_idx);
     }
 }
 
-void handle_readdir(fs_cmd_t cmd)
+/* Readdir */
+
+void handle_readdir(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_readdir(): entry\n");
     fs_cmd_params_dir_read_t params = cmd.params.dir_read;
@@ -462,20 +864,21 @@ void handle_readdir(fs_cmd_t cmd)
     char *path = fs_get_buffer(params.buf);
 
     if (params.buf.size < NAME_MAX_LEN) {
-        LOG_FS_OPS("handle_readdir(): client buf not big enough: %d < %d\n", params.buf.size, NAME_MAX_LEN);
-        fs_op_reply_failure(cmd.id, FS_STATUS_INVALID_BUFFER, (fs_cmpl_data_t){0});
+        LOG_FS_OPS("handle_readdir(): client buf not big enough: %lu < %d\n", params.buf.size, NAME_MAX_LEN);
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_INVALID_BUFFER, (fs_cmpl_data_t){0}), comp_idx);
+        return;
     }
 
     errno = 0;
     struct dirent *entry = readdir(dir_stream);
     if (!entry) {
         if (errno == 0) {
-            fs_op_reply_failure(cmd.id, FS_STATUS_END_OF_DIRECTORY, (fs_cmpl_data_t){0});
+            fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_END_OF_DIRECTORY, (fs_cmpl_data_t){0}), comp_idx);
             return;
         } else {
             int err_num = errno;
             LOG_FS_OPS("handle_readdir(): fail with errno %d\n", err_num);
-            fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+            fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0}), comp_idx);
             return;
         }
     }
@@ -484,29 +887,13 @@ void handle_readdir(fs_cmd_t cmd)
     strcpy(path, entry->d_name);
 
     fs_cmpl_data_t result;
-    memset(&result, 0, sizeof(result));
     result.dir_read.path_len = name_len;
-    fs_op_reply_success(cmd.id, result);
+    fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
 }
 
-void handle_fsync(fs_cmd_t cmd)
-{
-    LOG_FS_OPS("handle_fsync(): entry\n");
+/* Seekdir */
 
-    fs_cmd_params_file_sync_t params = cmd.params.file_sync;
-    uint64_t fd = params.fd;
-
-    errno = 0;
-    fsync(fd);
-
-    if (errno == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
-    } else {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
-    }
-}
-
-void handle_seekdir(fs_cmd_t cmd)
+void handle_seekdir(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_seekdir(): entry\n");
 
@@ -518,13 +905,15 @@ void handle_seekdir(fs_cmd_t cmd)
     seekdir(dir_stream, loc);
 
     if (errno == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
     } else {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0}), comp_idx);
     }
 }
 
-void handle_telldir(fs_cmd_t cmd)
+/* Telldir */
+
+void handle_telldir(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_telldir(): entry\n");
 
@@ -534,17 +923,18 @@ void handle_telldir(fs_cmd_t cmd)
     long pos = telldir(dir_stream);
     if (pos != -1) {
         fs_cmpl_data_t result;
-        memset(&result, 0, sizeof(result));
         result.dir_tell.location = pos;
-        fs_op_reply_success(cmd.id, result);
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
     } else {
         int err_num = errno;
         LOG_FS_OPS("handle_telldir(): fail with errno %d\n", err_num);
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(err_num), (fs_cmpl_data_t){0}), comp_idx);
     }
 }
 
-void handle_rewinddir(fs_cmd_t cmd)
+/* Rewinddir*/
+
+void handle_rewinddir(fs_cmd_t cmd, uint64_t *comp_idx)
 {
     LOG_FS_OPS("handle_rewinddir(): entry\n");
 
@@ -555,8 +945,8 @@ void handle_rewinddir(fs_cmd_t cmd)
     rewinddir(dir_stream);
 
     if (errno == 0) {
-        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
     } else {
-        fs_op_reply_failure(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0});
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, errno_to_lions_status(errno), (fs_cmpl_data_t){0}), comp_idx);
     }
 }

--- a/tools/linux/uio_drivers/fs/op.c
+++ b/tools/linux/uio_drivers/fs/op.c
@@ -888,7 +888,7 @@ void handle_readdir(fs_cmd_t cmd, uint64_t *comp_idx)
 
     fs_cmpl_data_t result;
     result.dir_read.path_len = name_len;
-    fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
+    fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, result), comp_idx);
 }
 
 /* Seekdir */
@@ -924,7 +924,7 @@ void handle_telldir(fs_cmd_t cmd, uint64_t *comp_idx)
     if (pos != -1) {
         fs_cmpl_data_t result;
         result.dir_tell.location = pos;
-        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, (fs_cmpl_data_t){0}), comp_idx);
+        fs_queue_enqueue_reply(CREATE_COMP(cmd.id, FS_STATUS_SUCCESS, result), comp_idx);
     } else {
         int err_num = errno;
         LOG_FS_OPS("handle_telldir(): fail with errno %d\n", err_num);

--- a/tools/linux/uio_drivers/fs/op.c
+++ b/tools/linux/uio_drivers/fs/op.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <sys/mount.h>
+#include <linux/limits.h>
+
+#include <lions/fs/protocol.h>
+
+#include "log.h"
+#include "op.h"
+#include "util.h"
+
+extern char blk_device[PATH_MAX];
+extern char mnt_point[PATH_MAX];
+extern char *fs_data;
+
+bool mounted = false;
+
+void fs_op_reply_success(uint64_t cmd_id, fs_cmpl_data_t result) {
+    fs_queue_reply((fs_cmpl_t){ 
+        .id = cmd_id,
+        .status = FS_STATUS_SUCCESS,
+        .data = result
+    });
+}
+
+void fs_op_reply_failure(uint64_t cmd_id, uint64_t status, fs_cmpl_data_t result) {
+    fs_queue_reply((fs_cmpl_t){ 
+        .id = cmd_id,
+        .status = status,
+        .data = result
+    });
+}
+
+void handle_initialise(fs_cmd_t cmd)
+{
+    LOG_FS_OPS("handle_initialise()\n");
+    
+    if (mounted) {
+        LOG_FS_OPS("already mounted!\n");
+        fs_queue_reply((fs_cmpl_t){ 
+            .id = cmd.id,
+            .status = FS_STATUS_ERROR,
+            .data = {0}
+        });
+    }
+
+    uint64_t status = FS_STATUS_ERROR;
+
+    uint64_t cmd_size = sizeof(char) * ((PATH_MAX * 2) + 16);
+    char *sh_mount_cmd = malloc(cmd_size);
+    if (!sh_mount_cmd) {
+        LOG_FS_ERR("out of memory\n");
+        exit(EXIT_FAILURE);
+    }
+
+    snprintf(sh_mount_cmd, cmd_size, "mount %s %s", blk_device, mnt_point);
+    LOG_FS_OPS("mounting with shell command: %s\n", sh_mount_cmd);
+
+    if (system(sh_mount_cmd) == 0) {
+        mounted = true;
+        LOG_FS_OPS("block device at %s mounted at %s\n", blk_device, mnt_point);
+        fs_op_reply_success(cmd.id, (fs_cmpl_data_t){0});
+    } else {
+        LOG_FS_OPS("failed to mount block device at %s\n", blk_device);
+        fs_op_reply_failure(cmd.id, FS_STATUS_ERROR, (fs_cmpl_data_t){0});
+    }
+
+    free(sh_mount_cmd);
+}
+
+void handle_deinitialise(fs_cmd_t cmd)
+{
+
+}
+void handle_open(fs_cmd_t cmd)
+{
+
+}
+void handle_stat(fs_cmd_t cmd)
+{
+
+}
+void handle_fsize(fs_cmd_t cmd)
+{
+
+}
+void handle_close(fs_cmd_t cmd)
+{
+
+}
+void handle_read(fs_cmd_t cmd)
+{
+
+}
+void handle_write(fs_cmd_t cmd)
+{
+
+}
+void handle_rename(fs_cmd_t cmd)
+{
+
+}
+void handle_unlink(fs_cmd_t cmd)
+{
+
+}
+void handle_truncate(fs_cmd_t cmd)
+{
+
+}
+void handle_mkdir(fs_cmd_t cmd)
+{
+
+}
+void handle_rmdir(fs_cmd_t cmd)
+{
+
+}
+void handle_opendir(fs_cmd_t cmd)
+{
+
+}
+void handle_closedir(fs_cmd_t cmd)
+{
+
+}
+void handle_readdir(fs_cmd_t cmd)
+{
+
+}
+void handle_fsync(fs_cmd_t cmd)
+{
+
+}
+void handle_seekdir(fs_cmd_t cmd)
+{
+
+}
+void handle_telldir(fs_cmd_t cmd)
+{
+
+}
+void handle_rewinddir(fs_cmd_t cmd)
+{
+
+}

--- a/tools/linux/uio_drivers/fs/op.h
+++ b/tools/linux/uio_drivers/fs/op.h
@@ -5,30 +5,36 @@
 
 #pragma once
 
+#include <liburing.h>
 #include <lions/fs/protocol.h>
 
-void handle_initialise(fs_cmd_t cmd);
-void handle_deinitialise(fs_cmd_t cmd);
-void handle_open(fs_cmd_t cmd);
-void handle_stat(fs_cmd_t cmd);
-void handle_fsize(fs_cmd_t cmd);
-void handle_close(fs_cmd_t cmd);
-void handle_read(fs_cmd_t cmd);
-void handle_write(fs_cmd_t cmd);
-void handle_rename(fs_cmd_t cmd);
-void handle_unlink(fs_cmd_t cmd);
-void handle_truncate(fs_cmd_t cmd);
-void handle_mkdir(fs_cmd_t cmd);
-void handle_rmdir(fs_cmd_t cmd);
-void handle_opendir(fs_cmd_t cmd);
-void handle_closedir(fs_cmd_t cmd);
-void handle_readdir(fs_cmd_t cmd);
-void handle_fsync(fs_cmd_t cmd);
-void handle_seekdir(fs_cmd_t cmd);
-void handle_telldir(fs_cmd_t cmd);
-void handle_rewinddir(fs_cmd_t cmd);
+/* Dispatch functions, modifies comp_idx if it sent a reply */
+/* The ones below are asynchronous and uses io_uring. */
+void handle_open(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_stat(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_fsize(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_close(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_read(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_write(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_rename(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_unlink(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_truncate(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_fsync(fs_cmd_t cmd, uint64_t *comp_idx);
+/* The ones below are synchronous due to a lack of corresponding operation in io_uring */
+void handle_initialise(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_deinitialise(fs_cmd_t cmd, uint64_t *comp_idx);
+/* Calling mkdir and rmdir will cause the io_uring SQEs queue to flush,
+   acting as a barrier to maintain order of operations for correctness. */
+void handle_mkdir(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_rmdir(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_opendir(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_closedir(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_readdir(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_seekdir(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_telldir(fs_cmd_t cmd, uint64_t *comp_idx);
+void handle_rewinddir(fs_cmd_t cmd, uint64_t *comp_idx);
 
-static void (*const cmd_handler[FS_NUM_COMMANDS])(fs_cmd_t cmd) = {
+static void (*const cmd_handler[FS_NUM_COMMANDS])(fs_cmd_t cmd, uint64_t *comp_idx) = {
     [FS_CMD_INITIALISE] = handle_initialise,
     [FS_CMD_DEINITIALISE] = handle_deinitialise,
     [FS_CMD_FILE_OPEN] = handle_open,
@@ -49,4 +55,64 @@ static void (*const cmd_handler[FS_NUM_COMMANDS])(fs_cmd_t cmd) = {
     [FS_CMD_DIR_SEEK] = handle_seekdir,
     [FS_CMD_DIR_TELL] = handle_telldir,
     [FS_CMD_DIR_REWIND] = handle_rewinddir,
+};
+
+/* Data structures to construct a "callback" from an io_uring completion. */
+/* This is malloc'ed! */
+typedef struct io_uring_comp_callback {
+    uint64_t cmd_id;
+    uint64_t cmd_type;
+    fs_buffer_t resp_buf;
+
+    /* Buffers malloced by a dispatch function. 
+       Must be free'ed if the value is not NULL */
+    char *malloced_data_1;
+    char *malloced_data_2;
+} io_uring_comp_callback_t;
+
+/* Callback functions */
+void cb_open(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+void cb_stat(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+void cb_fsize(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+void cb_close(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+void cb_read(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+void cb_write(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+void cb_rename(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+void cb_unlink(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+void cb_fsync(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+
+// No-ops
+// void cb_initialise(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_deinitialise(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_truncate(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_mkdir(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_rmdir(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_opendir(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_closedir(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_readdir(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_seekdir(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_telldir(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+// void cb_rewinddir(struct io_uring_cqe *cqe, uint64_t *comp_idx);
+
+static void (*const callback_handler[FS_NUM_COMMANDS])(struct io_uring_cqe *cqe, uint64_t *comp_idx) = {
+    [FS_CMD_INITIALISE] = NULL,
+    [FS_CMD_DEINITIALISE] = NULL,
+    [FS_CMD_FILE_OPEN] = cb_open,
+    [FS_CMD_FILE_CLOSE] = cb_close,
+    [FS_CMD_STAT] = cb_stat,
+    [FS_CMD_FILE_READ] = cb_read,
+    [FS_CMD_FILE_WRITE] = cb_write,
+    [FS_CMD_FILE_SIZE] = cb_fsize,
+    [FS_CMD_RENAME] = cb_rename,
+    [FS_CMD_FILE_REMOVE] = cb_unlink,
+    [FS_CMD_FILE_SYNC] = cb_fsync,
+    [FS_CMD_FILE_TRUNCATE] = NULL,
+    [FS_CMD_DIR_CREATE] = NULL,
+    [FS_CMD_DIR_REMOVE] = NULL,
+    [FS_CMD_DIR_OPEN] = NULL,
+    [FS_CMD_DIR_CLOSE] = NULL,
+    [FS_CMD_DIR_READ] = NULL,
+    [FS_CMD_DIR_SEEK] = NULL,
+    [FS_CMD_DIR_TELL] = NULL,
+    [FS_CMD_DIR_REWIND] = NULL,
 };

--- a/tools/linux/uio_drivers/fs/op.h
+++ b/tools/linux/uio_drivers/fs/op.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <lions/fs/protocol.h>
+
+void handle_initialise(fs_cmd_t cmd);
+void handle_deinitialise(fs_cmd_t cmd);
+void handle_open(fs_cmd_t cmd);
+void handle_stat(fs_cmd_t cmd);
+void handle_fsize(fs_cmd_t cmd);
+void handle_close(fs_cmd_t cmd);
+void handle_read(fs_cmd_t cmd);
+void handle_write(fs_cmd_t cmd);
+void handle_rename(fs_cmd_t cmd);
+void handle_unlink(fs_cmd_t cmd);
+void handle_truncate(fs_cmd_t cmd);
+void handle_mkdir(fs_cmd_t cmd);
+void handle_rmdir(fs_cmd_t cmd);
+void handle_opendir(fs_cmd_t cmd);
+void handle_closedir(fs_cmd_t cmd);
+void handle_readdir(fs_cmd_t cmd);
+void handle_fsync(fs_cmd_t cmd);
+void handle_seekdir(fs_cmd_t cmd);
+void handle_telldir(fs_cmd_t cmd);
+void handle_rewinddir(fs_cmd_t cmd);
+
+static void (*const cmd_handler[FS_NUM_COMMANDS])(fs_cmd_t cmd) = {
+    [FS_CMD_INITIALISE] = handle_initialise,
+    [FS_CMD_DEINITIALISE] = handle_deinitialise,
+    [FS_CMD_FILE_OPEN] = handle_open,
+    [FS_CMD_FILE_CLOSE] = handle_close,
+    [FS_CMD_STAT] = handle_stat,
+    [FS_CMD_FILE_READ] = handle_read,
+    [FS_CMD_FILE_WRITE] = handle_write,
+    [FS_CMD_FILE_SIZE] = handle_fsize,
+    [FS_CMD_RENAME] = handle_rename,
+    [FS_CMD_FILE_REMOVE] = handle_unlink,
+    [FS_CMD_FILE_TRUNCATE] = handle_truncate,
+    [FS_CMD_DIR_CREATE] = handle_mkdir,
+    [FS_CMD_DIR_REMOVE] = handle_rmdir,
+    [FS_CMD_DIR_OPEN] = handle_opendir,
+    [FS_CMD_DIR_CLOSE] = handle_closedir,
+    [FS_CMD_FILE_SYNC] = handle_fsync,
+    [FS_CMD_DIR_READ] = handle_readdir,
+    [FS_CMD_DIR_SEEK] = handle_seekdir,
+    [FS_CMD_DIR_TELL] = handle_telldir,
+    [FS_CMD_DIR_REWIND] = handle_rewinddir,
+};

--- a/tools/linux/uio_drivers/fs/uio_fs.mk
+++ b/tools/linux/uio_drivers/fs/uio_fs.mk
@@ -30,15 +30,15 @@ uio_fs_driver: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5) uio_fs_driver_main.o uio_fs_driv
 	$(CC_USERLEVEL) -static $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) $^ -o $@
 
 uio_fs_driver_main.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
-uio_fs_driver_main.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/main.c
+uio_fs_driver_main.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/main.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h
 	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
 
 uio_fs_driver_op.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
-uio_fs_driver_op.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/op.c
+uio_fs_driver_op.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/op.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h
 	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
 
 uio_fs_driver_util.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
-uio_fs_driver_util.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/util.c
+uio_fs_driver_util.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/util.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h
 	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
 
 clean::

--- a/tools/linux/uio_drivers/fs/uio_fs.mk
+++ b/tools/linux/uio_drivers/fs/uio_fs.mk
@@ -26,11 +26,19 @@ $(CHECK_UIO_FS_DRIVER_FLAGS_MD5):
 	-rm -f .uio_fs_driver_cflags-*
 	touch $@
 
-uio_fs_driver: uio_fs_driver.o
+uio_fs_driver: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5) uio_fs_driver_main.o uio_fs_driver_op.o uio_fs_driver_util.o
 	$(CC_USERLEVEL) -static $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) $^ -o $@
 
-uio_fs_driver.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
-uio_fs_driver.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/main.c
+uio_fs_driver_main.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
+uio_fs_driver_main.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/main.c
+	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
+
+uio_fs_driver_op.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
+uio_fs_driver_op.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/op.c
+	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
+
+uio_fs_driver_util.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
+uio_fs_driver_util.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/util.c
 	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
 
 clean::

--- a/tools/linux/uio_drivers/fs/uio_fs.mk
+++ b/tools/linux/uio_drivers/fs/uio_fs.mk
@@ -15,7 +15,11 @@ endif
 ifeq ($(strip $(CC_USERLEVEL)),)
 $(error CC_USERLEVEL must be specified)
 endif
+ifeq ($(strip $(CPP_USERLEVEL)),)
+$(error CPP_USERLEVEL must be specified)
+endif
 
+UIO_FS_IMAGES_DEP := uio_fs_driver_main.o uio_fs_driver_op.o uio_fs_driver_util.o liburing.a
 UIO_FS_IMAGES := uio_fs_driver
 
 CFLAGS_uio_fs_driver := -I$(SDDF)/include -I$(LIBVMM_TOOLS)/linux/include
@@ -26,19 +30,35 @@ $(CHECK_UIO_FS_DRIVER_FLAGS_MD5):
 	-rm -f .uio_fs_driver_cflags-*
 	touch $@
 
-uio_fs_driver: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5) uio_fs_driver_main.o uio_fs_driver_op.o uio_fs_driver_util.o
+# Compile liburing for io_uring operations
+LIBURING := $(LIBVMM_TOOLS)/../dep/liburing
+# zig cc and zig c++ does not have elf.h on macos
+LIBURING_CC := aarch64-linux-gnu-gcc
+LIBURING_CPP := aarch64-linux-gnu-g++
+
+CFLAGS_uio_fs_driver := $(CFLAGS_uio_fs_driver) -Iliburing/src/include
+
+liburing.a:
+	cp -r $(LIBURING) liburing && \
+	cd liburing && \
+	./configure --cc=$(LIBURING_CC) --cxx=$(LIBURING_CPP) --includedir=$(LIBVMM_TOOLS)/linux/uio_drivers/fs/linux && \
+	make library && \
+	cp src/liburing.a ../liburing.a
+
+# Compile our FS UIO driver
+uio_fs_driver: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5) $(UIO_FS_IMAGES_DEP)
 	$(CC_USERLEVEL) -static $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) $^ -o $@
 
 uio_fs_driver_main.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
-uio_fs_driver_main.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/main.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h
+uio_fs_driver_main.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/main.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h liburing.a
 	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
 
 uio_fs_driver_op.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
-uio_fs_driver_op.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/op.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h
+uio_fs_driver_op.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/op.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h liburing.a
 	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
 
 uio_fs_driver_util.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
-uio_fs_driver_util.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/util.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h
+uio_fs_driver_util.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/util.c $(LIBVMM_TOOLS)/linux/uio_drivers/fs/log.h liburing.a
 	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
 
 clean::

--- a/tools/linux/uio_drivers/fs/uio_fs.mk
+++ b/tools/linux/uio_drivers/fs/uio_fs.mk
@@ -1,0 +1,42 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This Makefile snippet builds filesystem UIO driver
+#
+
+ifeq ($(strip $(LIBVMM_TOOLS)),)
+$(error LIBVMM_TOOLS must be specified)
+endif
+ifeq ($(strip $(SDDF)),)
+$(error SDDF must be specified)
+endif
+ifeq ($(strip $(CC_USERLEVEL)),)
+$(error CC_USERLEVEL must be specified)
+endif
+
+UIO_FS_IMAGES := uio_fs_driver
+
+CFLAGS_uio_fs_driver := -I$(SDDF)/include -I$(LIBVMM_TOOLS)/linux/include
+
+CHECK_UIO_FS_DRIVER_FLAGS_MD5:=.uio_fs_driver_cflags-$(shell echo -- $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) | shasum | sed 's/ *-//')
+
+$(CHECK_UIO_FS_DRIVER_FLAGS_MD5):
+	-rm -f .uio_fs_driver_cflags-*
+	touch $@
+
+uio_fs_driver: uio_fs_driver.o
+	$(CC_USERLEVEL) -static $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) $^ -o $@
+
+uio_fs_driver.o: $(CHECK_UIO_FS_DRIVER_FLAGS_MD5)
+uio_fs_driver.o: $(LIBVMM_TOOLS)/linux/uio_drivers/fs/main.c
+	$(CC_USERLEVEL) $(CFLAGS_USERLEVEL) $(CFLAGS_uio_fs_driver) -o $@ -c $<
+
+clean::
+	rm -f uio_fs_driver.[od] .uio_fs_driver_cflags-*
+
+clobber::
+	rm -f $(UIO_FS_IMAGES)
+
+-include uio_fs_driver.d

--- a/tools/linux/uio_drivers/fs/util.c
+++ b/tools/linux/uio_drivers/fs/util.c
@@ -95,17 +95,23 @@ char *fs_malloc_create_path(fs_buffer_t params_path, size_t *path_len) {
 }
 
 void fs_memcpy(char *dest, const char *src, size_t n) {
+    size_t i = 0;
+
+    size_t odd_bytes = n % 8;
+    while (i < odd_bytes) {
+        dest[i] = src[i];
+        i += 1;
+    }
+
     size_t n_64bytes_chunks = n / 8;
+    const char *remainder_src = &src[i];
+    char *remainder_dest = &dest[i];
 
     for (size_t i = 0; i < n_64bytes_chunks; i++) {
-        ((uint64_t *) dest)[i] = ((uint64_t *) src)[i];
+        ((uint64_t *) remainder_dest)[i] = ((uint64_t *) remainder_src)[i];
     }
 
-    size_t remainder = n % 8;
-    size_t begin_byte = n_64bytes_chunks * 8;
-    for (size_t i = 0; i < remainder; i++) {
-        dest[begin_byte + i] = src[begin_byte + i];
-    }
+    assert(i == n);
 }
 
 uint64_t errno_to_lions_status(int err_num) {

--- a/tools/linux/uio_drivers/fs/util.c
+++ b/tools/linux/uio_drivers/fs/util.c
@@ -40,7 +40,6 @@ void flush_and_wait_io_uring_sqes(struct io_uring *ring, uint64_t *comp_idx) {
             LOG_FS_ERR("flush_io_uring_sqes(): io_uring_wait_cqes(): failed: %s", strerror(-wait_err));
             exit(EXIT_FAILURE);
         }
-        assert(n_submitted == n_returned);
 
         /* For each completion, invoke the callback then enqueue the reply */
         struct io_uring_cqe *this_cqe;

--- a/tools/linux/uio_drivers/fs/util.c
+++ b/tools/linux/uio_drivers/fs/util.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <assert.h>
+
+#include <lions/fs/protocol.h>
+
+extern struct fs_queue *comp_queue;
+
+void fs_queue_reply(fs_cmpl_t cmpl) {
+    assert(fs_queue_length_producer(comp_queue) != FS_QUEUE_CAPACITY);
+    fs_queue_idx_empty(comp_queue, 0)->cmpl = cmpl;
+    fs_queue_publish_production(comp_queue, 1);
+}

--- a/tools/linux/uio_drivers/fs/util.c
+++ b/tools/linux/uio_drivers/fs/util.c
@@ -14,6 +14,7 @@
 
 #include "log.h"
 
+/* From main.c */
 extern char mnt_point[PATH_MAX];
 extern struct fs_queue *comp_queue;
 extern char *fs_data;
@@ -76,9 +77,11 @@ uint64_t errno_to_lions_status(int err_num) {
         case ENOENT: {
             return FS_STATUS_INVALID_PATH;
         }
+        case ENOSPC:
         case EACCES: {
             return FS_STATUS_SERVER_WAS_DENIED;
         }
+        case EROFS:
         case EBADF: {
             return FS_STATUS_INVALID_FD;
         }
@@ -92,12 +95,10 @@ uint64_t errno_to_lions_status(int err_num) {
         case ENOMEM: {
             return FS_STATUS_ALLOCATION_ERROR;
         }
+        case EDQUOT:
         case EOVERFLOW:
         case ENAMETOOLONG: {
             return FS_STATUS_INVALID_NAME;
-        }
-        case ENOSPC: {
-            return FS_STATUS_DIRECTORY_IS_FULL;
         }
         case EBUSY: {
             return FS_STATUS_OUTSTANDING_OPERATIONS;

--- a/tools/linux/uio_drivers/fs/util.c
+++ b/tools/linux/uio_drivers/fs/util.c
@@ -11,34 +11,63 @@
 
 #include <lions/fs/protocol.h>
 #include <uio/fs.h>
+#include <liburing.h>
 
+#include "util.h"
 #include "log.h"
+#include "op.h"
 
 /* From main.c */
 extern char mnt_point[PATH_MAX];
+extern int mnt_point_len;
 extern struct fs_queue *comp_queue;
 extern char *fs_data;
 
-void fs_queue_reply(fs_cmpl_t cmpl) {
+bool io_uring_sqe_queue_empty(struct io_uring *ring) {
+    struct io_uring_sq *sq = &ring->sq;
+    return sq->khead == sq->ktail;
+}
+
+void flush_and_wait_io_uring_sqes(struct io_uring *ring, uint64_t *comp_idx) {
+    /* Poke the Linux kernel. */
+
+    int n_submitted = io_uring_submit(ring);
+    if (n_submitted > 0) {
+        /* Something was submitted, now wait. */
+        struct io_uring_cqe *first_cqe;
+        int wait_err = io_uring_wait_cqes(ring, &first_cqe, n_submitted, NULL, NULL);
+        if (wait_err) {
+            LOG_FS_ERR("flush_io_uring_sqes(): io_uring_wait_cqes(): failed: %s", strerror(-wait_err));
+            exit(EXIT_FAILURE);
+        }
+        assert(n_submitted == n_returned);
+
+        /* For each completion, invoke the callback then enqueue the reply */
+        struct io_uring_cqe *this_cqe;
+        unsigned head;
+        unsigned i = 0;
+        io_uring_for_each_cqe(ring, head, this_cqe) {
+            callback_handler[cb_dat_from_cqe(this_cqe)->cmd_type](this_cqe, comp_idx);
+            i += 1;
+        }
+        io_uring_cq_advance(ring, i);
+        assert(i == n_submitted);
+    } else if (n_submitted == 0) {
+        /* No-op, only received mount/unmount */
+    } else {
+        LOG_FS_ERR("flush_io_uring_sqes(): io_uring_submit(): failed: %s", strerror(-n_submitted));
+        exit(EXIT_FAILURE);
+    }
+}
+
+io_uring_comp_callback_t *cb_dat_from_cqe(struct io_uring_cqe *cqe) {
+    return (io_uring_comp_callback_t *) cqe->user_data;
+}
+
+void fs_queue_enqueue_reply(fs_cmpl_t cmpl, uint64_t *comp_idx) {
     assert(fs_queue_length_producer(comp_queue) != FS_QUEUE_CAPACITY);
-    fs_queue_idx_empty(comp_queue, 0)->cmpl = cmpl;
-    fs_queue_publish_production(comp_queue, 1);
-}
-
-void fs_op_reply_success(uint64_t cmd_id, fs_cmpl_data_t result) {
-    fs_queue_reply((fs_cmpl_t){ 
-        .id = cmd_id,
-        .status = FS_STATUS_SUCCESS,
-        .data = result
-    });
-}
-
-void fs_op_reply_failure(uint64_t cmd_id, uint64_t status, fs_cmpl_data_t result) {
-    fs_queue_reply((fs_cmpl_t){ 
-        .id = cmd_id,
-        .status = status,
-        .data = result
-    });
+    fs_queue_idx_empty(comp_queue, *comp_idx)->cmpl = cmpl;
+    *comp_idx += 1;
 }
 
 void *fs_get_buffer(fs_buffer_t buf) {
@@ -51,7 +80,7 @@ void *fs_get_buffer(fs_buffer_t buf) {
 }
 
 char *fs_malloc_create_path(fs_buffer_t params_path, size_t *path_len) {
-    size_t path_size = strlen(mnt_point) + params_path.size + 2; // extra slash and terminator
+    size_t path_size = mnt_point_len + params_path.size + 2; // extra slash and terminator
 
     char *path = malloc(path_size);
     if (!path) {
@@ -67,8 +96,16 @@ char *fs_malloc_create_path(fs_buffer_t params_path, size_t *path_len) {
 }
 
 void fs_memcpy(char *dest, const char *src, size_t n) {
-    for (size_t i = 0; i < n; i++) {
-        dest[i] = src[i];
+    size_t n_64bytes_chunks = n / 8;
+
+    for (size_t i = 0; i < n_64bytes_chunks; i++) {
+        ((uint64_t *) dest)[i] = ((uint64_t *) src)[i];
+    }
+
+    size_t remainder = n % 8;
+    size_t begin_byte = n_64bytes_chunks * 8;
+    for (size_t i = 0; i < remainder; i++) {
+        dest[begin_byte + i] = src[begin_byte + i];
     }
 }
 

--- a/tools/linux/uio_drivers/fs/util.c
+++ b/tools/linux/uio_drivers/fs/util.c
@@ -4,13 +4,105 @@
  */
 
 #include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <linux/limits.h>
 
 #include <lions/fs/protocol.h>
+#include <uio/fs.h>
 
+#include "log.h"
+
+extern char mnt_point[PATH_MAX];
 extern struct fs_queue *comp_queue;
+extern char *fs_data;
 
 void fs_queue_reply(fs_cmpl_t cmpl) {
     assert(fs_queue_length_producer(comp_queue) != FS_QUEUE_CAPACITY);
     fs_queue_idx_empty(comp_queue, 0)->cmpl = cmpl;
     fs_queue_publish_production(comp_queue, 1);
+}
+
+void fs_op_reply_success(uint64_t cmd_id, fs_cmpl_data_t result) {
+    fs_queue_reply((fs_cmpl_t){ 
+        .id = cmd_id,
+        .status = FS_STATUS_SUCCESS,
+        .data = result
+    });
+}
+
+void fs_op_reply_failure(uint64_t cmd_id, uint64_t status, fs_cmpl_data_t result) {
+    fs_queue_reply((fs_cmpl_t){ 
+        .id = cmd_id,
+        .status = status,
+        .data = result
+    });
+}
+
+void *fs_get_buffer(fs_buffer_t buf) {
+    if (buf.offset >= UIO_LENGTH_FS_DATA
+        || buf.size > UIO_LENGTH_FS_DATA - buf.offset
+        || buf.size == 0) {
+        return NULL;
+    }
+    return (void *)(fs_data + buf.offset);
+}
+
+char *fs_malloc_create_path(fs_buffer_t params_path, size_t *path_len) {
+    size_t path_size = strlen(mnt_point) + params_path.size + 2; // extra slash and terminator
+
+    char *path = malloc(path_size);
+    if (!path) {
+        return NULL;
+    }
+
+    strcpy(path, mnt_point);
+    strcat(path, "/");
+    strncat(path, fs_get_buffer(params_path), params_path.size);
+
+    *path_len = path_size;
+    return path;
+}
+
+void fs_memcpy(char *dest, const char *src, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        dest[i] = src[i];
+    }
+}
+
+uint64_t errno_to_lions_status(int err_num) {
+    switch (errno) {
+        case ENOENT: {
+            return FS_STATUS_INVALID_PATH;
+        }
+        case EACCES: {
+            return FS_STATUS_SERVER_WAS_DENIED;
+        }
+        case EBADF: {
+            return FS_STATUS_INVALID_FD;
+        }
+        case EFAULT: {
+            return FS_STATUS_INVALID_BUFFER;
+        }
+        case EMFILE:
+        case ENFILE: {
+            return FS_STATUS_TOO_MANY_OPEN_FILES;
+        }
+        case ENOMEM: {
+            return FS_STATUS_ALLOCATION_ERROR;
+        }
+        case EOVERFLOW:
+        case ENAMETOOLONG: {
+            return FS_STATUS_INVALID_NAME;
+        }
+        case ENOSPC: {
+            return FS_STATUS_DIRECTORY_IS_FULL;
+        }
+        case EBUSY: {
+            return FS_STATUS_OUTSTANDING_OPERATIONS;
+        }
+        default:
+            return FS_STATUS_ERROR;
+    }
 }

--- a/tools/linux/uio_drivers/fs/util.h
+++ b/tools/linux/uio_drivers/fs/util.h
@@ -5,6 +5,25 @@
 
 #pragma once
 
+#include <stdlib.h>
+
 #include <lions/fs/protocol.h>
 
+/* Enqueue a reply into the completion queue */
 void fs_queue_reply(fs_cmpl_t cmpl);
+/* Thin wrappers for the above */
+void fs_op_reply_success(uint64_t cmd_id, fs_cmpl_data_t result);
+void fs_op_reply_failure(uint64_t cmd_id, uint64_t status, fs_cmpl_data_t result);
+
+/* Convert a fs_buffer_t into our vaddr */
+void *fs_get_buffer(fs_buffer_t buf);
+/* Copy the path from client then concat it with the mount point. 
+   If the call succeeds, the path's total length will be written to *path_len.
+   *** Returns a buffer from malloc. *** */
+char *fs_malloc_create_path(fs_buffer_t path, size_t *path_len);
+
+/* Byte-by-byte memcpy as the string.h's memcpy is not compatible with UIO mappings */
+void fs_memcpy(char *dest, const char *src, size_t n);
+
+/* Converts the errno into LionsOS' equivalent status. */
+uint64_t errno_to_lions_status(int err_num);

--- a/tools/linux/uio_drivers/fs/util.h
+++ b/tools/linux/uio_drivers/fs/util.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <lions/fs/protocol.h>
+
+void fs_queue_reply(fs_cmpl_t cmpl);


### PR DESCRIPTION
This PR adds:
- Filesystem UIO driver to libvmm to allow creation of Filesystem VMs. Allowing native clients to use any filesystems supported by Linux streamed in from a native block device driver.
- A dependancy to `liburing`.

The basic idea is:
- The client filesystem command queue, completion queue and data region are mapped into the guest's userspace via UIO.
- Then, the Filesystem UIO driver dequeues all the commands and map it into the corresponding Linux FS calls.
- Via `io_uring`, the driver will enqueue all the Linux FS calls into `io_uring`'s submission queue and signal the kernel. `io_uring` was used to improve performance by allowing us to perform multiple I/O operations with only 1 syscall.
- The driver will wait for all SQEs (Submission Queue Entry) to complete. Then for each CQE (Completion Queue Entry), a callback is invoked to enqueue the completion message to the native client's completion queue.
- The driver finally faults on a pre-determined physical address for the VMM to signal the native FS client.

Note:
1. Not all FS calls go through `io_uring`. This includes:
    - Mount/unmount.
    - Truncate.
    - Directory calls (`FS_CMD_DIR_*`)
For these calls, the driver will "flush" the `io_uring` submission queue, wait for the flushed operations to finish and invoke the required operation. Acting as a barrier to ensure correctness in mixing synchonrous and asynchronous operations.