### PR TITLE
vmm.mk: add create modifier to ar flags

### DIFF
--- a/vmm.mk
+++ b/vmm.mk
@@ -74,7 +74,7 @@ libvmm/arch/aarch64/vgic:
 	mkdir -p libvmm/virtio
 
 libvmm.a: ${OBJECTS}
-	${AR} rv $@ $^
+	${AR} crv $@ $^
 
 ${OBJECTS}: ${SDDF}/include
 ${OBJECTS}: ${CHECK_LIBVMM_CFLAGS} |libvmm/arch/aarch64/vgic


### PR DESCRIPTION
This hides a warning about creating files that ar produces.

Cross reference: https://github.com/au-ts/sddf/pull/227