### PR TITLE
Add support for multiple vCPUs

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -142,6 +142,15 @@ region for the GIC into the guest.
 
 The rest of the GIC is virtualised in the vGIC driver in libvmm.
 
+## Multiple vCPUs
+
+There is support for multiple vCPUs (up to 16) on ARM.
+
+To change the number of vCPUs supported, override the value of `GUEST_NUM_VCPUS`
+when compiling libvmm.
+
+libvmm expects the vCPU IDs to be consecutive, with zero being the boot vCPU ID.
+
 # Passthrough
 
 This section describes what is generally referred to as "passthrough". Passthrough

--- a/examples/simple/vmm.c
+++ b/examples/simple/vmm.c
@@ -59,7 +59,8 @@ extern char _guest_initrd_image_end[];
 /* Microkit will set this variable to the start of the guest RAM memory region. */
 uintptr_t guest_ram_vaddr;
 
-static void serial_ack(size_t vcpu_id, int irq, void *cookie) {
+static void serial_ack(size_t vcpu_id, int irq, void *cookie)
+{
     /*
      * For now we by default simply ack the serial IRQ, we have not
      * come across a case yet where more than this needs to be done.
@@ -67,51 +68,46 @@ static void serial_ack(size_t vcpu_id, int irq, void *cookie) {
     microkit_irq_ack(SERIAL_IRQ_CH);
 }
 
-void init(void) {
+void init(void)
+{
     /* Initialise the VMM, the VCPU(s), and start the guest */
     LOG_VMM("starting \"%s\"\n", microkit_name);
     /* Place all the binaries in the right locations before starting the guest */
     size_t kernel_size = _guest_kernel_image_end - _guest_kernel_image;
     size_t dtb_size = _guest_dtb_image_end - _guest_dtb_image;
     size_t initrd_size = _guest_initrd_image_end - _guest_initrd_image;
-    uintptr_t kernel_pc = linux_setup_images(guest_ram_vaddr,
-                                      (uintptr_t) _guest_kernel_image,
-                                      kernel_size,
-                                      (uintptr_t) _guest_dtb_image,
-                                      GUEST_DTB_VADDR,
-                                      dtb_size,
-                                      (uintptr_t) _guest_initrd_image,
-                                      GUEST_INIT_RAM_DISK_VADDR,
-                                      initrd_size
-                                      );
+    uintptr_t kernel_pc = linux_setup_images(guest_ram_vaddr, (uintptr_t)_guest_kernel_image, kernel_size,
+                                             (uintptr_t)_guest_dtb_image, GUEST_DTB_VADDR, dtb_size,
+                                             (uintptr_t)_guest_initrd_image, GUEST_INIT_RAM_DISK_VADDR, initrd_size);
     if (!kernel_pc) {
         LOG_VMM_ERR("Failed to initialise guest images\n");
         return;
     }
     /* Initialise the virtual GIC driver */
-    bool success = virq_controller_init(GUEST_VCPU_ID);
+    bool success = virq_controller_init();
     if (!success) {
         LOG_VMM_ERR("Failed to initialise emulated interrupt controller\n");
         return;
     }
-    success = virq_register(GUEST_VCPU_ID, SERIAL_IRQ, &serial_ack, NULL);
+    success = virq_register(GUEST_BOOT_VCPU_ID, SERIAL_IRQ, &serial_ack, NULL);
     /* Just in case there is already an interrupt available to handle, we ack it here. */
     microkit_irq_ack(SERIAL_IRQ_CH);
     /* Finally start the guest */
-    guest_start(GUEST_VCPU_ID, kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
+    guest_start(kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
 }
 
-void notified(microkit_channel ch) {
+void notified(microkit_channel ch)
+{
     switch (ch) {
-        case SERIAL_IRQ_CH: {
-            bool success = virq_inject(GUEST_VCPU_ID, SERIAL_IRQ);
-            if (!success) {
-                LOG_VMM_ERR("IRQ %d dropped on vCPU %d\n", SERIAL_IRQ, GUEST_VCPU_ID);
-            }
-            break;
+    case SERIAL_IRQ_CH: {
+        bool success = virq_inject(SERIAL_IRQ);
+        if (!success) {
+            LOG_VMM_ERR("IRQ %d dropped\n", SERIAL_IRQ);
         }
-        default:
-            printf("Unexpected channel, ch: 0x%lx\n", ch);
+        break;
+    }
+    default:
+        printf("Unexpected channel, ch: 0x%lx\n", ch);
     }
 }
 
@@ -120,7 +116,8 @@ void notified(microkit_channel ch) {
  * Whenever our guest causes an exception, it gets delivered to this entry point for
  * the VMM to handle.
  */
-seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo) {
+seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo)
+{
     bool success = fault_handle(child, msginfo);
     if (success) {
         /* Now that we have handled the fault successfully, we reply to it so

--- a/examples/virtio-snd/client_vmm.c
+++ b/examples/virtio-snd/client_vmm.c
@@ -72,30 +72,24 @@ static struct virtio_snd_device virtio_sound;
 
 uintptr_t kernel_pc = 0;
 
-void init(void) {
+void init(void)
+{
     /* Initialise the VMM, the VCPU(s), and start the guest */
     LOG_VMM("starting \"%s\"\n", microkit_name);
     /* Place all the binaries in the right locations before starting the guest */
     size_t kernel_size = _guest_kernel_image_end - _guest_kernel_image;
     size_t dtb_size = _guest_dtb_image_end - _guest_dtb_image;
     size_t initrd_size = _guest_initrd_image_end - _guest_initrd_image;
-    kernel_pc = linux_setup_images(guest_ram_vaddr,
-                                      (uintptr_t) _guest_kernel_image,
-                                      kernel_size,
-                                      (uintptr_t) _guest_dtb_image,
-                                      GUEST_DTB_VADDR,
-                                      dtb_size,
-                                      (uintptr_t) _guest_initrd_image,
-                                      GUEST_INIT_RAM_DISK_VADDR,
-                                      initrd_size
-                                      );
+    kernel_pc = linux_setup_images(guest_ram_vaddr, (uintptr_t)_guest_kernel_image, kernel_size,
+                                   (uintptr_t)_guest_dtb_image, GUEST_DTB_VADDR, dtb_size,
+                                   (uintptr_t)_guest_initrd_image, GUEST_INIT_RAM_DISK_VADDR, initrd_size);
     if (!kernel_pc) {
         LOG_VMM_ERR("Failed to initialise guest images\n");
         return;
     }
 
     /* Initialise the virtual GIC driver */
-    bool success = virq_controller_init(GUEST_VCPU_ID);
+    bool success = virq_controller_init();
     if (!success) {
         LOG_VMM_ERR("Failed to initialise emulated interrupt controller\n");
         return;
@@ -103,15 +97,12 @@ void init(void) {
 
     /* Initialise our sDDF ring buffers for the serial device */
     serial_queue_handle_t serial_rxq, serial_txq;
-    serial_cli_queue_init_sys(microkit_name, &serial_rxq, serial_rx_queue, serial_rx_data, &serial_txq, serial_tx_queue, serial_tx_data);
+    serial_cli_queue_init_sys(microkit_name, &serial_rxq, serial_rx_queue, serial_rx_data, &serial_txq, serial_tx_queue,
+                              serial_tx_data);
 
     /* Initialise virtIO console device */
-    success = virtio_mmio_console_init(&virtio_console,
-                                  VIRTIO_CONSOLE_BASE,
-                                  VIRTIO_CONSOLE_SIZE,
-                                  VIRTIO_CONSOLE_IRQ,
-                                  &serial_rxq, &serial_txq,
-                                  SERIAL_VIRT_TX_CH);
+    success = virtio_mmio_console_init(&virtio_console, VIRTIO_CONSOLE_BASE, VIRTIO_CONSOLE_SIZE, VIRTIO_CONSOLE_IRQ,
+                                       &serial_rxq, &serial_txq, SERIAL_VIRT_TX_CH);
     assert(success);
 
     assert(sound_cmd_req);
@@ -137,38 +128,34 @@ void init(void) {
 
     while (!ATOMIC_LOAD(&shared_state->ready, __ATOMIC_ACQUIRE));
 
-    success = virtio_mmio_snd_init(&virtio_sound,
-                              VIRTIO_SOUND_BASE,
-                              VIRTIO_SOUND_SIZE,
-                              VIRTIO_SOUND_IRQ,
-                              shared_state,
-                              &sound_queues,
-                              sound_data,
-                              SOUND_DRIVER_CH);
+    success = virtio_mmio_snd_init(&virtio_sound, VIRTIO_SOUND_BASE, VIRTIO_SOUND_SIZE, VIRTIO_SOUND_IRQ, shared_state,
+                                   &sound_queues, sound_data, SOUND_DRIVER_CH);
     assert(success);
 
-    success = guest_start(GUEST_VCPU_ID, kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
+    success = guest_start(GUEST_BOOT_VCPU_ID, kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
     assert(success);
 }
 
-void notified(microkit_channel ch) {
+void notified(microkit_channel ch)
+{
     switch (ch) {
-        case SERIAL_VIRT_RX_CH: {
-            /* We have received an event from the serial virtualiser, so we
-             * call the virtIO console handling */
-            virtio_console_handle_rx(&virtio_console);
-            break;
-        }
-        case SOUND_DRIVER_CH: {
-            virtio_snd_notified(&virtio_sound);
-            break;
-        }
-        default:
-            printf("Unexpected channel, ch: 0x%lx\n", ch);
+    case SERIAL_VIRT_RX_CH: {
+        /* We have received an event from the serial virtualiser, so we
+         * call the virtIO console handling */
+        virtio_console_handle_rx(&virtio_console);
+        break;
+    }
+    case SOUND_DRIVER_CH: {
+        virtio_snd_notified(&virtio_sound);
+        break;
+    }
+    default:
+        printf("Unexpected channel, ch: 0x%lx\n", ch);
     }
 }
 
-seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo) {
+seL4_Bool fault(microkit_child child, microkit_msginfo msginfo, microkit_msginfo *reply_msginfo)
+{
     bool success = fault_handle(child, msginfo);
     if (success) {
         /* Now that we have handled the fault successfully, we reply to it so

--- a/examples/virtio/client_vmm.c
+++ b/examples/virtio/client_vmm.c
@@ -93,7 +93,7 @@ void init(void)
     }
 
     /* Initialise the virtual GIC driver */
-    bool success = virq_controller_init(GUEST_VCPU_ID);
+    bool success = virq_controller_init();
     if (!success) {
         LOG_VMM_ERR("Failed to initialise emulated interrupt controller\n");
         return;
@@ -161,7 +161,7 @@ void init(void)
     assert(success);
 
     /* Finally start the guest */
-    guest_start(GUEST_VCPU_ID, kernel_pc, vmm_config.dtb, vmm_config.initrd);
+    guest_start(kernel_pc, vmm_config.dtb, vmm_config.initrd);
     LOG_VMM("%s is ready\n", microkit_name);
 }
 

--- a/examples/virtio_pci/client_vmm.c
+++ b/examples/virtio_pci/client_vmm.c
@@ -90,7 +90,7 @@ void init(void)
     }
 
     /* Initialise the virtual GIC driver */
-    bool success = virq_controller_init(GUEST_VCPU_ID);
+    bool success = virq_controller_init();
     if (!success) {
         LOG_VMM_ERR("Failed to initialise emulated interrupt controller\n");
         return;
@@ -126,7 +126,7 @@ void init(void)
     assert(success);
 
     /* Finally start the guest */
-    guest_start(GUEST_VCPU_ID, kernel_pc, vmm_config.dtb, vmm_config.initrd);
+    guest_start(kernel_pc, vmm_config.dtb, vmm_config.initrd);
     LOG_VMM("%s is ready\n", microkit_name);
 }
 

--- a/examples/zig/src/vmm.zig
+++ b/examples/zig/src/vmm.zig
@@ -111,7 +111,7 @@ export fn init() callconv(.c) void {
         return;
     }
     // Initialise the virtual interrupt controller
-    if (!c.virq_controller_init(GUEST_BOOT_VCPU_ID)) {
+    if (!c.virq_controller_init()) {
         log.err("Failed to initialise virtual interrupt controller\n", .{});
         return;
     }
@@ -124,7 +124,7 @@ export fn init() callconv(.c) void {
     // handle, we ack it here.
     c.microkit_irq_ack(SERIAL_IRQ_CH);
     // Finally we can start the guest
-    if (!c.guest_start(GUEST_BOOT_VCPU_ID, kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR)) {
+    if (!c.guest_start(kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR)) {
         log.err("Failed to start guest\n", .{});
         return;
     }
@@ -133,9 +133,9 @@ export fn init() callconv(.c) void {
 export fn notified(ch: c.microkit_channel) callconv(.c) void {
     switch (ch) {
         SERIAL_IRQ_CH => {
-            const success = c.virq_inject(GUEST_BOOT_VCPU_ID, SERIAL_IRQ);
+            const success = c.virq_inject(SERIAL_IRQ);
             if (!success) {
-                log.err("IRQ {x} dropped on vCPU {x}\n", .{ SERIAL_IRQ, GUEST_BOOT_VCPU_ID });
+                log.err("IRQ {x} dropped\n", .{ SERIAL_IRQ });
             }
         },
         else => log.err("Unexpected channel, ch: {x}\n", .{ ch })

--- a/include/libvmm/arch/aarch64/cpuif.h
+++ b/include/libvmm/arch/aarch64/cpuif.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <libvmm/util/util.h>
+
+typedef bool (*sysreg_access_fn_t)(size_t vcpu_id, seL4_UserContext *regs, bool is_read);
+typedef bool (*sysreg_read_exception_handler_t)(size_t vcpu_id, seL4_UserContext *regs);
+typedef bool (*sysreg_write_exception_handler_t)(size_t vcpu_id, seL4_UserContext *regs, uint64_t data);
+
+/* Handles exception from MSR, MRS, or System instruction execution in AArch64 state (EC class 0x18). */
+bool handle_sysreg_64_fault(size_t vcpu_id, uint64_t hsr, seL4_UserContext *regs);

--- a/include/libvmm/arch/aarch64/fault.h
+++ b/include/libvmm/arch/aarch64/fault.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, UNSW (ABN 57 195 873 179)
+ * Copyright 2025, UNSW (ABN 57 195 873 179)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,6 +24,7 @@ typedef bool (*vm_exception_handler_t)(size_t vcpu_id, size_t offset, size_t fsr
 bool fault_register_vm_exception_handler(uintptr_t base, size_t size, vm_exception_handler_t callback, void *data);
 
 /* Helpers for emulating the fault and getting fault details */
+seL4_Word *decode_rt(size_t reg_idx, seL4_UserContext *regs);
 bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs);
 bool fault_advance(size_t vcpu_id, seL4_UserContext *regs, uint64_t addr, uint64_t fsr, uint64_t reg_val);
 uint64_t fault_get_data_mask(uint64_t addr, uint64_t fsr);

--- a/include/libvmm/arch/aarch64/psci.h
+++ b/include/libvmm/arch/aarch64/psci.h
@@ -44,4 +44,4 @@ typedef enum psci {
  * Issue E (PSCI version 1.2)
  */
 
-bool handle_psci(size_t vcpu_id, seL4_UserContext *regs,  uint64_t fn_number, uint32_t hsr);
+bool handle_psci(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number, uint64_t hsr);

--- a/include/libvmm/arch/aarch64/smc.h
+++ b/include/libvmm/arch/aarch64/smc.h
@@ -13,7 +13,7 @@
 #include <microkit.h>
 
 /* SMC vCPU fault handler */
-bool smc_handle(size_t vcpu_id, uint32_t hsr);
+bool smc_handle(size_t vcpu_id, uint64_t hsr);
 
 /*
  * A custom handler for SMC SiP calls can be registered.

--- a/include/libvmm/arch/aarch64/vgic/vgic.h
+++ b/include/libvmm/arch/aarch64/vgic/vgic.h
@@ -30,8 +30,9 @@
 #if defined(GIC_V2)
 #define GIC_DIST_SIZE 0x1000
 #elif defined(GIC_V3)
-#define GIC_DIST_SIZE       0x10000
-#define GIC_REDIST_SIZE     0xc0000
+#define GIC_DIST_SIZE                0x10000
+#define GIC_REDIST_INDIVIDUAL_SIZE   0x20000
+#define GIC_REDIST_TOTAL_SIZE        (GIC_REDIST_INDIVIDUAL_SIZE * GUEST_NUM_VCPUS)
 #else
 #error Unknown GIC version
 #endif
@@ -52,9 +53,15 @@
 #define LOG_DIST(...) do{}while(0)
 #endif
 
+#define IRQ_IDX(irq) ((irq) / 32)
+#define IRQ_BIT(irq) (1U << ((irq) % 32))
+
 void vgic_init();
-bool fault_handle_vgic_maintenance(size_t vcpu_id);
-bool handle_vgic_dist_fault(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data);
-bool handle_vgic_redist_fault(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data);
+
+bool vgic_handle_fault_maintenance(size_t vcpu_id);
+
+bool vgic_handle_fault_dist(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data);
+bool vgic_handle_fault_redist(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data);
+
 bool vgic_register_irq(size_t vcpu_id, int virq_num, virq_ack_fn_t ack_fn, void *ack_data);
 bool vgic_inject_irq(size_t vcpu_id, int irq);

--- a/include/libvmm/arch/aarch64/vgic/vgic_v2.h
+++ b/include/libvmm/arch/aarch64/vgic/vgic_v2.h
@@ -156,3 +156,14 @@ static inline void vgic_dist_disable(struct gic_dist_map *gic_dist)
 {
     gic_dist->ctlr = 0;
 }
+
+static inline void set_sgi_ppi_pending(struct gic_dist_map *gic_dist, int irq, bool set_pending, int vcpu_id)
+{
+    if (set_pending) {
+        gic_dist->pending_set0[vcpu_id] |= IRQ_BIT(irq);
+        gic_dist->pending_clr0[vcpu_id] |= IRQ_BIT(irq);
+    } else {
+        gic_dist->pending_set0[vcpu_id] &= ~IRQ_BIT(irq);
+        gic_dist->pending_clr0[vcpu_id] &= ~IRQ_BIT(irq);
+    }
+}

--- a/include/libvmm/arch/aarch64/vgic/vgic_v3.h
+++ b/include/libvmm/arch/aarch64/vgic/vgic_v3.h
@@ -1,9 +1,12 @@
 /*
  * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2019, DornerWorks
+ * Copyright 2025, UNSW (ABN 57 195 873 179)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
+
+#pragma once
 
 #define GIC_500_GRP0     (1 << 0)
 #define GIC_500_GRP1_NS  (1 << 1)
@@ -84,22 +87,22 @@ struct gic_redist_map {          /* Starting */
 };
 
 /* Memory map for the GIC Redistributor Registers for the SGI and PPI's */
-// struct gic_redist_sgi_ppi_map {  /* Starting */
-//     uint32_t    igroup[32];     /* 0x0080 */
-//     uint32_t    isenable[32];   /* 0x0100 */
-//     uint32_t    icenable[32];   /* 0x0180 */
-//     uint32_t    ispend[32];     /* 0x0200 */
-//     uint32_t    icpend[32];     /* 0x0280 */
-//     uint32_t    isactive[32];   /* 0x0300 */
-//     uint32_t    icactive[32];   /* 0x0380 */
-//     uint32_t    ipriorityrn[8]; /* 0x0400 */
-//     uint32_t    icfgrn_ro;      /* 0x0C00 */
-//     uint32_t    icfgrn_rw;      /* 0x0C04 */
-//     uint32_t    igrpmod[64];    /* 0x0D00 */
-//     uint32_t    nsac;           /* 0x0E00 */
-//     uint32_t    miscstatsr;     /* 0xC000 */
-//     uint32_t    ppisr;          /* 0xC080 */
-// };
+struct gic_redist_sgi_ppi_map {  /* Starting */
+    uint32_t igroupr0;       /* 0x0080 */
+    uint32_t isenable;       /* 0x0100 */
+    // uint32_t    icenabler0;     /* 0x0180 */
+    uint32_t ispend;         /* 0x0200 */
+    // uint32_t    icpend;         /* 0x0280 */
+    uint32_t isactive;       /* 0x0300 */
+    // uint32_t    icactiver0;     /* 0x0380 */
+    uint32_t ipriorityrn[8]; /* 0x0400 */
+    // uint32_t    icfgrn_ro;      /* 0x0C00 */
+    uint32_t icfgrn_rw;      /* 0x0C04 */
+    // uint32_t    igrpmod[64];    /* 0x0D00 */
+    // uint32_t    nsac;           /* 0x0E00 */
+    // uint32_t    miscstatsr;     /* 0xC000 */
+    // uint32_t    ppisr;          /* 0xC080 */
+};
 
 /*
  * GIC Distributor Register Map
@@ -178,6 +181,7 @@ struct gic_redist_map {          /* Starting */
 #define GICR_IIDR           0x004
 #define GICR_TYPER          0x008
 #define GICR_WAKER          0x014
+#define GICR_PIDR2          0xffe8
 
 #define GICR_IGROUPR0       0x10080
 #define GICR_ISENABLER0     0x10100
@@ -191,9 +195,9 @@ typedef struct {
     /// Virtual distributor registers
     struct gic_dist_map *dist;
     /// Virtual redistributor registers for control and physical LPIs
-    struct gic_redist_map *redist;
+    struct gic_redist_map *redist[GUEST_NUM_VCPUS];
     /// Virtual redistributor for SGI and PPIs
-    // struct gic_redist_sgi_ppi_map *sgi;
+    struct gic_redist_sgi_ppi_map *sgi[GUEST_NUM_VCPUS];
 } vgic_reg_t;
 
 static inline bool vgic_dist_is_enabled(struct gic_dist_map *gic_dist)
@@ -203,12 +207,13 @@ static inline bool vgic_dist_is_enabled(struct gic_dist_map *gic_dist)
 
 static inline void vgic_dist_enable(struct gic_dist_map *gic_dist)
 {
-    gic_dist->ctlr |= GIC_500_GRP1_NS | GIC_500_ARE_S;
+    /* Enable group 1 non-secure IRQs. */
+    gic_dist->ctlr |= GIC_500_GRP1_NS;
 }
 
 static inline void vgic_dist_disable(struct gic_dist_map *gic_dist)
 {
-    gic_dist->ctlr &= ~(GIC_500_GRP1_NS | GIC_500_ARE_S);
+    gic_dist->ctlr &= ~(GIC_500_GRP1_NS);
 }
 
 static inline struct gic_dist_map *vgic_get_dist(void *registers)
@@ -217,9 +222,56 @@ static inline struct gic_dist_map *vgic_get_dist(void *registers)
     return ((vgic_reg_t *) registers)->dist;
 }
 
-static inline struct gic_redist_map *vgic_get_redist(void *registers)
+static inline struct gic_redist_map *vgic_get_redist(void *registers, size_t vcpu_id)
 {
     assert(registers);
-    return ((vgic_reg_t *) registers)->redist;
+    return ((vgic_reg_t *)registers)->redist[vcpu_id];
 }
 
+static inline struct gic_redist_sgi_ppi_map *vgic_get_redist_sgi_ppi(void *registers, size_t vcpu_id)
+{
+    assert(registers);
+    return ((vgic_reg_t *)registers)->sgi[vcpu_id];
+}
+
+static inline bool is_sgi_ppi_enabled_v3(struct gic_redist_sgi_ppi_map *sgi, int irq)
+{
+    return (sgi->isenable & IRQ_BIT(irq));
+}
+
+static inline void set_sgi_ppi_enable_v3(struct gic_redist_sgi_ppi_map *sgi, int irq, bool set_enable)
+{
+    if (set_enable) {
+        sgi->isenable |= IRQ_BIT(irq);
+    } else {
+        sgi->isenable &= ~IRQ_BIT(irq);
+    }
+}
+
+static inline bool is_sgi_ppi_pending_v3(struct gic_redist_sgi_ppi_map *sgi, int irq)
+{
+    return !!(sgi->ispend & IRQ_BIT(irq));
+}
+
+static inline void set_sgi_ppi_pending_v3(struct gic_redist_sgi_ppi_map *sgi, int irq, bool set_pending)
+{
+    if (set_pending) {
+        sgi->ispend |= IRQ_BIT(irq);
+    } else {
+        sgi->ispend &= ~IRQ_BIT(irq);
+    }
+}
+
+static inline bool is_sgi_ppi_active_v3(struct gic_redist_sgi_ppi_map *sgi, int irq)
+{
+    return !!(sgi->isactive & IRQ_BIT(irq));
+}
+
+static inline void set_sgi_ppi_active_v3(struct gic_redist_sgi_ppi_map *sgi, int irq, bool set_active)
+{
+    if (set_active) {
+        sgi->isactive |= IRQ_BIT(irq);
+    } else {
+        sgi->isactive &= ~IRQ_BIT(irq);
+    }
+}

--- a/include/libvmm/arch/aarch64/vgic/vgic_v3_cpuif.h
+++ b/include/libvmm/arch/aarch64/vgic/vgic_v3_cpuif.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <libvmm/util/util.h>
+#include <libvmm/arch/aarch64/cpuif.h>
+
+bool icc_sgi1r_el1_access(size_t vcpu_id, seL4_UserContext *regs, bool is_read);
+bool icc_sgi1r_el1_write(size_t vcpu_id, seL4_UserContext *regs, uint64_t data);

--- a/include/libvmm/arch/aarch64/vgic/virq.h
+++ b/include/libvmm/arch/aarch64/vgic/virq.h
@@ -206,7 +206,13 @@ static inline bool vgic_vcpu_load_list_reg(vgic_t *vgic, size_t vcpu_id, int idx
     vgic_vcpu_t *vgic_vcpu = get_vgic_vcpu(vgic, vcpu_id);
     assert(vgic_vcpu);
     assert((idx >= 0) && (idx < ARRAY_SIZE(vgic_vcpu->lr_shadow)));
-    // @ivanv: why is the priority 0?
+    // TODO: we always set the priority to zero, but the guest tells us the priority so we should be
+    // respecting that instead.
+
+#if defined(GIC_V3)
+    assert(group == 1);
+#endif
+
     microkit_vcpu_arm_inject_irq(vcpu_id, virq->virq, 0, group, idx);
     vgic_vcpu->lr_shadow[idx] = *virq;
 

--- a/include/libvmm/arch/aarch64/vgic/virq.h
+++ b/include/libvmm/arch/aarch64/vgic/virq.h
@@ -24,10 +24,21 @@
 #define NUM_VCPU_LOCAL_VIRQS    (NUM_SGI_VIRQS + NUM_PPI_VIRQS)
 
 /* Usually, VMs do not use all SPIs. To reduce the memory footprint, our vGIC
- * implementation manages the SPIs in a fixed size slot list. 200 entries have
- * been good trade-off that is sufficient for most systems.
+ * implementation manages the SPIs in a fixed size slot list. 128 entries has
+ * been a good trade-off that is sufficient for most systems.
+ * For the encoding of ITLinesNumber, it is optimal for this to be a power of two.
  */
-#define NUM_SLOTS_SPI_VIRQ      200
+#define NUM_SLOTS_SPI_VIRQ      128
+
+#define NUM_VIRQS               (NUM_VCPU_LOCAL_VIRQS + NUM_SLOTS_SPI_VIRQ)
+/*
+ * The GIC specification describes ITLinesNumber=N where the maximum number
+ * of interrupts is 32(N+1).
+ * Arm IHI 0069H.b  ID041224  12-621
+ */
+#define ITLINES                 ((NUM_VIRQS / 32) - 1)
+
+_Static_assert(ITLINES < 32, "Maximum ITLinesNumber value is 32 (0b11111)");
 
 #define VIRQ_INVALID -1
 

--- a/include/libvmm/guest.h
+++ b/include/libvmm/guest.h
@@ -7,9 +7,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define GUEST_VCPU_ID 0
-#define GUEST_NUM_VCPUS 1
+#define GUEST_BOOT_VCPU_ID 0
 
-bool guest_start(size_t boot_vcpu_id, uintptr_t kernel_pc, uintptr_t dtb, uintptr_t initrd);
-void guest_stop(size_t boot_vcpu_id);
-bool guest_restart(size_t boot_vcpu_id, uintptr_t guest_ram_vaddr, size_t guest_ram_size);
+#ifndef GUEST_NUM_VCPUS
+#define GUEST_NUM_VCPUS 1
+#endif
+
+bool guest_start(uintptr_t kernel_pc, uintptr_t dtb, uintptr_t initrd);
+void guest_stop();
+bool guest_restart(uintptr_t guest_ram_vaddr, size_t guest_ram_size);

--- a/include/libvmm/vcpu.h
+++ b/include/libvmm/vcpu.h
@@ -6,7 +6,22 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
+
+/*
+ * Checks whether the given vCPU is on.
+ *
+ * Returns true if the vCPU is on, otherwise false.
+ * Returns false if an invalid vCPU ID is given.
+ */
+bool vcpu_is_on(size_t vcpu_id);
+
+/*
+ * Change the state tracking for whether a given vCPU is on.
+ * Does nothing if an invalid vCPU ID is given.
+ */
+void vcpu_set_on(size_t vcpu_id, bool on);
 
 void vcpu_reset(size_t vcpu_id);
 void vcpu_print_regs(size_t vcpu_id);

--- a/include/libvmm/virq.h
+++ b/include/libvmm/virq.h
@@ -14,9 +14,24 @@
 
 typedef void (*virq_ack_fn_t)(size_t vcpu_id, int irq, void *cookie);
 
-bool virq_controller_init(size_t boot_vcpu_id);
+/*
+ * Initialise the architecture-depedent virtual interrupt controller.
+ * On ARM, this is the virtual Generic Interrupt Controller (vGIC).
+ */
+bool virq_controller_init();
 bool virq_register(size_t vcpu_id, size_t virq_num, virq_ack_fn_t ack_fn, void *ack_data);
-bool virq_inject(size_t vcpu_id, int irq);
+
+/*
+ * Inject an IRQ into the boot virtual CPU.
+ * Note that this API requires that the IRQ has been registered (with virq_register).
+ */
+bool virq_inject(int irq);
+
+/*
+ * The same functionality as virq_inject, but will inject the virtual IRQ into a specific
+ * virtual CPU.
+ */
+bool virq_inject_vcpu(size_t vcpu_id, int irq);
 
 /*
  * These two APIs are convenient for when you want to directly passthrough an IRQ from

--- a/src/arch/aarch64/cpuif.c
+++ b/src/arch/aarch64/cpuif.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <libvmm/util/util.h>
+#include <libvmm/arch/aarch64/vgic/vgic.h>
+#include <libvmm/arch/aarch64/cpuif.h>
+#include <libvmm/arch/aarch64/fault.h>
+#include <libvmm/arch/aarch64/vgic/vgic_v3_cpuif.h>
+
+#define ESR_EL2_IL_BIT 25
+
+/* The ISS encoding was taken from "Arm A-profile Architecture Registers" DDI0601,
+   section "ESR_EL2, Exception Syndrome Register (EL2)",
+   heading "ISS encoding for an exception from MSR, MRS, or System instruction execution in AArch64 state" */
+#define ISS_MASK_FROM_HSR      0xffffff
+#define ISS_SYSREG_IS_READ_BIT 0
+#define ISS_SYSREG_CRM_SHIFT   1
+#define ISS_SYSREG_CRM_MASK    0xf
+#define ISS_SYSREG_RT_SHIFT    5
+#define ISS_SYSREG_RT_MASK     0x1f
+#define ISS_SYSREG_CRN_SHIFT   10
+#define ISS_SYSREG_CRN_MASK    0xf
+#define ISS_SYSREG_OP1_SHIFT   14
+#define ISS_SYSREG_OP1_MASK    0x7
+#define ISS_SYSREG_OP2_SHIFT   17
+#define ISS_SYSREG_OP2_MASK    0x7
+#define ISS_SYSREG_OP0_SHIFT   20
+#define ISS_SYSREG_OP0_MASK    0x3
+
+/* Data structure of system registers we currently emulate. */
+typedef struct aarch64_sysreg_info {
+    /* For debugging only. */
+    char *name;
+
+    /* Location of register. */
+    uint8_t crn;
+    uint8_t crm;
+    uint8_t opc0;
+    uint8_t opc1;
+    uint8_t opc2;
+
+    /* Access functions for both direction. NULL if access will be denied. */
+    sysreg_read_exception_handler_t read_fn;
+    sysreg_write_exception_handler_t write_fn;
+} aarch64_sysreg_info_t;
+
+static const aarch64_sysreg_info_t cpuif_reginfo[] = {
+#if defined(GIC_V3)
+    /* The following registers values were taken from:
+       "Arm Generic Interrupt Controller Architecture Specification GIC architecture version 3 and version 4".
+       Document IHI0069H.b ID041224. */
+    {
+        /* Page 12-276 */
+        .name = "ICC_SGI1R_EL1",
+        .opc0 = 3,
+        .opc1 = 0,
+        .crn = 12,
+        .crm = 11,
+        .opc2 = 5,
+        .read_fn = NULL,
+        .write_fn = icc_sgi1r_el1_write,
+    }
+#endif
+};
+
+static int sysreg_fault_get_rt(uint64_t hsr)
+{
+    /* Make sure the instruction length bit == 1 for 32-bits instructions. */
+    if (BIT_LOW(ESR_EL2_IL_BIT)) {
+        return (hsr >> ISS_SYSREG_RT_SHIFT) & ISS_SYSREG_RT_MASK;
+    } else {
+        printf("sysreg_fault_get_rt() for 16-bits instructions not implemented.\n");
+        assert(false);
+    }
+}
+
+/* We can't use `fault_get_data()` because the HSR register encoding is different in this scenario. */
+static uint64_t sysreg_fault_get_data(seL4_UserContext *regs, uint64_t hsr)
+{
+    /* Get register opearand */
+    int rt = sysreg_fault_get_rt(hsr);
+    uint64_t data = *decode_rt(rt, regs);
+    return data;
+}
+
+bool handle_sysreg_64_fault(size_t vcpu_id, uint64_t hsr, seL4_UserContext *regs)
+{
+    uint32_t iss = hsr & ISS_MASK_FROM_HSR;
+    uint8_t op0 = (iss >> ISS_SYSREG_OP0_SHIFT) & ISS_SYSREG_OP0_MASK;
+    uint8_t op2 = (iss >> ISS_SYSREG_OP2_SHIFT) & ISS_SYSREG_OP2_MASK;
+    uint8_t op1 = (iss >> ISS_SYSREG_OP1_SHIFT) & ISS_SYSREG_OP1_MASK;
+    uint8_t crn = (iss >> ISS_SYSREG_CRN_SHIFT) & ISS_SYSREG_CRN_MASK;
+    uint8_t crm = (iss >> ISS_SYSREG_CRM_SHIFT) & ISS_SYSREG_CRM_MASK;
+    bool is_read = (iss >> ISS_SYSREG_IS_READ_BIT) & 0x1;
+    uint64_t data = sysreg_fault_get_data(regs, hsr);
+
+    for (int i = 0; i < ARRAY_SIZE(cpuif_reginfo); i++) {
+        if (cpuif_reginfo[i].opc0 == op0 && cpuif_reginfo[i].opc1 == op1 && cpuif_reginfo[i].crn == crn
+            && cpuif_reginfo[i].crm == crm && cpuif_reginfo[i].opc2 == op2) {
+            /* Check access rights */
+            if (is_read) {
+                assert(cpuif_reginfo[i].read_fn);
+                return cpuif_reginfo[i].read_fn(vcpu_id, regs);
+            } else {
+                assert(cpuif_reginfo[i].write_fn);
+                return cpuif_reginfo[i].write_fn(vcpu_id, regs, data);
+            }
+        }
+    }
+
+    LOG_VMM("trapped sysreg 64 exception with unimplemented instruction: op0 %u, op2 %u, op1 %u, crn %u, crm %u, is "
+            "read %u\n",
+            op0, op2, op1, crn, crm, is_read);
+    return false;
+}

--- a/src/arch/aarch64/psci.c
+++ b/src/arch/aarch64/psci.c
@@ -7,6 +7,7 @@
 
 #include <stdbool.h>
 #include <libvmm/guest.h>
+#include <libvmm/vcpu.h>
 #include <libvmm/util/util.h>
 #include <libvmm/arch/aarch64/psci.h>
 #include <libvmm/arch/aarch64/smc.h>
@@ -32,71 +33,104 @@
 #define PSCI_DISABLED -8
 #define PSCI_INVALID_ADDRESS -9
 
-bool handle_psci(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number, uint32_t hsr)
+bool handle_psci(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number, uint64_t hsr)
 {
     // @ivanv: write a note about what convention we assume, should we be checking
     // the convention?
     switch (fn_number) {
-        case PSCI_VERSION: {
-            /* We support PSCI version 1.2 */
-            uint32_t version = PSCI_MAJOR_VERSION(1) | PSCI_MINOR_VERSION(2);
-            smc_set_return_value(regs, version);
-            break;
-        }
-        case PSCI_CPU_ON: {
-            uintptr_t target_cpu = smc_get_arg(regs, 1);
-            // Right now we only have one vCPU and so any fault for a target vCPU
-            // that isn't the one that's already on we consider an error on the
-            // guest's side.
-            if (target_cpu == vcpu_id) {
+    case PSCI_VERSION: {
+        /* We support PSCI version 1.2 */
+        uint32_t version = PSCI_MAJOR_VERSION(1) | PSCI_MINOR_VERSION(2);
+        smc_set_return_value(regs, version);
+        break;
+    }
+    case PSCI_CPU_ON: {
+        size_t target_vcpu = smc_get_arg(regs, 1);
+        if (target_vcpu < GUEST_NUM_VCPUS && target_vcpu >= 0) {
+            /* The guest has given a valid target vCPU */
+            if (vcpu_is_on(target_vcpu)) {
                 smc_set_return_value(regs, PSCI_ALREADY_ON);
             } else {
-                // The guest has requested to turn on a virtual CPU that does
-                // not exist.
-                smc_set_return_value(regs, PSCI_INVALID_PARAMETERS);
+                /* We have a valid target vCPU, that is not started yet. So let's turn it on. */
+                uintptr_t vcpu_entry_point = smc_get_arg(regs, 2);
+                size_t context_id = smc_get_arg(regs, 3);
+
+                seL4_UserContext vcpu_regs = { 0 };
+                vcpu_regs.x0 = context_id;
+                vcpu_regs.spsr = 5; // PMODE_EL1h
+                vcpu_regs.pc = vcpu_entry_point;
+
+                /* TODO: support more than 16 vCPUs, we need to correctly set the affinity
+                 * bits in VMPIDR_EL2. */
+                assert(vcpu_id < 16);
+                microkit_vcpu_arm_write_reg(target_vcpu, seL4_VCPUReg_VMPIDR_EL2, target_vcpu);
+
+                seL4_Error err = seL4_TCB_WriteRegisters(
+                    BASE_VM_TCB_CAP + target_vcpu,
+                    false, // We'll explcitly start the guest below rather than in this call
+                    0, // No flags
+                    SEL4_USER_CONTEXT_SIZE, &vcpu_regs);
+                assert(err == seL4_NoError);
+                if (err != seL4_NoError) {
+                    return err;
+                }
+
+                /* Now that we have started the vCPU, we can set is as turned on. */
+                vcpu_set_on(target_vcpu, true);
+
+                LOG_VMM("starting guest vCPU (0x%lx) with entry point 0x%lx, context ID: 0x%lx\n", target_vcpu,
+                        vcpu_regs.pc, context_id);
+                microkit_vcpu_restart(target_vcpu, vcpu_regs.pc);
+
+                smc_set_return_value(regs, PSCI_SUCCESS);
             }
-            break;
+        } else {
+            // The guest has requested to turn on a virtual CPU that does
+            // not exist.
+            smc_set_return_value(regs, PSCI_INVALID_PARAMETERS);
         }
-        case PSCI_MIGRATE_INFO_TYPE:
-            /*
-             * There are multiple possible return values for MIGRATE_INFO_TYPE.
-             * In this case returning 2 will tell the guest that this is a
-             * system that does not use a "Trusted OS" as the PSCI
-             * specification says.
-             */
-            smc_set_return_value(regs, 2);
-            break;
-        case PSCI_FEATURES:
-            // @ivanv: seems weird that we just return nothing here.
-            smc_set_return_value(regs, PSCI_NOT_SUPPORTED);
-            break;
-        case PSCI_SYSTEM_RESET: {
-            // @refactor come back to
-            // bool success = guest_restart();
-            // if (!success) {
-            //     LOG_VMM_ERR("Failed to restart guest\n");
-            //     smc_set_return_value(regs, PSCI_INTERNAL_FAILURE);
-            // } else {
-                
-            //      * If we've successfully restarted the guest, all we want to do
-            //      * is reply to the fault that caused us to handle the PSCI call
-            //      * so that the guest can continue executing. We do not need to
-            //      * advance the vCPU program counter as we typically do when
-            //      * handling a fault since the correct PC has been set when we
-            //      * call guest_restart().
-                 
-            //     return true;
-            // }
-            break;
-        }
-        case PSCI_SYSTEM_OFF:
-            // @refactor, is it guaranteed that the CPU that does the vCPU request
-            // is the boot vcpu?
-            guest_stop(vcpu_id);
-            return true;
-        default:
-            LOG_VMM_ERR("Unhandled PSCI function ID 0x%lx\n", fn_number);
-            return false;
+        break;
+    }
+    case PSCI_MIGRATE_INFO_TYPE:
+        /*
+         * There are multiple possible return values for MIGRATE_INFO_TYPE.
+         * In this case returning 2 will tell the guest that this is a
+         * system that does not use a "Trusted OS" as the PSCI
+         * specification says.
+         */
+        smc_set_return_value(regs, 2);
+        break;
+    case PSCI_FEATURES:
+        // @ivanv: seems weird that we just return nothing here.
+        smc_set_return_value(regs, PSCI_NOT_SUPPORTED);
+        break;
+    case PSCI_SYSTEM_RESET: {
+        // @refactor come back to
+        // bool success = guest_restart();
+        // if (!success) {
+        //     LOG_VMM_ERR("Failed to restart guest\n");
+        //     smc_set_return_value(regs, PSCI_INTERNAL_FAILURE);
+        // } else {
+
+        //      * If we've successfully restarted the guest, all we want to do
+        //      * is reply to the fault that caused us to handle the PSCI call
+        //      * so that the guest can continue executing. We do not need to
+        //      * advance the vCPU program counter as we typically do when
+        //      * handling a fault since the correct PC has been set when we
+        //      * call guest_restart().
+
+        //     return true;
+        // }
+        break;
+    }
+    case PSCI_SYSTEM_OFF:
+        // @refactor, is it guaranteed that the CPU that does the vCPU request
+        // is the boot vcpu?
+        guest_stop();
+        return true;
+    default:
+        LOG_VMM_ERR("Unhandled PSCI function ID 0x%lx\n", fn_number);
+        return false;
     }
 
     bool success = fault_advance_vcpu(vcpu_id, regs);

--- a/src/arch/aarch64/smc.c
+++ b/src/arch/aarch64/smc.c
@@ -192,7 +192,7 @@ bool smc_register_sip_handler(smc_sip_handler_t handler)
 }
 
 // @ivanv: print out which SMC call as a string we can't handle.
-bool smc_handle(size_t vcpu_id, uint32_t hsr)
+bool smc_handle(size_t vcpu_id, uint64_t hsr)
 {
     seL4_UserContext regs;
     int err = seL4_TCB_ReadRegisters(BASE_VM_TCB_CAP + vcpu_id, false, 0, SEL4_USER_CONTEXT_SIZE, &regs);

--- a/src/arch/aarch64/tcb.c
+++ b/src/arch/aarch64/tcb.c
@@ -9,7 +9,8 @@
 #include <libvmm/tcb.h>
 #include <libvmm/util/util.h>
 
-void tcb_print_regs(size_t vcpu_id) {
+void tcb_print_regs(size_t vcpu_id)
+{
     /*
      * While we are potentially doing an extra system call in order to read the
      * TCB registers (as the VMM may have already read the TCB registers before

--- a/src/arch/aarch64/vgic/vgic.c
+++ b/src/arch/aarch64/vgic/vgic.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <microkit.h>
+#include <libvmm/vcpu.h>
 #include <libvmm/util/util.h>
 #include <libvmm/arch/aarch64/fault.h>
 #include <libvmm/arch/aarch64/vgic/vgic.h>
@@ -23,13 +24,13 @@
 /* The driver expects the VGIC state to be initialised before calling any of the driver functionality. */
 extern vgic_t vgic;
 
-bool fault_handle_vgic_maintenance(size_t vcpu_id)
+bool vgic_handle_fault_maintenance(size_t vcpu_id)
 {
     // @ivanv: reivist, also inconsistency between int and bool
     bool success = true;
     int idx = microkit_mr_get(seL4_VGICMaintenance_IDX);
     /* Currently not handling spurious IRQs */
-    // @ivanv: wtf, this comment seems irrelevant to the code.
+    // @ivanv: this comment seems irrelevant to the code.
     assert(idx >= 0);
 
     // @ivanv: Revisit and make sure it's still correct.
@@ -44,7 +45,7 @@ bool fault_handle_vgic_maintenance(size_t vcpu_id)
     slot->ack_data = NULL;
     /* Clear pending */
     LOG_IRQ("Maintenance IRQ %d\n", lr_virq.virq);
-    set_pending(vgic_get_dist(vgic.registers), lr_virq.virq, false, vcpu_id);
+    set_pending(&vgic, lr_virq.virq, false, vcpu_id);
     virq_ack(vcpu_id, &lr_virq);
     /* Check the overflow list for pending IRQs */
     struct virq_handle *virq = vgic_irq_dequeue(&vgic, vcpu_id);
@@ -62,15 +63,29 @@ bool fault_handle_vgic_maintenance(size_t vcpu_id)
     }
 
     if (!success) {
-        printf("VGIC|ERROR: maintenance handler failed\n");
+        LOG_VMM_ERR("vGIC maintenance handler failed\n");
         assert(0);
     }
 
     return success;
 }
 
-// @ivanv: maybe this shouldn't be here?
-bool vgic_register_irq(size_t vcpu_id, int virq_num, virq_ack_fn_t ack_fn, void *ack_data) {
+bool vgic_handle_fault_dist(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data)
+{
+    bool success = false;
+    if (fault_is_read(fsr)) {
+        success = vgic_handle_fault_dist_read(vcpu_id, &vgic, offset, fsr, regs);
+        assert(success);
+    } else {
+        success = vgic_handle_fault_dist_write(vcpu_id, &vgic, offset, fsr, regs);
+        assert(success);
+    }
+
+    return success;
+}
+
+bool vgic_register_irq(size_t vcpu_id, int virq_num, virq_ack_fn_t ack_fn, void *ack_data)
+{
     assert(virq_num >= 0 && virq_num != VIRQ_INVALID);
     struct virq_handle virq = {
         .virq = virq_num,
@@ -83,32 +98,10 @@ bool vgic_register_irq(size_t vcpu_id, int virq_num, virq_ack_fn_t ack_fn, void 
 
 bool vgic_inject_irq(size_t vcpu_id, int irq)
 {
-    LOG_IRQ("Injecting IRQ %d\n", irq);
+    LOG_IRQ("(vCPU %d) injecting IRQ %d\n", vcpu_id, irq);
 
-    return vgic_dist_set_pending_irq(&vgic, vcpu_id, irq);
-
-    // @ivanv: explain why we don't check error before checking this fault stuff
-    // @ivanv: seperately, it seems weird to have this fault handling code here?
-    // @ivanv: revist
-    // if (!fault_handled(vcpu->vcpu_arch.fault) && fault_is_wfi(vcpu->vcpu_arch.fault)) {
-    //     // ignore_fault(vcpu->vcpu_arch.fault);
-    //     err = advance_vcpu_fault(regs);
-    // }
-}
-
-// @ivanv: revisit this whole function
-bool handle_vgic_dist_fault(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data)
-{
-    bool success = false;
-    if (fault_is_read(fsr)) {
-        // printf("VGIC|INFO: Read dist\n");
-        success = vgic_dist_reg_read(vcpu_id, &vgic, offset, fsr, regs);
-        assert(success);
-    } else {
-        // printf("VGIC|INFO: Write dist\n");
-        success = vgic_dist_reg_write(vcpu_id, &vgic, offset, fsr, regs);
-        assert(success);
-    }
+    bool success = vgic_dist_set_pending_irq(&vgic, vcpu_id, irq);
+    assert(success);
 
     return success;
 }

--- a/src/arch/aarch64/vgic/vgic_v2.c
+++ b/src/arch/aarch64/vgic/vgic_v2.c
@@ -54,6 +54,8 @@
 vgic_t vgic;
 struct gic_dist_map dist;
 
+#define GICD_TYPER (0x0000fce7 | ITLINES)
+
 static void vgic_dist_reset(struct gic_dist_map *gic_dist)
 {
     gic_dist->typer = 0x0000fce7; /* RO */

--- a/src/arch/aarch64/vgic/vgic_v3.c
+++ b/src/arch/aarch64/vgic/vgic_v3.c
@@ -173,13 +173,13 @@ bool vgic_handle_fault_redist(size_t vcpu_id, size_t offset, size_t fsr, seL4_Us
     }
 }
 
+#define GICD_TYPER (0x7B04A0 | ITLINES)
+
 static void vgic_dist_reset(struct gic_dist_map *dist)
 {
     memset(dist, 0, sizeof(*dist));
 
-    // @billn, why are the lowest 4 bits zero???, it means this GIC implementation doesn't support any SPIs??
-    // Arm IHI 0069H.b  ID041224  12-621
-    dist->typer            = 0x7B04B0; /* RO */
+    dist->typer            = GICD_TYPER; /* RO */
     dist->iidr             = 0x1043B ; /* RO */
 
     dist->enable_set[0]    = 0x0000ffff; /* 16bit RO */

--- a/src/arch/aarch64/vgic/vgic_v3_cpuif.c
+++ b/src/arch/aarch64/vgic/vgic_v3_cpuif.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <libvmm/guest.h>
+#include <libvmm/vcpu.h>
+#include <libvmm/util/util.h>
+#include <libvmm/arch/aarch64/fault.h>
+#include <libvmm/arch/aarch64/vgic/vgic.h>
+#include <libvmm/arch/aarch64/vgic/vgic_v3_cpuif.h>
+
+#define ICC_SGI1R_EL1_IRM_BIT 40
+#define ICC_SGI1R_EL1_INTID_SHIFT 24
+#define ICC_SGI1R_EL1_INTID_MASK  0xf
+
+bool icc_sgi1r_el1_write(size_t vcpu_id, seL4_UserContext *regs, uint64_t data)
+{
+    uint8_t intid = (data >> ICC_SGI1R_EL1_INTID_SHIFT) & ICC_SGI1R_EL1_INTID_MASK;
+
+    if ((data >> ICC_SGI1R_EL1_IRM_BIT) & 0x1) {
+        /* Interrupt routed to all PEs in the system, excluding “self”. */
+        for (int i = 0; i < GUEST_NUM_VCPUS; i++) {
+            if (vcpu_is_on(i) && i != vcpu_id) {
+                assert(vgic_inject_irq(i, intid));
+            }
+        }
+    } else {
+        /* Interrupt routed to the PEs specified by Aff3.Aff2.Aff1.<target list>.
+           Where the bit number in target specify vCPU ID. */
+        uint16_t target_list = data & 0xffff;
+        for (int i = 0; i < GUEST_NUM_VCPUS && i < 16; i++) {
+            // @billn revisit: affinity routing for > 16 vCPUs
+            if ((target_list >> i & 0x1) && vcpu_is_on(i)) {
+                assert(vgic_inject_irq(i, intid));
+            }
+        }
+    }
+
+    return fault_advance_vcpu(vcpu_id, regs);
+}

--- a/src/arch/aarch64/virq.c
+++ b/src/arch/aarch64/virq.c
@@ -25,7 +25,8 @@ static void vppi_event_ack(size_t vcpu_id, int irq, void *cookie)
 
 static void sgi_ack(size_t vcpu_id, int irq, void *cookie) {}
 
-bool virq_controller_init(size_t boot_vcpu_id) {
+bool virq_controller_init()
+{
     bool success;
 
     vgic_init();
@@ -38,52 +39,64 @@ bool virq_controller_init(size_t boot_vcpu_id) {
 #endif
 
     /* Register the fault handler */
-    success = fault_register_vm_exception_handler(GIC_DIST_PADDR, GIC_DIST_SIZE, handle_vgic_dist_fault, NULL);
+    success = fault_register_vm_exception_handler(GIC_DIST_PADDR, GIC_DIST_SIZE, vgic_handle_fault_dist, NULL);
     if (!success) {
         LOG_VMM_ERR("Failed to register fault handler for GIC distributor region\n");
         return false;
     }
 #if defined(GIC_V3)
-    success = fault_register_vm_exception_handler(GIC_REDIST_PADDR, GIC_REDIST_SIZE, handle_vgic_redist_fault, NULL);
+    success = fault_register_vm_exception_handler(GIC_REDIST_PADDR, GIC_REDIST_TOTAL_SIZE, vgic_handle_fault_redist,
+                                                  NULL);
     if (!success) {
         LOG_VMM_ERR("Failed to register fault handler for GIC redistributor region\n");
         return false;
     }
 #endif
 
-    success = vgic_register_irq(boot_vcpu_id, PPI_VTIMER_IRQ, &vppi_event_ack, NULL);
-    if (!success) {
-        LOG_VMM_ERR("Failed to register vCPU virtual timer IRQ: 0x%lx\n", PPI_VTIMER_IRQ);
-        return false;
-    }
-    success = vgic_register_irq(boot_vcpu_id, SGI_RESCHEDULE_IRQ, &sgi_ack, NULL);
-    if (!success) {
-        LOG_VMM_ERR("Failed to register vCPU SGI 0 IRQ");
-        return false;
-    }
-    success = vgic_register_irq(boot_vcpu_id, SGI_FUNC_CALL, &sgi_ack, NULL);
-    if (!success) {
-        LOG_VMM_ERR("Failed to register vCPU SGI 1 IRQ");
-        return false;
+    for (int vcpu = 0; vcpu < GUEST_NUM_VCPUS; vcpu++) {
+        success = vgic_register_irq(vcpu, PPI_VTIMER_IRQ, &vppi_event_ack, NULL);
+        if (!success) {
+            LOG_VMM_ERR("Failed to register vCPU virtual timer IRQ: 0x%lx\n", PPI_VTIMER_IRQ);
+            return false;
+        }
+        success = vgic_register_irq(vcpu, SGI_RESCHEDULE_IRQ, &sgi_ack, NULL);
+        if (!success) {
+            LOG_VMM_ERR("Failed to register vCPU SGI 0 IRQ");
+            return false;
+        }
+        success = vgic_register_irq(vcpu, SGI_FUNC_CALL, &sgi_ack, NULL);
+        if (!success) {
+            LOG_VMM_ERR("Failed to register vCPU SGI 1 IRQ");
+            return false;
+        }
     }
 
     return true;
 }
 
-bool virq_inject(size_t vcpu_id, int irq) {
+bool virq_inject_vcpu(size_t vcpu_id, int irq)
+{
     return vgic_inject_irq(vcpu_id, irq);
 }
 
-bool virq_register(size_t vcpu_id, size_t virq_num, virq_ack_fn_t ack_fn, void *ack_data) {
+bool virq_inject(int irq)
+{
+    return vgic_inject_irq(GUEST_BOOT_VCPU_ID, irq);
+}
+
+bool virq_register(size_t vcpu_id, size_t virq_num, virq_ack_fn_t ack_fn, void *ack_data)
+{
     return vgic_register_irq(vcpu_id, virq_num, ack_fn, ack_data);
 }
 
-static void virq_passthrough_ack(size_t vcpu_id, int irq, void *cookie) {
+static void virq_passthrough_ack(size_t vcpu_id, int irq, void *cookie)
+{
     /* We are down-casting to microkit_channel so must first cast to size_t */
     microkit_irq_ack((microkit_channel)(size_t)cookie);
 }
 
-bool virq_register_passthrough(size_t vcpu_id, size_t irq, microkit_channel irq_ch) {
+bool virq_register_passthrough(size_t vcpu_id, size_t irq, microkit_channel irq_ch)
+{
     assert(irq_ch < MICROKIT_MAX_CHANNELS);
     if (irq_ch >= MICROKIT_MAX_CHANNELS) {
         LOG_VMM_ERR("Invalid channel number given '0x%lx' for passthrough vIRQ 0x%lx\n", irq_ch, irq);
@@ -93,7 +106,7 @@ bool virq_register_passthrough(size_t vcpu_id, size_t irq, microkit_channel irq_
     LOG_VMM("Register passthrough vIRQ 0x%lx on vCPU 0x%lx (IRQ channel: 0x%lx)\n", irq, vcpu_id, irq_ch);
     virq_passthrough_map[irq_ch] = irq;
 
-    bool success = virq_register(GUEST_VCPU_ID, irq, &virq_passthrough_ack, (void *)(size_t)irq_ch);
+    bool success = virq_register(GUEST_BOOT_VCPU_ID, irq, &virq_passthrough_ack, (void *)(size_t)irq_ch);
     assert(success);
     if (!success) {
         LOG_VMM_ERR("Failed to register passthrough vIRQ %d\n", irq);
@@ -103,16 +116,18 @@ bool virq_register_passthrough(size_t vcpu_id, size_t irq, microkit_channel irq_
     return true;
 }
 
-bool virq_handle_passthrough(microkit_channel irq_ch) {
+bool virq_handle_passthrough(microkit_channel irq_ch)
+{
     assert(virq_passthrough_map[irq_ch] >= 0);
     if (virq_passthrough_map[irq_ch] < 0) {
         LOG_VMM_ERR("attempted to handle invalid passthrough IRQ channel 0x%lx\n", irq_ch);
         return false;
     }
 
-    bool success = vgic_inject_irq(GUEST_VCPU_ID, virq_passthrough_map[irq_ch]);
+    bool success = vgic_inject_irq(GUEST_BOOT_VCPU_ID, virq_passthrough_map[irq_ch]);
     if (!success) {
-        LOG_VMM_ERR("could not inject passthrough vIRQ 0x%lx, dropped on vCPU 0x%lx\n", virq_passthrough_map[irq_ch], GUEST_VCPU_ID);
+        LOG_VMM_ERR("could not inject passthrough vIRQ 0x%lx, dropped on vCPU 0x%lx\n", virq_passthrough_map[irq_ch],
+                    GUEST_BOOT_VCPU_ID);
         return false;
     }
 

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -157,7 +157,7 @@ static inline void virtio_blk_used_buffer(struct virtio_device *dev, uint16_t de
 
 static inline bool virtio_blk_virq_inject(struct virtio_device *dev)
 {
-    return virq_inject(GUEST_VCPU_ID, dev->virq);
+    return virq_inject(dev->virq);
 }
 
 static inline void virtio_blk_set_interrupt_status(struct virtio_device *dev, bool used_buffer, bool config_change)

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -163,7 +163,7 @@ static bool virtio_console_handle_tx(struct virtio_device *dev)
      * available data. In this case we do not set the IRQ status. */
     if (transferred) {
         dev->regs.InterruptStatus = BIT_LOW(0);
-        bool success = virq_inject(GUEST_VCPU_ID, dev->virq);
+        bool success = virq_inject(dev->virq);
         assert(success);
 
         microkit_notify(console->tx_ch);
@@ -208,7 +208,7 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
      * available data. In this case we do not set the IRQ status. */
     if (transferred) {
         console->virtio_device.regs.InterruptStatus = BIT_LOW(0);
-        bool success = virq_inject(GUEST_VCPU_ID, console->virtio_device.virq);
+        bool success = virq_inject(console->virtio_device.virq);
         assert(success);
 
         return success;

--- a/src/virtio/mmio.c
+++ b/src/virtio/mmio.c
@@ -328,7 +328,7 @@ bool virtio_mmio_register_device(virtio_device_t *dev,
     /* Register the virtual IRQ that will be used to communicate from the device
      * to the guest. This assumes that the interrupt controller is already setup. */
     // @ivanv: we should check that (on AArch64) the virq is an SPI.
-    success = virq_register(GUEST_VCPU_ID, virq, &virtio_virq_default_ack, NULL);
+    success = virq_register(GUEST_BOOT_VCPU_ID, virq, &virtio_virq_default_ack, NULL);
     assert(success);
 
     return success;

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -141,7 +141,7 @@ static void virtq_enqueue_used(struct virtq *virtq, uint32_t desc_head, uint32_t
 static bool virtio_net_respond(struct virtio_device *dev)
 {
     dev->regs.InterruptStatus = BIT_LOW(0);
-    bool success = virq_inject(GUEST_VCPU_ID, dev->virq);
+    bool success = virq_inject(dev->virq);
     assert(success);
 
     return success;

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -661,7 +661,7 @@ bool virtio_pci_register_device(virtio_device_t *dev, int virq)
 
     /* Register the virtual IRQ that will be used to communicate from the device
      * to the guest. This assumes that the interrupt controller is already setup. */
-    success = virq_register(GUEST_VCPU_ID, virq, &virtio_virq_default_ack, NULL);
+    success = virq_register(GUEST_BOOT_VCPU_ID, virq, &virtio_virq_default_ack, NULL);
     assert(success);
 
     return success;

--- a/src/virtio/sound.c
+++ b/src/virtio/sound.c
@@ -147,7 +147,7 @@ static const char *code_to_str(uint32_t code)
 static void virtio_snd_respond(struct virtio_device *dev)
 {
     dev->regs.InterruptStatus = BIT_LOW(0);
-    bool success = virq_inject(GUEST_VCPU_ID, dev->virq);
+    bool success = virq_inject(dev->virq);
     assert(success);
 }
 

--- a/vmm.mk
+++ b/vmm.mk
@@ -14,12 +14,12 @@ ifeq ($(filter ${MICROKIT_BOARD},${GIC_V3_BOARDS}),)
 	VGIC_FILES := src/arch/aarch64/vgic/vgic_v2.c
 else
 	VGIC := GIC_V3
-	VGIC_FILES := src/arch/aarch64/vgic/vgic_v3.c
+	VGIC_FILES := src/arch/aarch64/vgic/vgic_v3.c src/arch/aarch64/vgic/vgic_v3_cpuif.c
 endif
 
 AARCH64_FILES := src/arch/aarch64/fault.c \
 		 src/arch/aarch64/linux.c \
-		 src/arch/aarch64/linux.c \
+		 src/arch/aarch64/cpuif.c \
 		 src/arch/aarch64/psci.c \
 		 src/arch/aarch64/smc.c \
 		 src/arch/aarch64/tcb.c \


### PR DESCRIPTION
Re-based version of https://github.com/au-ts/libvmm/pull/116.

It should be noted that multi-core virtual machines won't work yet because Microkit lacks support for it, but when Microkit does add support for pinning a virtual CPU to a particular core, there won't be any changes necessary to libvmm to enable multi-core guests.

Remaining TODOs:
* [x] Update manual
* [x] Update vGICv3 code for multiple vCPUs.
* [x] Add a test for multiple vCPUs.
* [x] Add `simple-smp` example to CI.
* [x] Investigate why smp qemu aarch64 crashes on vIRQ 27 not enabled on Zig, but ok on Make.

Closes https://github.com/au-ts/libvmm/issues/4.