### PR TITLE
Update Zig usage to 0.14.0-dev.3011+e4c049e41

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v1.2.0
         with:
-          version: 0.13.0
+          version: master
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Build and run examples
@@ -78,7 +78,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v1.2.0
         with:
-          version: 0.13.0
+          version: master
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - name: Build and run examples

--- a/examples/simple/build.zig
+++ b/examples/simple/build.zig
@@ -142,7 +142,7 @@ pub fn build(b: *std.Build) void {
     // point (`main()`), which runs the main handler loop.
     exe.addObjectFile(.{ .cwd_relative = libmicrokit });
     // Specify the linker script, this is necessary to set the ELF entry point address.
-    exe.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+    exe.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
 
     // Link the libvmm library, this will automatically add the libvmm headers as well.
     exe.linkLibrary(libvmm);

--- a/examples/zig/build.zig
+++ b/examples/zig/build.zig
@@ -93,7 +93,7 @@ pub fn build(b: *std.Build) void {
     exe.addObjectFile(.{ .cwd_relative = libmicrokit });
     exe.addObject(zig_libmicrokit);
     // Specify the linker script, this is necessary to set the ELF entry point address.
-    exe.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+    exe.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
 
     exe.linkLibrary(libvmm);
 


### PR DESCRIPTION
There will be a new release of Zig within a couple of weeks which we can pin to. Until then, need to pin to a pre-release.