### PR TITLE
Virtio-block device implementation bug fixes

### DIFF
--- a/examples/virtio/README.md
+++ b/examples/virtio/README.md
@@ -185,4 +185,4 @@ time to contain a FAT filesystem for both partitions.
 
 When running on one of the supported hardware platforms, the system expects to
 read and write from the SD card. You will need to format the SD card prior to
-kbooting.
+booting.

--- a/examples/virtio/build.zig
+++ b/examples/virtio/build.zig
@@ -206,6 +206,10 @@ pub fn build(b: *std.Build) !void {
             libvmm_dep.path("tools/linux/blk/blk_client_init"),
             libvmm_dep.path("tools/linux/net/net_client_init"),
         };
+        const home_scripts = .{
+            libvmm_dep.path("tools/linux/blk/blk_integration_tests.sh"),
+            libvmm_dep.path("tools/linux/blk/blk_bench.sh"),
+        };
         const packrootfs = libvmm_dep.path("tools/packrootfs");
         packrootfs_cmd.addFileArg(packrootfs);
         packrootfs_cmd.addFileInput(packrootfs);
@@ -215,6 +219,11 @@ pub fn build(b: *std.Build) !void {
         const packed_rootfs = packrootfs_cmd.addOutputFileArg("rootfs.cpio.gz");
         packrootfs_cmd.addArg("--startup");
         inline for (init_scripts) |s| {
+            packrootfs_cmd.addFileInput(s);
+            packrootfs_cmd.addFileArg(s);
+        }
+        packrootfs_cmd.addArg("--home");
+        inline for (home_scripts) |s| {
             packrootfs_cmd.addFileInput(s);
             packrootfs_cmd.addFileArg(s);
         }

--- a/examples/virtio/client_vmm.c
+++ b/examples/virtio/client_vmm.c
@@ -136,14 +136,10 @@ void init(void)
     assert(success);
 
     /* Initialise virtIO block device */
-    success = virtio_mmio_blk_init(&virtio_blk,
-                                   vmm_config.virtio_mmio_devices[blk_vdev_idx].base,
+    success = virtio_mmio_blk_init(&virtio_blk, vmm_config.virtio_mmio_devices[blk_vdev_idx].base,
                                    vmm_config.virtio_mmio_devices[blk_vdev_idx].size,
-                                   vmm_config.virtio_mmio_devices[blk_vdev_idx].irq,
-                                   (uintptr_t)blk_config.data.vaddr,
-                                   blk_config.data.size,
-                                   storage_info,
-                                   &blk_queue,
+                                   vmm_config.virtio_mmio_devices[blk_vdev_idx].irq, (uintptr_t)blk_config.data.vaddr,
+                                   blk_config.data.size, storage_info, &blk_queue, blk_config.virt.num_buffers,
                                    blk_config.virt.id);
     assert(success);
 

--- a/examples/virtio/meta.py
+++ b/examples/virtio/meta.py
@@ -57,7 +57,7 @@ BOARDS: List[Board] = [
         guest_blk="virtio-blk@150000",
         net="soc@0/bus@30800000/ethernet@30be0000",
         guest_net="virtio-net@160000",
-        partition=0
+        partition=2
     ),
 ]
 

--- a/examples/virtio/virtio.mk
+++ b/examples/virtio/virtio.mk
@@ -34,7 +34,8 @@ METAPROGRAM := $(VIRTIO_EXAMPLE)/meta.py
 
 SDDF_CUSTOM_LIBC := 1
 
-CLIENT_VM_USERLEVEL_INIT := blk_client_init net_client_init
+CLIENT_VM_USERLEVEL_INIT := blk_client_init
+CLIENT_VM_USERLEVEL_HOME := $(LIBVMM_TOOLS)/linux/blk/blk_integration_tests.sh $(LIBVMM_TOOLS)/linux/blk/blk_bench.sh
 
 vpath %.c $(SDDF) $(LIBVMM) $(VIRTIO_EXAMPLE) $(NETWORK_COMPONENTS)
 
@@ -58,7 +59,9 @@ LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a libvmm.a --end-group
 
 include $(SDDF)/util/util.mk
+ifeq ($(MICROKIT_BOARD), maaxboard)
 include $(TIMER_DRIVER)/timer_driver.mk
+endif
 include $(SERIAL_DRIVER)/serial_driver.mk
 include $(SERIAL_COMPONENTS)/serial_components.mk
 include ${BLK_DRIVER}/blk_driver.mk
@@ -133,10 +136,11 @@ ${INITRD}:
 	cp initrd_download_dir/${INITRD}/rootfs.cpio.gz ${INITRD}
 
 client_vm/rootfs.cpio.gz: ${INITRD} \
-	$(CLIENT_VM_USERLEVEL_INIT) |client_vm
+	$(CLIENT_VM_USERLEVEL_INIT) $(CLIENT_VM_USERLEVEL_HOME) |client_vm
 	$(LIBVMM)/tools/packrootfs ${INITRD} \
 		client_vm/rootfs_staging -o $@ \
-		--startup $(CLIENT_VM_USERLEVEL_INIT)
+		--startup $(CLIENT_VM_USERLEVEL_INIT) \
+		--home $(CLIENT_VM_USERLEVEL_HOME)
 
 blk_storage:
 	$(LIBVMM_TOOLS)/mkvirtdisk $@ $(BLK_NUM_PART) $(BLK_SIZE) $(BLK_MEM)

--- a/examples/virtio_pci/client_vmm.c
+++ b/examples/virtio_pci/client_vmm.c
@@ -110,7 +110,7 @@ void init(void)
     assert(success);
 
     success = virtio_pci_blk_init(&virtio_blk, 1, 49, (uintptr_t)blk_config.data.vaddr, blk_config.data.size,
-                                  storage_info, &blk_queue, blk_config.virt.id);
+                                  storage_info, &blk_queue, blk_config.virt.num_buffers, blk_config.virt.id);
     assert(success);
 
     /* Initialise virtIO net device */

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, UNSW
+ * Copyright 2025, UNSW
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,29 +18,44 @@
 #include <sddf/util/fsmalloc.h>
 #include <sddf/util/ialloc.h>
 
+#define SECTORS_IN_TRANSFER_WINDOW (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)
+
 /* Uncomment this to enable debug logging */
 /* #define DEBUG_BLOCK */
 
 #if defined(DEBUG_BLOCK)
-#define LOG_BLOCK(...) do{ printf("VIRTIO(BLOCK): "); printf(__VA_ARGS__); }while(0)
+#define LOG_BLOCK(...)             \
+    do                             \
+    {                              \
+        printf("VIRTIO(BLOCK): "); \
+        printf(__VA_ARGS__);       \
+    } while (0)
 #else
-#define LOG_BLOCK(...) do{}while(0)
+#define LOG_BLOCK(...) \
+    do                 \
+    {                  \
+    } while (0)
 #endif
 
-#define LOG_BLOCK_ERR(...) do{ printf("VIRTIO(BLOCK)|ERROR: "); printf(__VA_ARGS__); }while(0)
+#define LOG_BLOCK_ERR(...)               \
+    do                                   \
+    {                                    \
+        printf("VIRTIO(BLOCK)|ERROR: "); \
+        printf(__VA_ARGS__);             \
+    } while (0)
 
 static inline struct virtio_blk_device *device_state(struct virtio_device *dev)
 {
     return (struct virtio_blk_device *)dev->device_data;
 }
 
-static void virtio_blk_mmio_reset(struct virtio_device *dev)
+static inline void virtio_blk_mmio_reset(struct virtio_device *dev)
 {
     dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].ready = false;
     dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].last_idx = 0;
 }
 
-static bool virtio_blk_mmio_get_device_features(struct virtio_device *dev, uint32_t *features)
+static inline bool virtio_blk_mmio_get_device_features(struct virtio_device *dev, uint32_t *features)
 {
     if (dev->regs.Status & VIRTIO_CONFIG_S_FEATURES_OK) {
         LOG_BLOCK_ERR("driver somehow wants to read device features after FEATURES_OK\n");
@@ -51,30 +66,35 @@ static bool virtio_blk_mmio_get_device_features(struct virtio_device *dev, uint3
     case 0:
         *features = BIT_LOW(VIRTIO_BLK_F_FLUSH);
         *features = *features | BIT_LOW(VIRTIO_BLK_F_BLK_SIZE);
+        *features = *features | BIT_LOW(VIRTIO_BLK_F_SIZE_MAX);
+        *features = *features | BIT_LOW(VIRTIO_BLK_F_SEG_MAX);
+        *features = *features | BIT_LOW(VIRTIO_BLK_F_TOPOLOGY);
         break;
     /* features bits 32 to 63 */
     case 1:
         *features = BIT_HIGH(VIRTIO_F_VERSION_1);
         break;
     default:
-        LOG_BLOCK_ERR("driver sets DeviceFeaturesSel to 0x%x, which doesn't make sense\n",
-                      dev->regs.DeviceFeaturesSel);
+        LOG_BLOCK_ERR("driver sets DeviceFeaturesSel to 0x%x, which doesn't make sense\n", dev->regs.DeviceFeaturesSel);
         return false;
     }
 
     return true;
 }
 
-static bool virtio_blk_mmio_set_driver_features(struct virtio_device *dev, uint32_t features)
+static inline bool virtio_blk_mmio_set_driver_features(struct virtio_device *dev, uint32_t features)
 {
     /* According to virtio initialisation protocol,
-       this should check what device features were set, and return the subset of features understood
-       by the driver. */
+       this should check what device features were set, and return the subset of
+       features understood by the driver. */
     bool success = false;
 
     uint32_t device_features = 0;
-    device_features = device_features | BIT_LOW(VIRTIO_BLK_F_FLUSH);
-    device_features = device_features | BIT_LOW(VIRTIO_BLK_F_BLK_SIZE);
+    device_features |= BIT_LOW(VIRTIO_BLK_F_FLUSH);
+    device_features |= BIT_LOW(VIRTIO_BLK_F_BLK_SIZE);
+    device_features |= BIT_LOW(VIRTIO_BLK_F_SIZE_MAX);
+    device_features |= BIT_LOW(VIRTIO_BLK_F_SEG_MAX);
+    device_features |= BIT_LOW(VIRTIO_BLK_F_TOPOLOGY);
 
     switch (dev->regs.DriverFeaturesSel) {
     /* feature bits 0 to 31 */
@@ -98,34 +118,35 @@ static bool virtio_blk_mmio_set_driver_features(struct virtio_device *dev, uint3
     return success;
 }
 
-static bool virtio_blk_mmio_get_device_config(struct virtio_device *dev, uint32_t offset, uint32_t *ret_val)
+static inline bool virtio_blk_mmio_get_device_config(struct virtio_device *dev, uint32_t offset, uint32_t *ret_val)
 {
     struct virtio_blk_device *state = device_state(dev);
 
     uintptr_t config_base_addr = (uintptr_t)&state->config;
     uint32_t *config_field_addr = (uint32_t *)(config_base_addr + offset);
     *ret_val = *config_field_addr;
-    LOG_BLOCK("get device config with base_addr 0x%x and field_address 0x%x has value %d\n",
+    LOG_BLOCK("get device config with base_addr 0x%x and field_address 0x%x has "
+              "value %d\n",
               config_base_addr, config_field_addr, *ret_val);
 
     return true;
 }
 
-static bool virtio_blk_mmio_set_device_config(struct virtio_device *dev, uint32_t offset, uint32_t val)
+static inline bool virtio_blk_mmio_set_device_config(struct virtio_device *dev, uint32_t offset, uint32_t val)
 {
     struct virtio_blk_device *state = device_state(dev);
 
     uintptr_t config_base_addr = (uintptr_t)&state->config;
-    uintptr_t config_field_offset = (uintptr_t)offset;
-    uint32_t *config_field_addr = (uint32_t *)(config_base_addr + config_field_offset);
+    uint32_t *config_field_addr = (uint32_t *)(config_base_addr + offset);
     *config_field_addr = val;
-    LOG_BLOCK("set device config with base_addr 0x%x and field_address 0x%x with value %d\n",
+    LOG_BLOCK("set device config with base_addr 0x%x and field_address 0x%x with "
+              "value %d\n",
               config_base_addr, config_field_addr, val);
 
     return true;
 }
 
-static void virtio_blk_used_buffer(struct virtio_device *dev, uint16_t desc)
+static inline void virtio_blk_used_buffer(struct virtio_device *dev, uint16_t desc)
 {
     struct virtq *virtq = &dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].virtq;
     struct virtq_used_elem used_elem = {desc, 0};
@@ -134,14 +155,12 @@ static void virtio_blk_used_buffer(struct virtio_device *dev, uint16_t desc)
     virtq->used->idx++;
 }
 
-static bool virtio_blk_virq_inject(struct virtio_device *dev)
+static inline bool virtio_blk_virq_inject(struct virtio_device *dev)
 {
     return virq_inject(GUEST_VCPU_ID, dev->virq);
 }
 
-static void virtio_blk_set_interrupt_status(struct virtio_device *dev,
-                                            bool used_buffer,
-                                            bool config_change)
+static inline void virtio_blk_set_interrupt_status(struct virtio_device *dev, bool used_buffer, bool config_change)
 {
     /* Set the reason of the irq.
        bit 0: used buffer
@@ -149,350 +168,646 @@ static void virtio_blk_set_interrupt_status(struct virtio_device *dev,
     dev->regs.InterruptStatus = used_buffer | (config_change << 1);
 }
 
-/* Set response to virtio request to error */
-static void virtio_blk_set_req_fail(struct virtio_device *dev, uint16_t desc)
+static inline void virtio_blk_set_req_fail(struct virtio_device *dev, uint16_t desc)
 {
     struct virtq *virtq = &dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].virtq;
 
-    uint16_t curr_virtio_desc = desc;
-    for (; virtq->desc[curr_virtio_desc].flags & VIRTQ_DESC_F_NEXT;
-         curr_virtio_desc = virtq->desc[curr_virtio_desc].next) {}
-    *((uint8_t *)virtq->desc[curr_virtio_desc].addr) = VIRTIO_BLK_S_IOERR;
+    /* Loop to the final byte of the final descriptor and write response code
+     * there */
+    uint16_t curr_desc = desc;
+    while (virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT) {
+        curr_desc = virtq->desc[curr_desc].next;
+    }
+    assert(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_WRITE);
+    *(uint8_t *)(virtq->desc[curr_desc].addr + virtq->desc[curr_desc].len - 1) = VIRTIO_BLK_S_IOERR;
 }
 
-static void virtio_blk_set_req_success(struct virtio_device *dev, uint16_t desc)
+static inline void virtio_blk_set_req_success(struct virtio_device *dev, uint16_t desc)
 {
     struct virtq *virtq = &dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].virtq;
 
-    uint16_t curr_virtio_desc = desc;
-    for (; virtq->desc[curr_virtio_desc].flags & VIRTQ_DESC_F_NEXT;
-         curr_virtio_desc = virtq->desc[curr_virtio_desc].next) {}
-    *((uint8_t *)virtq->desc[curr_virtio_desc].addr) = VIRTIO_BLK_S_OK;
+    uint16_t curr_desc = desc;
+    while (virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT) {
+        curr_desc = virtq->desc[curr_desc].next;
+    }
+    assert(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_WRITE);
+    *(uint8_t *)(virtq->desc[curr_desc].addr + virtq->desc[curr_desc].len - 1) = VIRTIO_BLK_S_OK;
 }
 
-static bool sddf_make_req_check(struct virtio_blk_device *state, uint16_t sddf_count)
+static inline bool sddf_make_req_check(struct virtio_blk_device *state, uint16_t sddf_count)
 {
     /* Check if ialloc is full, if data region is full, if req queue is full.
        If these all pass then this request can be handled successfully */
+
+    /* A sanity check that all the maths checks out. <=2 because we have negotiated
+       with the driver to only send 1 4k segment at any given time. And 2 because such segment
+       can sit between 2 sDDF block transfer window. */
+    assert(sddf_count <= 2);
+
     if (ialloc_full(&state->ialloc)) {
-        LOG_BLOCK_ERR("Request bookkeeping array is full\n");
+        LOG_BLOCK("Request bookkeeping array is full\n");
         return false;
     }
 
     if (blk_queue_full_req(&state->queue_h)) {
-        LOG_BLOCK_ERR("Request queue is full\n");
+        LOG_BLOCK("Request queue is full\n");
         return false;
     }
 
     if (fsmalloc_full(&state->fsmalloc, sddf_count)) {
-        LOG_BLOCK_ERR("Data region is full\n");
+        LOG_BLOCK("Data region is full\n");
         return false;
     }
 
     return true;
 }
 
-static bool virtio_blk_mmio_queue_notify(struct virtio_device *dev)
+/* Returns true if both requests hit the same block */
+bool do_requests_overlap(reqbk_t *req1, reqbk_t *req2)
 {
-    /* If multiqueue feature bit negotiated, should read which queue from dev->QueueNotify,
-       but for now we just assume it's the one and only default queue */
+    uint32_t start1 = req1->sddf_block_number;
+    uint32_t end1 = start1 + req1->sddf_count - 1;
+    uint32_t start2 = req2->sddf_block_number;
+    uint32_t end2 = start2 + req2->sddf_count - 1;
+    return (start1 <= end2 && start2 <= end1);
+}
+
+bool request_is_write(reqbk_t *req)
+{
+    return req->state >= STATE_WRITING_ALIGNED;
+}
+
+static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_consumed)
+{
+    int err = 0;
+    /* If multiqueue feature bit negotiated, should read which queue from
+       dev->QueueNotify, but for now we just assume it's the one and only default
+       queue */
     virtio_queue_handler_t *vq = &dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ];
     struct virtq *virtq = &vq->virtq;
 
     struct virtio_blk_device *state = device_state(dev);
 
-    bool has_dropped = false; /* if any request has to be dropped due to any number of reasons, this becomes true */
+    /* If any request has to be dropped due to any number of reasons, such as an invalid req, this becomes
+     * true */
+    bool has_dropped = false;
+    int nums_consumed = 0;
 
-    /* get next available request to be handled */
-    uint16_t idx = vq->last_idx;
+    /* Handle available requests beginning from the last handled request */
+    uint16_t last_handled_avail_idx = vq->last_idx;
 
-    int err = 0;
-    LOG_BLOCK("------------- Driver notified device -------------\n");
-    for (; idx != virtq->avail->idx; idx++) {
-        uint16_t desc_head = virtq->avail->ring[idx % virtq->num];
+    LOG_BLOCK("------------- handle_client_requests start loop -------------\n");
+    for (; last_handled_avail_idx != virtq->avail->idx; last_handled_avail_idx++) {
+        uint16_t desc_head = virtq->avail->ring[last_handled_avail_idx % virtq->num];
+        uint16_t curr_desc = desc_head;
+        uint32_t curr_desc_bytes_read = 0;
 
-        uint16_t curr_desc_head = desc_head;
+        /* There are three parts with each block request. The header, body (which
+         * contains the data) and reply. */
+        uint32_t header_bytes_read = 0;
+        struct virtio_blk_outhdr virtio_req_header;
+        for (; header_bytes_read < sizeof(struct virtio_blk_outhdr); curr_desc = virtq->desc[curr_desc].next) {
+            /* Header is device read only */
+            assert(!(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_WRITE));
+            /* We can guarantee existence of next descriptor as footer is write only
+             */
+            assert(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT);
+            if (header_bytes_read + virtq->desc[curr_desc].len > sizeof(struct virtio_blk_outhdr)) {
+                void *src_addr = (void *)virtq->desc[curr_desc].addr;
+                void *dst_addr = (void *)&virtio_req_header;
+                uint32_t copy_sz = sizeof(struct virtio_blk_outhdr) - header_bytes_read;
+                memcpy(dst_addr, src_addr, copy_sz);
+                curr_desc_bytes_read = sizeof(struct virtio_blk_outhdr) - header_bytes_read;
+                header_bytes_read += sizeof(struct virtio_blk_outhdr) - header_bytes_read;
+                /* Don't go to the next descriptor yet, we're not done processing with
+                 * current one */
+                break;
+            } else {
+                void *src_addr = (void *)virtq->desc[curr_desc].addr;
+                void *dst_addr = (void *)&virtio_req_header;
+                uint32_t copy_sz = virtq->desc[curr_desc].len;
+                memcpy(dst_addr, src_addr, copy_sz);
+                header_bytes_read += virtq->desc[curr_desc].len;
+            }
+        }
 
-        /* Print out what the request type is */
-        struct virtio_blk_outhdr *virtio_req = (void *)virtq->desc[curr_desc_head].addr;
-        LOG_BLOCK("----- Request type is 0x%x -----\n", virtio_req->type);
+        LOG_BLOCK("----- Request type is 0x%x -----\n", virtio_req_header.type);
 
-        /* Parse different requests */
-        switch (virtio_req->type) {
-        /* There are three parts with each block request. The header, body (which contains the data) and reply. */
+        switch (virtio_req_header.type) {
         case VIRTIO_BLK_T_IN: {
             LOG_BLOCK("Request type is VIRTIO_BLK_T_IN\n");
-            LOG_BLOCK("Sector (read/write offset) is %d\n", virtio_req->sector);
+            LOG_BLOCK("Sector (read/write offset) is %d\n", virtio_req_header.sector);
 
-            curr_desc_head = virtq->desc[curr_desc_head].next;
-            LOG_BLOCK("Descriptor index is %d, Descriptor flags are: 0x%x, length is 0x%x\n", curr_desc_head,
-                      (uint16_t)virtq->desc[curr_desc_head].flags, virtq->desc[curr_desc_head].len);
+            /* Converting virtio sector number to sddf block number, we are rounding
+             * down */
+            uint32_t sddf_block_number = (virtio_req_header.sector * VIRTIO_BLK_SECTOR_SIZE) / BLK_TRANSFER_SIZE;
 
-            /* Converting virtio sector number to sddf block number, we are rounding down */
-            uint64_t sddf_block_number = (virtio_req->sector * VIRTIO_BLK_SECTOR_SIZE) / BLK_TRANSFER_SIZE;
-            /* Converting bytes to the number of blocks, we are rounding up */
-            uint16_t sddf_count = (virtq->desc[curr_desc_head].len + BLK_TRANSFER_SIZE - 1) / BLK_TRANSFER_SIZE;
-
-            if (!sddf_make_req_check(state, sddf_count)) {
-                virtio_blk_set_req_fail(dev, desc_head);
-                has_dropped = true;
-                break;
+            /* Figure out how many bytes are in the body of the request */
+            uint32_t body_size_bytes = 0;
+            uint32_t tmp_curr_desc_bytes_read = curr_desc_bytes_read;
+            for (uint16_t tmp_curr_desc = curr_desc; virtq->desc[tmp_curr_desc].flags & VIRTQ_DESC_F_NEXT;
+                 tmp_curr_desc = virtq->desc[tmp_curr_desc].next) {
+                if (tmp_curr_desc_bytes_read != 0) {
+                    body_size_bytes += virtq->desc[tmp_curr_desc].len - tmp_curr_desc_bytes_read;
+                    tmp_curr_desc_bytes_read = 0;
+                } else {
+                    body_size_bytes += virtq->desc[tmp_curr_desc].len;
+                }
+                if (!(virtq->desc[tmp_curr_desc].flags & VIRTQ_DESC_F_WRITE)
+                    || virtq->desc[tmp_curr_desc].len < VIRTIO_BLK_SECTOR_SIZE) {
+                    break;
+                }
             }
 
-            /* Allocate data buffer from data region based on sddf_count */
-            uintptr_t sddf_data;
-            fsmalloc_alloc(&state->fsmalloc, &sddf_data, sddf_count);
+            /* Figure out whether the guest's read request spills over to the next 4k transfer window */
+            uint32_t num_sectors = body_size_bytes / VIRTIO_BLK_SECTOR_SIZE;
+            uint32_t sddf_count = (body_size_bytes + BLK_TRANSFER_SIZE - 1) / BLK_TRANSFER_SIZE;
+            if (((virtio_req_header.sector % SECTORS_IN_TRANSFER_WINDOW) + num_sectors) > SECTORS_IN_TRANSFER_WINDOW) {
+                sddf_count++;
+            }
 
-            /* Bookkeep the virtio sddf block size translation */
-            uintptr_t virtio_data = sddf_data + (virtio_req->sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE;
-            uintptr_t virtio_data_size = virtq->desc[curr_desc_head].len;
+            if (!sddf_make_req_check(state, sddf_count)) {
+                /* One of the book-keeping structure or the data region is full */
+                goto stop_processing;
+            }
 
-            /* Book keep the request */
+            /* Allocate data cells from sddf data region based on sddf_count */
+            uintptr_t sddf_data_cell_base;
+            fsmalloc_alloc(&state->fsmalloc, &sddf_data_cell_base, sddf_count);
+
+            /* Find address within the data cells for reading/writing virtio data */
+            uintptr_t sddf_data = sddf_data_cell_base
+                                + (virtio_req_header.sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE;
+
+            /* Generate sddf request id and bookkeep the request */
             uint32_t req_id;
-            ialloc_alloc(&state->ialloc, &req_id);
-            state->reqbk[req_id] = (reqbk_t) {
-                desc_head, sddf_data, sddf_count, sddf_block_number,
-                           virtio_data, virtio_data_size, 0
-            };
-
-            uintptr_t offset = sddf_data - ((struct virtio_blk_device *)dev->device_data)->data_region;
-            err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, offset, sddf_block_number, sddf_count, req_id);
+            err = ialloc_alloc(&state->ialloc, &req_id);
             assert(!err);
+            assert(!state->reqsbk[req_id].valid);
+
+            state->reqsbk[req_id] =
+                (reqbk_t) { true,      desc_head,       sddf_data_cell_base, sddf_count, sddf_block_number,
+                            sddf_data, body_size_bytes, STATE_READING };
+
+            uintptr_t sddf_offset = sddf_data_cell_base - ((struct virtio_blk_device *)dev->device_data)->data_region;
+            err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset, sddf_block_number, sddf_count, req_id);
+            nums_consumed += 1;
+            assert(!err);
+
+            LOG_BLOCK("send read sector %u, sddf block %u, body size %u, data off %u, nums block %u, virtio desc %u\n",
+                      virtio_req_header.sector, sddf_block_number, body_size_bytes,
+                      (virtio_req_header.sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE, sddf_count, curr_desc);
+
             break;
         }
         case VIRTIO_BLK_T_OUT: {
             LOG_BLOCK("Request type is VIRTIO_BLK_T_OUT\n");
-            LOG_BLOCK("Sector (read/write offset) is %d\n", virtio_req->sector);
+            LOG_BLOCK("Sector (read/write offset) is %d, curr_desc is %u\n", virtio_req_header.sector, curr_desc);
 
-            curr_desc_head = virtq->desc[curr_desc_head].next;
-            LOG_BLOCK("Descriptor index is %d, Descriptor flags are: 0x%x, length is 0x%x\n", curr_desc_head,
-                      (uint16_t)virtq->desc[curr_desc_head].flags, virtq->desc[curr_desc_head].len);
+            /* Converting virtio sector number to sddf block number, we are rounding
+             * down */
+            uint32_t sddf_block_number = (virtio_req_header.sector * VIRTIO_BLK_SECTOR_SIZE) / BLK_TRANSFER_SIZE;
+            LOG_BLOCK("sddf_block_number is %u\n", sddf_block_number);
 
-            /* Converting virtio sector number to sddf block number, we are rounding down */
-            uint64_t sddf_block_number = (virtio_req->sector * VIRTIO_BLK_SECTOR_SIZE) / BLK_TRANSFER_SIZE;
-            /* Converting bytes to the number of blocks, we are rounding up */
-            uint16_t sddf_count = (virtq->desc[curr_desc_head].len + BLK_TRANSFER_SIZE - 1) / BLK_TRANSFER_SIZE;
-
-            bool aligned = ((virtio_req->sector % (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)) == 0);
-
-            /* If the write request is not aligned to the sddf transfer size, we need to do a read-modify-write:
-            we need to first read the surrounding aligned memory, overwrite that read memory on the unaligned areas
-            we want write to, and then write the entire memory back to disk. */
-            if (!aligned) {
-                if (!sddf_make_req_check(state, sddf_count)) {
-                    virtio_blk_set_req_fail(dev, desc_head);
-                    has_dropped = true;
+            /* Figure out how many bytes are in the body of the request */
+            uint32_t body_size_bytes = 0;
+            uint32_t tmp_curr_desc_bytes_read = curr_desc_bytes_read;
+            for (uint16_t tmp_curr_desc = curr_desc; virtq->desc[tmp_curr_desc].flags & VIRTQ_DESC_F_NEXT;
+                 tmp_curr_desc = virtq->desc[tmp_curr_desc].next) {
+                if (tmp_curr_desc_bytes_read != 0) {
+                    body_size_bytes += virtq->desc[tmp_curr_desc].len - tmp_curr_desc_bytes_read;
+                    tmp_curr_desc_bytes_read = 0;
+                } else {
+                    body_size_bytes += virtq->desc[tmp_curr_desc].len;
+                }
+                if (!(virtq->desc[tmp_curr_desc].flags & VIRTQ_DESC_F_WRITE)
+                    || virtq->desc[tmp_curr_desc].len < VIRTIO_BLK_SECTOR_SIZE) {
                     break;
                 }
+            }
+            LOG_BLOCK("body_size_bytes is %u\n", body_size_bytes);
 
-                /* Allocate data buffer from data region based on sddf_count */
-                uintptr_t sddf_data;
-                fsmalloc_alloc(&state->fsmalloc, &sddf_data, sddf_count);
+            /* Figure out whether the guest's write request spills over to the next 4k transfer window */
+            uint32_t num_sectors = body_size_bytes / VIRTIO_BLK_SECTOR_SIZE;
+            uint32_t sddf_count = (body_size_bytes + BLK_TRANSFER_SIZE - 1) / BLK_TRANSFER_SIZE;
+            if (((virtio_req_header.sector % SECTORS_IN_TRANSFER_WINDOW) + num_sectors) > SECTORS_IN_TRANSFER_WINDOW) {
+                sddf_count++;
+            }
 
-                /* Bookkeep the virtio sddf block size translation */
-                uintptr_t virtio_data = sddf_data + (virtio_req->sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE;
-                uintptr_t virtio_data_size = virtq->desc[curr_desc_head].len;
+            LOG_BLOCK("sddf_count is %u\n", sddf_count);
 
-                /* Book keep the request */
-                uint32_t req_id;
-                ialloc_alloc(&state->ialloc, &req_id);
-                state->reqbk[req_id] = (reqbk_t) {
-                    desc_head, sddf_data, sddf_count, sddf_block_number,
-                               virtio_data, virtio_data_size, aligned
-                };
+            if (!sddf_make_req_check(state, sddf_count)) {
+                LOG_BLOCK("write: data region full at sector %u, body bytes %u, sddf count %u\n",
+                          virtio_req_header.sector, body_size_bytes, sddf_count);
+                goto stop_processing;
+            }
 
-                uintptr_t offset = sddf_data - ((struct virtio_blk_device *)dev->device_data)->data_region;
-                err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, offset, sddf_block_number, sddf_count, req_id);
-                assert(!err);
+            /* If the write request is not aligned on the sddf transfer window, we need
+             * to do a read-modify-write: we need to first read the surrounding
+             * memory, overwrite the memory on the unaligned areas, and then write the
+             * entire memory back to disk.
+             */
+            bool aligned = true;
+            if (body_size_bytes % BLK_TRANSFER_SIZE != 0) {
+                aligned = false;
             } else {
-                if (!sddf_make_req_check(state, sddf_count)) {
-                    virtio_blk_set_req_fail(dev, desc_head);
-                    has_dropped = true;
-                    break;
+                aligned = ((virtio_req_header.sector % (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)) == 0);
+            }
+
+            LOG_BLOCK("aligned is %d, \n", aligned);
+
+            if (!aligned) {
+                /* Allocate data buffer from data region based on sddf_count */
+                uintptr_t sddf_data_cell_base;
+                assert(fsmalloc_alloc(&state->fsmalloc, &sddf_data_cell_base, sddf_count) == 0);
+
+                /* Find address within the data cells for reading/writing virtio data */
+                uintptr_t sddf_data = sddf_data_cell_base
+                                    + (virtio_req_header.sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE;
+                LOG_BLOCK("not aligned, sddf_data offset is %u\n",
+                          (virtio_req_header.sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE);
+
+                /* Generate sddf request id and bookkeep the request */
+                uint32_t req_id;
+                assert(!ialloc_alloc(&state->ialloc, &req_id));
+                assert(!state->reqsbk[req_id].valid);
+                state->reqsbk[req_id] =
+                    (reqbk_t) { true,      desc_head,       sddf_data_cell_base, sddf_count, sddf_block_number,
+                                sddf_data, body_size_bytes, STATE_RMW_READING };
+
+                /* Before we actually do anything, double check whether we are already handling
+                   an unaligned write op on that sDDF block to prevent data race. */
+                bool process = true;
+                for (int i = 0; i < SDDF_MAX_QUEUE_CAPACITY; i++) {
+                    if (i != req_id && state->reqsbk[i].valid
+                        && do_requests_overlap(&state->reqsbk[i], &state->reqsbk[req_id])
+                        && request_is_write(&state->reqsbk[i])) {
+
+                        LOG_BLOCK("not aligned and found another req inflight, queueing, this req id is %u\n", req_id);
+                        process = false;
+                        break;
+                    }
                 }
 
+                if (process) {
+                    LOG_BLOCK("not aligned and NOT found another unaligned req inflight, sending read\n");
+                    uintptr_t sddf_offset = sddf_data_cell_base
+                                          - ((struct virtio_blk_device *)dev->device_data)->data_region;
+                    err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset, sddf_block_number, sddf_count,
+                                          req_id);
+                    nums_consumed += 1;
+                    assert(!err);
+                } else {
+                    state->reqsbk[req_id].state = STATE_RMW_QUEUEING;
+                }
+            } else {
+                /* Handle normal write request */
                 /* Allocate data buffer from data region based on sddf_count */
-                uintptr_t sddf_data;
-                fsmalloc_alloc(&state->fsmalloc, &sddf_data, sddf_count);
+                uintptr_t sddf_data_cell_base;
+                assert(fsmalloc_alloc(&state->fsmalloc, &sddf_data_cell_base, sddf_count) == 0);
+                /* Find address within the data cells for reading/writing virtio data */
+                uintptr_t sddf_data = sddf_data_cell_base
+                                    + (virtio_req_header.sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE;
 
-                /* Bookkeep the virtio sddf block size translation */
-                uintptr_t virtio_data = sddf_data + (virtio_req->sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE;
-                uintptr_t virtio_data_size = virtq->desc[curr_desc_head].len;
+                /* Copy data from virtio buffer to sddf buffer */
+                uint32_t body_bytes_read = 0;
+                for (; body_bytes_read < body_size_bytes; curr_desc = virtq->desc[curr_desc].next) {
+                    /* For write requests, the body is a read descriptor, and the footer
+                     * is a write descriptor, we know there must be a descriptor cut-off
+                     * at the end.
+                     */
+                    assert(body_bytes_read + virtq->desc[curr_desc].len <= body_size_bytes);
+                    assert(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT);
+                    if (curr_desc_bytes_read != 0) {
+                        void *src_addr = (void *)virtq->desc[curr_desc].addr + curr_desc_bytes_read;
+                        void *dst_addr = (void *)sddf_data + body_bytes_read;
+                        uint32_t copy_sz = virtq->desc[curr_desc].len - curr_desc_bytes_read;
+                        memcpy(dst_addr, src_addr, copy_sz);
+                        body_bytes_read += virtq->desc[curr_desc].len - curr_desc_bytes_read;
+                        curr_desc_bytes_read = 0;
+                    } else {
+                        void *src_addr = (void *)virtq->desc[curr_desc].addr;
+                        void *dst_addr = (void *)sddf_data + body_bytes_read;
+                        uint32_t copy_sz = virtq->desc[curr_desc].len;
+                        memcpy(dst_addr, src_addr, copy_sz);
+                        body_bytes_read += virtq->desc[curr_desc].len;
+                    }
+                }
 
-                /* Book keep the request */
+                /* Generate sddf request id and bookkeep the request */
                 uint32_t req_id;
-                ialloc_alloc(&state->ialloc, &req_id);
-                state->reqbk[req_id] = (reqbk_t) {
-                    desc_head, sddf_data, sddf_count, sddf_block_number,
-                               virtio_data, virtio_data_size, aligned
-                };
+                assert(!ialloc_alloc(&state->ialloc, &req_id));
+                assert(!state->reqsbk[req_id].valid);
+                state->reqsbk[req_id] =
+                    (reqbk_t) { true,      desc_head,       sddf_data_cell_base,  sddf_count, sddf_block_number,
+                                sddf_data, body_size_bytes, STATE_WRITING_ALIGNED };
 
-                /* Copy data from virtio buffer to data buffer, create sddf write request and initialise it with data buffer */
-                memcpy((void *)sddf_data, (void *)virtq->desc[curr_desc_head].addr, virtq->desc[curr_desc_head].len);
-
-                uintptr_t offset = sddf_data - ((struct virtio_blk_device *)dev->device_data)->data_region;
-                err = blk_enqueue_req(&state->queue_h, BLK_REQ_WRITE, offset, sddf_block_number, sddf_count, req_id);
+                uintptr_t sddf_offset = sddf_data_cell_base
+                                      - ((struct virtio_blk_device *)dev->device_data)->data_region;
+                err = blk_enqueue_req(&state->queue_h, BLK_REQ_WRITE, sddf_offset, sddf_block_number, sddf_count,
+                                      req_id);
+                nums_consumed += 1;
                 assert(!err);
+                LOG_BLOCK("send normal write sector %u, sddf block %u, body size %u, data off %u, nums block %u, "
+                          "virtio desc %u\n",
+                          virtio_req_header.sector, sddf_block_number, body_size_bytes,
+                          (virtio_req_header.sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE, sddf_count,
+                          curr_desc);
             }
             break;
         }
         case VIRTIO_BLK_T_FLUSH: {
             LOG_BLOCK("Request type is VIRTIO_BLK_T_FLUSH\n");
-
             if (!sddf_make_req_check(state, 0)) {
-                virtio_blk_set_req_fail(dev, desc_head);
-                has_dropped = true;
-                break;
+                goto stop_processing;
             }
 
-            /* Book keep the request */
+            /* Bookkeep the request */
             uint32_t req_id;
             ialloc_alloc(&state->ialloc, &req_id);
             /* except for virtio desc, nothing else needs to be retrieved later
              * so leave as 0 */
-            state->reqbk[req_id] = (reqbk_t) {
-                desc_head, 0, 0, 0, 0, 0
-            };
+            state->reqsbk[req_id] = (reqbk_t) { true, desc_head, 0, 0, 0, 0, 0, STATE_FLUSHING };
 
             err = blk_enqueue_req(&state->queue_h, BLK_REQ_FLUSH, 0, 0, 0, req_id);
+            nums_consumed += 1;
             break;
         }
         default: {
-            LOG_BLOCK_ERR(
-                "Handling VirtIO block request, but virtIO request type is not recognised: %d\n",
-                virtio_req->type);
-            virtio_blk_set_req_fail(dev, desc_head);
+            LOG_BLOCK_ERR("Handling VirtIO block request, but virtIO request type is "
+                          "not recognised: %d\n",
+                          virtio_req_header.type);
+            virtio_blk_set_req_fail(dev, curr_desc);
             has_dropped = true;
             break;
         }
         }
     }
 
+stop_processing:
+    *num_reqs_consumed = nums_consumed;
+
     /* Update virtq index to the next available request to be handled */
-    vq->last_idx = idx;
+    vq->last_idx = last_handled_avail_idx;
 
-    bool success = true;
+    return !has_dropped;
+}
 
-    /* If any request has to be dropped due to any number of reasons, we inject an interrupt */
-    if (has_dropped) {
+static bool virtio_blk_mmio_queue_notify(struct virtio_device *dev)
+{
+    int nums_consumed = 0;
+    LOG_BLOCK("virtio_blk_mmio_queue_notify calling handle_client_requests\n");
+    bool consumption_status = handle_client_requests(dev, &nums_consumed);
+
+    bool virq_inject_success = true;
+    if (!consumption_status) {
+        LOG_BLOCK("virtio_blk_mmio_queue_notify dropped requests\n");
         virtio_blk_set_interrupt_status(dev, true, false);
-        success = virtio_blk_virq_inject(dev);
+        virq_inject_success = virtio_blk_virq_inject(dev);
     }
 
-    if (!blk_queue_plugged_req(&state->queue_h)) {
-        /* there is a world where all requests to be handled during this batch
-         * are dropped and hence this notify to the other PD would be redundant */
+    struct virtio_blk_device *state = device_state(dev);
+    if (nums_consumed && !blk_queue_plugged_req(&state->queue_h)) {
+        LOG_BLOCK("virtio_blk_mmio_queue_notify notified virt\n");
         microkit_notify(state->server_ch);
     }
 
-    return success;
+    return virq_inject_success;
 }
 
 bool virtio_blk_handle_resp(struct virtio_blk_device *state)
 {
+    LOG_BLOCK(" ----------- Blk virt notified VMM ----------- \n");
+
+    int err = 0;
     struct virtio_device *dev = &state->virtio_device;
 
     blk_resp_status_t sddf_ret_status;
     uint16_t sddf_ret_success_count;
     uint32_t sddf_ret_id;
 
-    bool handled = false;
-    int err = 0;
+    bool virt_notify = false;
+    bool resp_handled = false;
+    bool read_write_modify_inflight = false;
     while (!blk_queue_empty_resp(&state->queue_h)) {
-        err = blk_dequeue_resp(&state->queue_h,
-                               &sddf_ret_status,
-                               &sddf_ret_success_count,
-                               &sddf_ret_id);
+        err = blk_dequeue_resp(&state->queue_h, &sddf_ret_status, &sddf_ret_success_count, &sddf_ret_id);
         assert(!err);
 
-        /* Freeing and retrieving data store */
-        reqbk_t *data = &state->reqbk[sddf_ret_id];
-        ialloc_free(&state->ialloc, sddf_ret_id);
+        /* Retrieve request bookkeep information */
+        reqbk_t *reqbk = &state->reqsbk[sddf_ret_id];
 
         struct virtq *virtq = &dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].virtq;
 
-        struct virtio_blk_outhdr *virtio_req = (void *)virtq->desc[data->virtio_desc_head].addr;
+        uint16_t curr_desc = reqbk->virtio_desc_head;
+        uint32_t curr_desc_bytes_read = 0;
 
-        uint16_t curr_virtio_desc = virtq->desc[data->virtio_desc_head].next;
+        uint32_t header_bytes_read = 0;
+        struct virtio_blk_outhdr virtio_req_header;
+        for (; header_bytes_read < sizeof(struct virtio_blk_outhdr); curr_desc = virtq->desc[curr_desc].next) {
+            /* Header is device read only */
+            assert(!(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_WRITE));
+            /* We can always guarantee existence of next descriptor as footer is write
+             * only */
+            assert(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT);
+            if (header_bytes_read + virtq->desc[curr_desc].len > sizeof(struct virtio_blk_outhdr)) {
+                void *src_addr = (void *)virtq->desc[curr_desc].addr;
+                void *dst_addr = (void *)&virtio_req_header;
+                uint32_t copy_sz = sizeof(struct virtio_blk_outhdr) - header_bytes_read;
+                memcpy(dst_addr, src_addr, copy_sz);
+                curr_desc_bytes_read = sizeof(struct virtio_blk_outhdr) - header_bytes_read;
+                header_bytes_read += sizeof(struct virtio_blk_outhdr) - header_bytes_read;
+                /* Don't go to the next descriptor yet, we're not done processing with
+                 * current one */
+                break;
+            } else {
+                void *src_addr = (void *)virtq->desc[curr_desc].addr;
+                void *dst_addr = (void *)&virtio_req_header;
+                uint32_t copy_sz = virtq->desc[curr_desc].len;
+                memcpy(dst_addr, src_addr, copy_sz);
+                header_bytes_read += virtq->desc[curr_desc].len;
+            }
+        }
 
         bool resp_success = false;
         if (sddf_ret_status == BLK_RESP_OK) {
             resp_success = true;
-            switch (virtio_req->type) {
+            switch (virtio_req_header.type) {
             case VIRTIO_BLK_T_IN: {
-                memcpy((void *)virtq->desc[curr_virtio_desc].addr,
-                       (void *)data->virtio_data, data->virtio_data_size);
+                uint32_t data_off = reqbk->sddf_data - reqbk->sddf_data_cell_base;
+                LOG_BLOCK("resp read sector %u, sddf block %u, body size %u, data off %u\n", virtio_req_header.sector,
+                          reqbk->sddf_block_number, reqbk->virtio_body_size_bytes, data_off);
+                assert(reqbk->sddf_data_cell_base + data_off == reqbk->sddf_data);
+
+                /* Going from read (header) to write (body) descriptor, there should be
+                 * a descriptor cut-off at the beginning. */
+                assert(curr_desc_bytes_read == 0);
+                uint32_t body_bytes_read = 0;
+                for (; body_bytes_read < reqbk->virtio_body_size_bytes; curr_desc = virtq->desc[curr_desc].next) {
+                    if (body_bytes_read + virtq->desc[curr_desc].len > reqbk->virtio_body_size_bytes) {
+                        void *src_addr = (void *)reqbk->sddf_data + body_bytes_read;
+                        void *dst_addr = (void *)virtq->desc[curr_desc].addr;
+                        uint32_t copy_sz = reqbk->virtio_body_size_bytes - body_bytes_read;
+                        memcpy(dst_addr, src_addr, copy_sz);
+                        body_bytes_read += reqbk->virtio_body_size_bytes - body_bytes_read;
+                        /* This is the final descriptor if we get into this condition, don't
+                        //  * go to next descriptor */
+                        LOG_BLOCK("virtq->desc[curr_desc].len: %d\n", virtq->desc[curr_desc].len);
+                        assert(!(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT));
+                        break;
+                    } else {
+                        void *src_addr = (void *)reqbk->sddf_data + body_bytes_read;
+                        void *dst_addr = (void *)virtq->desc[curr_desc].addr;
+                        uint32_t copy_sz = virtq->desc[curr_desc].len;
+                        memcpy(dst_addr, src_addr, copy_sz);
+
+                        body_bytes_read += virtq->desc[curr_desc].len;
+                        /* Because there is still the footer, we are guaranteed next
+                         * descriptor exists */
+                        assert(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT);
+                    }
+                }
                 break;
             }
             case VIRTIO_BLK_T_OUT: {
-                if (!data->aligned) {
-                    /* Copy the write data into an offset into the allocated sddf data buffer */
-                    memcpy((void *)data->virtio_data,
-                           (void *)virtq->desc[curr_virtio_desc].addr,
-                           data->virtio_data_size);
+                if (reqbk->state == STATE_RMW_READING) {
+                    LOG_BLOCK("resp read-to-write sector %u, sddf block %u, body size %u, data off %u, sddf_cell_base "
+                              "0x%x, virtio desc %u\n",
+                              virtio_req_header.sector, reqbk->sddf_block_number, reqbk->virtio_body_size_bytes,
+                              reqbk->sddf_data - reqbk->sddf_data_cell_base, reqbk->sddf_data_cell_base, curr_desc);
+                    /* Handling read-modify-write procedure, copy virtio write data to the
+                     * correct offset in the same sddf data region allocated to do the
+                     * surrounding read.
+                     */
+                    uint32_t body_bytes_read = 0;
+                    for (; body_bytes_read < reqbk->virtio_body_size_bytes; curr_desc = virtq->desc[curr_desc].next) {
+                        /* For write requests, the body is a read descriptor and the footer
+                         * is a write descriptor, there must be a descriptor cut-off at the
+                         * end
+                         */
+                        assert(body_bytes_read + virtq->desc[curr_desc].len <= reqbk->virtio_body_size_bytes);
+                        assert(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT);
+                        if (curr_desc_bytes_read != 0) {
+                            void *src_addr = (void *)virtq->desc[curr_desc].addr + curr_desc_bytes_read;
+                            void *dst_addr = (void *)reqbk->sddf_data + body_bytes_read;
+                            uint32_t copy_sz = virtq->desc[curr_desc].len - curr_desc_bytes_read;
+                            memcpy(dst_addr, src_addr, copy_sz);
+                            body_bytes_read += virtq->desc[curr_desc].len - curr_desc_bytes_read;
+                            curr_desc_bytes_read = 0;
+                        } else {
+                            void *src_addr = (void *)virtq->desc[curr_desc].addr;
+                            void *dst_addr = (void *)reqbk->sddf_data + body_bytes_read;
+                            uint32_t copy_sz = virtq->desc[curr_desc].len;
+                            memcpy(dst_addr, src_addr, copy_sz);
+                            body_bytes_read += virtq->desc[curr_desc].len;
+                        }
+                    }
 
-                    uint32_t new_sddf_id;
-                    ialloc_alloc(&state->ialloc, &new_sddf_id);
-                    state->reqbk[new_sddf_id] = (reqbk_t) {
-                        data->virtio_desc_head,
-                             data->sddf_data, data->sddf_count,
-                             data->sddf_block_number, 0, 0, true
-                    };
-
-                    err = blk_enqueue_req(&state->queue_h,
-                                          BLK_REQ_WRITE,
-                                          data->sddf_data - state->data_region,
-                                          data->sddf_block_number,
-                                          data->sddf_count,
-                                          new_sddf_id);
+                    state->reqsbk[sddf_ret_id].state = STATE_RMW_WRITING;
+                    err = blk_enqueue_req(&state->queue_h, BLK_REQ_WRITE,
+                                          reqbk->sddf_data_cell_base
+                                              - ((struct virtio_blk_device *)dev->device_data)->data_region,
+                                          reqbk->sddf_block_number, reqbk->sddf_count, sddf_ret_id);
                     assert(!err);
-                    microkit_notify(state->server_ch);
+                    virt_notify = true;
+                    read_write_modify_inflight = true;
+                    /* The virtIO request is not complete yet so we don't tell the driver
+                     * (just skip over to next request) */
+
                     continue;
+                } else {
+                    LOG_BLOCK(
+                        "resp write complete sector %u, sddf block %u, body size %u, data off %u, virtio desc %u\n",
+                        virtio_req_header.sector, reqbk->sddf_block_number, reqbk->virtio_body_size_bytes,
+                        reqbk->sddf_data - reqbk->sddf_data_cell_base, curr_desc);
                 }
                 break;
             }
             case VIRTIO_BLK_T_FLUSH:
                 break;
             default: {
-                LOG_BLOCK_ERR(
-                    "Retrieving sDDF block response, but virtIO request type is not recognised: %d\n",
-                    virtio_req->type);
+                LOG_BLOCK_ERR("Retrieving sDDF block response, but virtIO request type "
+                              "is not recognised: %d\n",
+                              virtio_req_header.type);
                 resp_success = false;
                 break;
             }
             }
+
+            if (reqbk->state == STATE_WRITING_ALIGNED || reqbk->state == STATE_RMW_WRITING) {
+                /* If we get here, we've just finished processing a normal or unaligned write. Now check
+                   which request is queueing on the same sDDF block we touched and process it. */
+                for (int i = 0; i < SDDF_MAX_QUEUE_CAPACITY; i++) {
+                    if (state->reqsbk[i].valid && state->reqsbk[i].state == STATE_RMW_QUEUEING
+                        && do_requests_overlap(&(state->reqsbk[i]), reqbk)) {
+
+                        state->reqsbk[i].state = STATE_RMW_READING;
+                        uintptr_t next_sddf_offset = state->reqsbk[i].sddf_data_cell_base
+                                                   - ((struct virtio_blk_device *)dev->device_data)->data_region;
+
+                        err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, next_sddf_offset,
+                                              state->reqsbk[i].sddf_block_number, state->reqsbk[i].sddf_count, i);
+                        assert(!err);
+
+                        virt_notify = true;
+                        read_write_modify_inflight = true;
+                        break;
+                    }
+                }
+            }
         }
 
         if (resp_success) {
-            virtio_blk_set_req_success(dev, data->virtio_desc_head);
+            virtio_blk_set_req_success(dev, reqbk->virtio_desc_head);
         } else {
-            virtio_blk_set_req_fail(dev, data->virtio_desc_head);
+            virtio_blk_set_req_fail(dev, reqbk->virtio_desc_head);
         }
 
         /* Free corresponding bookkeeping structures regardless of the request's
-         * success status */
-        if (virtio_req->type == VIRTIO_BLK_T_IN || virtio_req->type == VIRTIO_BLK_T_OUT) {
-            fsmalloc_free(&state->fsmalloc, data->sddf_data, data->sddf_count);
+         * success status.
+         */
+        if (virtio_req_header.type == VIRTIO_BLK_T_IN || virtio_req_header.type == VIRTIO_BLK_T_OUT) {
+
+            LOG_BLOCK("freeing fs buff for sector %u\n", virtio_req_header.sector);
+            fsmalloc_free(&state->fsmalloc, reqbk->sddf_data_cell_base, reqbk->sddf_count);
         }
 
-        virtio_blk_used_buffer(dev, data->virtio_desc_head);
+        virtio_blk_used_buffer(dev, reqbk->virtio_desc_head);
 
-        handled = true;
+        reqbk->valid = false;
+        err = ialloc_free(&state->ialloc, sddf_ret_id);
+        assert(!err);
+
+        resp_handled = true;
     }
 
-    bool success = true;
+    int nums_pending_cmds_consumed = 0;
+    if (!read_write_modify_inflight) {
+        LOG_BLOCK("virtio_blk_handle_resp calling handle_client_requests\n");
+        handle_client_requests(dev, &nums_pending_cmds_consumed);
+        LOG_BLOCK("handle_client_requests consumed %d reqs\n", nums_pending_cmds_consumed);
+        if (nums_pending_cmds_consumed) {
+            virt_notify = true;
+        }
+    }
 
-    /* We need to know if we handled any responses, if we did we inject an
-     * interrupt, if we didn't we don't inject */
-    if (handled) {
+    /* We need to know if we've finished handling all the requests in the previous cycle, if we did, we inject an
+     * interrupt, if we didn't we don't inject.
+     */
+    bool virq_inject_success = true;
+    if (resp_handled && !read_write_modify_inflight && !virt_notify) {
         virtio_blk_set_interrupt_status(dev, true, false);
-        success = virtio_blk_virq_inject(dev);
+        virq_inject_success = virtio_blk_virq_inject(dev);
     }
 
-    return success;
+    if (virt_notify) {
+        LOG_BLOCK("virtio_blk_handle_resp virt notify\n");
+        microkit_notify(state->server_ch);
+    }
+
+    return virq_inject_success;
 }
 
-static void virtio_blk_config_init(struct virtio_blk_device *blk_dev)
+static inline void virtio_blk_config_init(struct virtio_blk_device *blk_dev)
 {
     blk_storage_info_t *storage_info = blk_dev->storage_info;
 
@@ -502,6 +817,18 @@ static void virtio_blk_config_init(struct virtio_blk_device *blk_dev)
     } else {
         blk_dev->config.blk_size = storage_info->sector_size;
     }
+
+    /* Restrict the guest driver to only send 1x 4K segment per request at any given time.
+    This is to prevent internal fragmentation within the data region, leading to a deadlock
+    where we can't handle large requests when the free cells in the data region isn't contiguous. */
+    blk_dev->config.size_max = BLK_TRANSFER_SIZE;
+    blk_dev->config.seg_max = 1;
+
+    blk_dev->config.topology.physical_block_exp =
+        3; // 2^3 = 8 logical blocks in 1 physical block (sDDF transfer window)
+    blk_dev->config.topology.alignment_offset = 0;
+    blk_dev->config.topology.min_io_size = 8;
+    blk_dev->config.topology.opt_io_size = blk_dev->config.topology.min_io_size;
 }
 
 static virtio_device_funs_t functions = {
@@ -515,7 +842,7 @@ static virtio_device_funs_t functions = {
 
 static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, size_t virq, uintptr_t data_region,
                                              size_t data_region_size, blk_storage_info_t *storage_info,
-                                             blk_queue_handle_t *queue_h, int server_ch)
+                                             blk_queue_handle_t *queue_h, uint32_t queue_capacity, int server_ch)
 {
     struct virtio_device *dev = &blk_dev->virtio_device;
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_BLOCK;
@@ -529,45 +856,41 @@ static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, 
     blk_dev->storage_info = storage_info;
     blk_dev->queue_h = *queue_h;
     blk_dev->data_region = data_region;
+    blk_dev->queue_capacity = queue_capacity;
     blk_dev->server_ch = server_ch;
 
-    size_t sddf_data_buffers = data_region_size / BLK_TRANSFER_SIZE;
-    /* This assert is necessary as the bookkeeping data structures need to have a
-     * defined size at compile time and that depends on the number of buffers
-     * passed to us during initialisation. */
-    assert(sddf_data_buffers <= SDDF_MAX_DATA_BUFFERS);
+    size_t num_sddf_cells = (data_region_size / BLK_TRANSFER_SIZE) < SDDF_MAX_DATA_CELLS
+                              ? (data_region_size / BLK_TRANSFER_SIZE)
+                              : SDDF_MAX_DATA_CELLS;
+
+    assert(num_sddf_cells == queue_capacity);
 
     virtio_blk_config_init(blk_dev);
 
-    fsmalloc_init(&blk_dev->fsmalloc,
-                  data_region,
-                  BLK_TRANSFER_SIZE,
-                  sddf_data_buffers,
-                  &blk_dev->fsmalloc_avail_bitarr,
-                  blk_dev->fsmalloc_avail_bitarr_words,
-                  roundup_bits2words64(sddf_data_buffers));
+    fsmalloc_init(&blk_dev->fsmalloc, data_region, BLK_TRANSFER_SIZE, num_sddf_cells, &blk_dev->fsmalloc_avail_bitarr,
+                  blk_dev->fsmalloc_avail_bitarr_words, roundup_bits2words64(num_sddf_cells));
 
-    ialloc_init(&blk_dev->ialloc, blk_dev->ialloc_idxlist, sddf_data_buffers);
+    ialloc_init(&blk_dev->ialloc, blk_dev->ialloc_idxlist, num_sddf_cells);
 
     return dev;
 }
 
 bool virtio_mmio_blk_init(struct virtio_blk_device *blk_dev, uintptr_t region_base, uintptr_t region_size, size_t virq,
                           uintptr_t data_region, size_t data_region_size, blk_storage_info_t *storage_info,
-                          blk_queue_handle_t *queue_h, int server_ch)
+                          blk_queue_handle_t *queue_h, uint32_t queue_capacity, int server_ch)
 {
     struct virtio_device *dev = virtio_blk_init(blk_dev, virq, data_region, data_region_size, storage_info, queue_h,
-                                                server_ch);
+                                                queue_capacity, server_ch);
 
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
 
 bool virtio_pci_blk_init(struct virtio_blk_device *blk_dev, uint32_t dev_slot, size_t virq, uintptr_t data_region,
                          size_t data_region_size, blk_storage_info_t *storage_info, blk_queue_handle_t *queue_h,
-                         int server_ch)
+                         uint32_t queue_capacity, int server_ch)
 {
     struct virtio_device *dev = virtio_blk_init(blk_dev, virq, data_region, data_region_size, storage_info, queue_h,
-                                                server_ch);
+                                                queue_capacity, server_ch);
 
     dev->transport_type = VIRTIO_TRANSPORT_PCI;
     dev->transport.pci.device_id = VIRTIO_PCI_BLK_DEV_ID;

--- a/tools/linux/blk/blk_bench.sh
+++ b/tools/linux/blk/blk_bench.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Assumes a FAT FS based partition mounted at /mnt
+
+set -e
+
+TEST_ENV=/mnt/libvmm-virtio-blk-bench-env
+
+echo "Starting virtio-block bench"
+
+echo -n "*** Preparing environment..."
+
+if [ -e "$TEST_ENV" ];
+then
+    rm -rf "$TEST_ENV"
+fi && sync
+
+mkdir "$TEST_ENV" && cd "$TEST_ENV" && sync
+
+if [ $? -ne 0 ];
+then
+    echo "FAILED to create test env folder at $TEST_ENV"
+    exit 1
+fi
+if [ $(dmesg | grep "FAT-fs" | grep -v "Volume was not properly unmounted" | wc -l) -ne 0 ];
+then
+    echo "FAILED, encountered FS errors, dmesg dump:"
+    dmesg
+    exit 1
+fi
+echo "OK"
+
+# =============================================================
+# Now write test data
+echo 3 > /proc/sys/vm/drop_caches
+
+BLOCK_SZ=500
+COUNT=100000
+BYTES=$(($BLOCK_SZ * $COUNT))
+echo "*** Writing $BYTES bytes..."
+time sh -c "dd if=/dev/urandom of=data.txt bs=$BLOCK_SZ count=$COUNT && sync"
+echo 3 > /proc/sys/vm/drop_caches
+
+# =============================================================
+# Now read it back
+echo "*** Reading $BYTES_EXPECTED bytes..."
+time sh -c "dd if=data.txt of=/dev/null bs=$BLOCK_SZ count=$COUNT"
+
+echo "*** Cleaning environment..."
+cd ~ && rm -rf "$TEST_ENV" && sync
+if [ "$?" -ne 0 ];
+then
+    echo "FAILED...cannot remove test dir"
+    exit 1
+fi
+echo "ALL DONE"

--- a/tools/linux/blk/blk_integration_tests.sh
+++ b/tools/linux/blk/blk_integration_tests.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Assumes a FAT FS based partition mounted at /mnt
+
+# This file implement integration tests for libvmm's virtio-blk implementation.
+# It operates on the Filesystem level instead of block level as a FS would generate
+# more varied request types than a block level tool like dd can.
+
+set -e
+
+check_fs_errors() {
+    if [ "$(dmesg | grep 'FAT-fs' | grep -vc 'Volume was not properly unmounted' )" -ne 0 ];
+    then
+        echo "FAILED, encountered FS errors, dmesg dump:"
+        dmesg
+        exit 1
+    fi
+}
+
+sync_drop_slab_and_page_caches() {
+    sync && echo 3 > /proc/sys/vm/drop_caches
+}
+
+TEST_ENV=/mnt/libvmm-virtio-blk-test-env
+
+echo "Starting virtio-block integration tests"
+echo "*** Preparing environment..."
+
+if [ -e "$TEST_ENV" ];
+then
+    rm -rf "$TEST_ENV"
+fi
+
+sync_drop_slab_and_page_caches
+if ! mkdir "$TEST_ENV";
+then
+    echo "FAILED to create test env folder at $TEST_ENV"
+fi
+if ! cd "$TEST_ENV";
+then
+    echo "FAILED to enter test env folder at $TEST_ENV"
+fi
+sync_drop_slab_and_page_caches
+
+check_fs_errors
+
+echo "OK"
+
+# =============================================================
+# Check R/W to unaligned sectors on the sDDF 4K transfer window
+echo "*** Test 1: Create 100 folders, stress unaligned access..."
+
+NUM_FOLDERS_EXPECTED=100
+
+# Create
+for SEQUENCE in $(seq 1 "$NUM_FOLDERS_EXPECTED");
+do
+    if ! mkdir "$SEQUENCE";
+    then
+        echo "FAILED, couldn't create folder at sequence $SEQUENCE"
+        exit 1
+    fi
+done && sync
+
+# Drop page caches to trigger fresh reads from blk dev
+sync_drop_slab_and_page_caches
+
+# Now read, first sanity check
+# shellcheck disable=SC2012
+# Don't need to use find here
+NUM_FOLDERS_GOT=$(ls | wc -w)
+if [ "$NUM_FOLDERS_GOT" -ne "$NUM_FOLDERS_EXPECTED" ];
+then
+    echo "FAILED, expected $NUM_FOLDERS_EXPECTED folders to exists but only found $NUM_FOLDERS_GOT"
+    exit 1
+fi
+
+# Then check that the names aren't corrupted
+SEQUENCE="1"
+# shellcheck disable=SC2012
+for FOLDER in $(ls | sort -n);
+do
+    if [ "$FOLDER" -ne "$SEQUENCE" ];
+    then
+        echo "FAILED, at expected folder with name $SEQUENCE but got $FOLDER"
+        exit 1
+    fi
+    SEQUENCE=$((SEQUENCE + 1))
+done
+
+check_fs_errors
+
+# Make sure the root point is still in a sane state
+if ! ls .. >/dev/null;
+then
+    echo "FAILED, couldn't ls the root point"
+    exit 1
+fi
+
+check_fs_errors
+
+echo "PASSED"
+
+# =============================================================
+# Check bulk data transfer, stresses sDDF block data region full handling
+echo "*** Test 2: Bulk data transfer (will take a few minutes)..."
+SEQ_START=0
+SEQ_END=1000000
+BYTES_EXPECTED=6888897
+
+if ! seq -s ',' "$SEQ_START" "$SEQ_END" | tr -d '\n' >test_data.txt;
+then
+    echo "FAILED, couldn't write data to test file"
+    exit 1
+fi
+
+sync_drop_slab_and_page_caches
+
+# Now sanity read
+if ! READ_BYTES=$(wc -c <"test_data.txt");
+then
+    echo "FAILED, couldn't read back data from test file"
+    exit 1
+fi
+if [ "$READ_BYTES" != "$BYTES_EXPECTED" ];
+then
+    echo "FAILED, expected $BYTES_EXPECTED bytes but only got $READ_BYTES"
+    exit 1
+fi
+
+# Check that each byte is equal to what we written out
+# Will take a few minutes.
+SEQUENCE="0"
+for READ_NUM in $(tr ',' ' ' <"test_data.txt");
+do
+    if [ "$READ_NUM" -ne "$SEQUENCE" ];
+    then
+        echo "FAILED, at expected sequence number $SEQUENCE but got $READ_NUM"
+        exit 1
+    fi
+    SEQUENCE=$((SEQUENCE + 1))
+done
+
+check_fs_errors
+sync_drop_slab_and_page_caches
+echo "PASSED"
+
+# =============================================================
+# Now check that writing a bunch of stuff didn't corrupt the filesystem
+echo "*** Test 3: Root point sanity check..."
+
+if ! ls .. >/dev/null;
+then
+    echo "FAILED, couldn't ls the root point"
+    exit 1
+fi
+
+check_fs_errors
+sync_drop_slab_and_page_caches
+echo "PASSED"
+
+# =============================================================
+echo "*** Cleaning environment..."
+
+if ! cd ..;
+then
+    echo "FAILED...cannot escape test dir"
+    exit 1
+fi
+if ! rm -rf "$TEST_ENV";
+then
+    echo "FAILED...cannot remove test dir"
+    exit 1
+fi
+
+sync_drop_slab_and_page_caches
+if [ -d "$TEST_ENV" ];
+then
+    echo "FAILED, deleted test dir but it still exists?"
+    exit 1
+fi
+
+check_fs_errors
+
+echo "OK"
+echo "All is well in the universe"
+exit 0


### PR DESCRIPTION
This PR:
- Integrated virtio block device implementation changes from #128 that fixes descriptor chain parsing.

- Fixed an issue that caused the data on the backing storage device to be corrupted if the guest driver issues commands in a certain order or hit certain blocks. This was caused by two bugs:
     -> Writes to sectors that are not aligned on the sDDF Block transfer window were not handled atomically. This PR added a state machine to each request to keep track of dirty blocks and queues up requests hitting the same block to prevent data races.
     -> A buffer overrun on the data region when the guest driver issues requests that span >1 sDDF Block transfer window. For example, a write of 8 sectors which starts at sector 4 will span 2 transfer windows (because the transfer windows are aligned on 8 sectors). Previously the device implementation would only allocate 1 transfer window and overrun it. 

- Fixed an issue that caused the guest to hang if the block data region or bookkeeping structures become full. Previously the virtio block device implementation would just drop the requests silently in such cases, now the device will correctly queue up requests and create back-pressure in the guest to prevent the device from overloading.

- Fixed an issue that caused the guest to hang due to an internal fragmentation issue within the data region. Previously, the device did not implement the `VIRTIO_BLK_F_SIZE_MAX` and `VIRTIO_BLK_F_SEG_MAX` feature bits. Which allowed the guest driver to make huge requests (upwards of 100k) that the device would never be able to fulfill due to natural internal fragmentation in the data region. Now, the device restrict the driver to 4K requests at a time, a more reasonable limit that the device will be able to fulfill (eventually) as previous requests complete and resources are freed up.

- Implemented the `VIRTIO_BLK_F_TOPOLOGY` feature bit to hint optimal I/O alignment to the guest driver.

- Added an integration test script for virtio block that was used to catch all the above issues.

- Mount the third partition on maaxboard instead of the first one.

- Update sDDF to [fee9f97](https://github.com/au-ts/sddf/commit/fee9f978431cffaf65117001e90d7264de767931) to fix a cache-coherency issue within the Block subsystem and for the faster imx8 SD driver.

Fixes #150 