### PR TITLE
Remove unused struct fields in GIC register maps

### DIFF
--- a/include/libvmm/arch/aarch64/vgic/vgic_v2.h
+++ b/include/libvmm/arch/aarch64/vgic/vgic_v2.h
@@ -31,8 +31,6 @@ struct gic_dist_map {
     uint32_t typer;                                 /* 0x004 */
     uint32_t iidr;                                  /* 0x008 */
 
-    uint32_t res1[29];                              /* [0x00C, 0x080) */
-
     uint32_t irq_group0[GUEST_NUM_VCPUS];           /* [0x080, 0x84) */
     uint32_t irq_group[31];                         /* [0x084, 0x100) */
     uint32_t enable_set0[GUEST_NUM_VCPUS];          /* [0x100, 0x104) */
@@ -49,29 +47,21 @@ struct gic_dist_map {
     uint32_t active_clr[31];                        /* [0x384, 0x400) */
     uint32_t priority0[GUEST_NUM_VCPUS][8];         /* [0x400, 0x420) */
     uint32_t priority[247];                         /* [0x420, 0x7FC) */
-    uint32_t res3;                                  /* 0x7FC */
 
     uint32_t targets0[GUEST_NUM_VCPUS][8];          /* [0x800, 0x820) */
     uint32_t targets[247];                          /* [0x820, 0xBFC) */
-    uint32_t res4;                                  /* 0xBFC */
 
     uint32_t config[64];                            /* [0xC00, 0xD00) */
 
     uint32_t spi[32];                               /* [0xD00, 0xD80) */
-    uint32_t res5[20];                              /* [0xD80, 0xDD0) */
-    uint32_t res6;                                  /* 0xDD0 */
     uint32_t legacy_int;                            /* 0xDD4 */
-    uint32_t res7[2];                               /* [0xDD8, 0xDE0) */
     uint32_t match_d;                               /* 0xDE0 */
     uint32_t enable_d;                              /* 0xDE4 */
-    uint32_t res8[70];                              /* [0xDE8, 0xF00) */
 
     uint32_t sgir;                                  /* 0xF00 */
-    uint32_t res9[3];                               /* [0xF04, 0xF10) */
 
     uint32_t sgi_pending_clr[GUEST_NUM_VCPUS][4];   /* [0xF10, 0xF20) */
     uint32_t sgi_pending_set[GUEST_NUM_VCPUS][4];   /* [0xF20, 0xF30) */
-    uint32_t res10[40];                             /* [0xF30, 0xFC0) */
 
     uint32_t periph_id[12];                         /* [0xFC0, 0xFF0) */
     uint32_t component_id[4];                       /* [0xFF0, 0xFFF] */
@@ -148,6 +138,8 @@ typedef struct gic_dist_map vgic_reg_t;
 
 static inline struct gic_dist_map *vgic_get_dist(void *registers)
 {
+    LOG_VMM("sizeof gic_dist_map: %d\n", sizeof(struct gic_dist_map));
+
     return (struct gic_dist_map *) registers;
 }
 

--- a/include/libvmm/arch/aarch64/vgic/vgic_v3.h
+++ b/include/libvmm/arch/aarch64/vgic/vgic_v3.h
@@ -21,15 +21,10 @@ struct gic_dist_map {
     uint32_t ctlr;                /* 0x0000 */
     uint32_t typer;               /* 0x0004 */
     uint32_t iidr;                /* 0x0008 */
-    uint32_t res1[13];            /* [0x000C, 0x0040) */
     uint32_t setspi_nsr;          /* 0x0040 */
-    uint32_t res2;                /* 0x0044 */
     uint32_t clrspi_nsr;          /* 0x0048 */
-    uint32_t res3;                /* 0x004C */
     uint32_t setspi_sr;           /* 0x0050 */
-    uint32_t res4;                /* 0x0054 */
     uint32_t clrspi_sr;           /* 0x0058 */
-    uint32_t res5[9];             /* [0x005C, 0x0080) */
     uint32_t irq_group0[GUEST_NUM_VCPUS];          /* [0x080, 0x84) */
     uint32_t irq_group[31];                             /* [0x084, 0x100) */
     uint32_t enable_set0[GUEST_NUM_VCPUS];         /* [0x100, 0x104) */
@@ -46,28 +41,21 @@ struct gic_dist_map {
     uint32_t active_clr[31];                            /* [0x384, 0x400) */
     uint32_t priority0[GUEST_NUM_VCPUS][8];        /* [0x400, 0x420) */
     uint32_t priority[247];                             /* [0x420, 0x7FC) */
-    uint32_t res6;                  /* 0x7FC */
 
     uint32_t targets0[GUEST_NUM_VCPUS][8];         /* [0x800, 0x820) */
     uint32_t targets[247];                              /* [0x820, 0xBFC) */
-    uint32_t res7;                  /* 0xBFC */
 
     uint32_t config[64];            /* [0xC00, 0xD00) */
     uint32_t group_mod[64];         /* [0xD00, 0xE00) */
     uint32_t nsacr[64];             /* [0xE00, 0xF00) */
     uint32_t sgir;                  /* 0xF00 */
-    uint32_t res8[3];               /* [0xF00, 0xF10) */
     uint32_t sgi_pending_clr[GUEST_NUM_VCPUS][4];  /* [0xF10, 0xF20) */
     uint32_t sgi_pending_set[GUEST_NUM_VCPUS][4];  /* [0xF20, 0xF30) */
-    uint32_t res9[5235];            /* [0x0F30, 0x6100) */
 
     uint64_t irouter[960];          /* [0x6100, 0x7F00) */
-    uint64_t res10[2080];           /* [0x7F00, 0xC000) */
     uint32_t estatusr;              /* 0xC000 */
     uint32_t errtestr;              /* 0xC004 */
-    uint32_t res11[31];             /* [0xC008, 0xC084) */
     uint32_t spisr[30];             /* [0xC084, 0xC0FC) */
-    uint32_t res12[4021];           /* [0xC0FC, 0xFFD0) */
 
     uint32_t pidrn[8];              /* [0xFFD0, 0xFFF0) */
     uint32_t cidrn[4];              /* [0xFFD0, 0xFFFC] */
@@ -78,12 +66,9 @@ struct gic_redist_map {          /* Starting */
     uint32_t    ctlr;           /* 0x0000 */
     uint32_t    iidr;           /* 0x0004 */
     uint64_t    typer;          /* 0x008 */
-    uint32_t    res0;           /* 0x0010 */
     uint32_t    waker;          /* 0x0014 */
-    uint32_t    res1[21];       /* 0x0018 */
     uint64_t    propbaser;      /* 0x0070 */
     uint64_t    pendbaser;      /* 0x0078 */
-    uint32_t    res2[16340];    /* 0x0080 */
     uint32_t    pidr4;          /* 0xFFD0 */
     uint32_t    pidr5;          /* 0xFFD4 */
     uint32_t    pidr6;          /* 0xFFD8 */
@@ -100,7 +85,6 @@ struct gic_redist_map {          /* Starting */
 
 /* Memory map for the GIC Redistributor Registers for the SGI and PPI's */
 // struct gic_redist_sgi_ppi_map {  /* Starting */
-//     uint32_t    res0[32];       /* 0x0000 */
 //     uint32_t    igroup[32];     /* 0x0080 */
 //     uint32_t    isenable[32];   /* 0x0100 */
 //     uint32_t    icenable[32];   /* 0x0180 */
@@ -109,17 +93,12 @@ struct gic_redist_map {          /* Starting */
 //     uint32_t    isactive[32];   /* 0x0300 */
 //     uint32_t    icactive[32];   /* 0x0380 */
 //     uint32_t    ipriorityrn[8]; /* 0x0400 */
-//     uint32_t    res1[504];      /* 0x0420 */
 //     uint32_t    icfgrn_ro;      /* 0x0C00 */
 //     uint32_t    icfgrn_rw;      /* 0x0C04 */
-//     uint32_t    res2[62];       /* 0x0C08 */
 //     uint32_t    igrpmod[64];    /* 0x0D00 */
 //     uint32_t    nsac;           /* 0x0E00 */
-//     uint32_t    res11[11391];   /* 0x0E04 */
 //     uint32_t    miscstatsr;     /* 0xC000 */
-//     uint32_t    res3[31];       /* 0xC004 */
 //     uint32_t    ppisr;          /* 0xC080 */
-//     uint32_t    res4[4062];     /* 0xC084 */
 // };
 
 /*


### PR DESCRIPTION
These are emulated devices, and we aren't emulating the reserved regions. This only makes sense in a context where you have a one-to-one mapping between struct field offset and device register offset, which we do not.

On GICv2 this saves 668 bytes, on GICv3 it saves 119368 bytes.

I'm sure there's much more to do, but this is very low-hanging fruit.