### PR TITLE
README: Mention about git submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ nix-shell
 
 ### Building and running
 
+First, initialize the repository:
+
+```sh
+git clone https://github.com/au-ts/libvmm
+cd libvmm
+git submodule update --init
+```
+
 Finally, we can simulate a basic system with a single Linux guest with the
 following commands:
 ```sh


### PR DESCRIPTION
Before libvmm can be built, the git submodule for sddf must be initialized first, this PR mentions about it in the README.

Most people using this repository probably know enough about git submodule to do it when make fail in the first run but I think it's still a good idea to document it.