### PR TITLE
Remove export override directives, remove unnecessary export directives

### DIFF
--- a/examples/rust/Makefile
+++ b/examples/rust/Makefile
@@ -12,11 +12,11 @@ export MICROKIT_BOARD = qemu_virt_aarch64
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
-export override MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
+override MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
 
-export BUILD_DIR:=$(abspath $(BUILD_DIR))
-export MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
-export EXAMPLE_DIR:=$(abspath .)
+export BUILD_DIR := $(abspath $(BUILD_DIR))
+export MICROKIT_SDK := $(abspath $(MICROKIT_SDK))
+export EXAMPLE_DIR := $(abspath .)
 
 export TARGET := aarch64-none-elf
 export CC := clang
@@ -26,8 +26,8 @@ export AR := llvm-ar
 export DTC := dtc
 export RANLIB := llvm-ranlib
 export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
-export SDDF=$(abspath ../../dep/sddf)
-export LIBVMM=$(abspath ../../)
+export SDDF := $(abspath ../../dep/sddf)
+export LIBVMM := $(abspath ../../)
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -10,15 +10,14 @@ export MICROKIT_CONFIG ?= debug
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
-export override MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
+override MICROKIT_SDK := $(abspath $(MICROKIT_SDK))
 
 ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
 
-export BUILD_DIR:=$(abspath $(BUILD_DIR))
-export MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
-export EXAMPLE_DIR:=$(abspath .)
+export BUILD_DIR := $(abspath $(BUILD_DIR))
+export EXAMPLE_DIR := $(abspath .)
 
 export TARGET := aarch64-none-elf
 export CC := clang
@@ -28,8 +27,8 @@ export AR := llvm-ar
 export DTC := dtc
 export RANLIB := llvm-ranlib
 export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
-export SDDF=$(abspath ../../dep/sddf)
-export LIBVMM=$(abspath ../../)
+export SDDF = $(abspath ../../dep/sddf)
+export LIBVMM = $(abspath ../../)
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -27,8 +27,8 @@ export AR := llvm-ar
 export DTC := dtc
 export RANLIB := llvm-ranlib
 export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
-export SDDF = $(abspath ../../dep/sddf)
-export LIBVMM = $(abspath ../../)
+export SDDF := $(abspath ../../dep/sddf)
+export LIBVMM := $(abspath ../../)
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt

--- a/examples/simple/simple.mk
+++ b/examples/simple/simple.mk
@@ -46,7 +46,7 @@ CFLAGS := \
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := --start-group -lmicrokit -Tmicrokit.ld libvmm.a --end-group
 
-CHECK_FLAGS_BOARD_MD5:=.board_cflags-$(shell echo -- $(CFLAGS) $(BOARD) $(MICROKIT_CONFIG) | shasum | sed 's/ *-//')
+CHECK_FLAGS_BOARD_MD5 := .board_cflags-$(shell echo -- $(CFLAGS) $(BOARD) $(MICROKIT_CONFIG) | shasum | sed 's/ *-//')
 
 $(CHECK_FLAGS_BOARD_MD5):
 	-rm -f .board_cflags-*

--- a/examples/virtio-snd/Makefile
+++ b/examples/virtio-snd/Makefile
@@ -36,8 +36,8 @@ export AR := llvm-ar
 export DTC := dtc
 export RANLIB := llvm-ranlib
 export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
-export SDDF = $(abspath ../../dep/sddf)
-export LIBVMM = $(abspath ../../)
+export SDDF := $(abspath ../../dep/sddf)
+export LIBVMM := $(abspath ../../)
 
 # If on macOS, override backend to `coreaudio`
 export QEMU_SND_BACKEND := alsa

--- a/examples/virtio-snd/Makefile
+++ b/examples/virtio-snd/Makefile
@@ -10,7 +10,7 @@ export MICROKIT_CONFIG ?= debug
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
-export override MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
+override MICROKIT_SDK := $(abspath $(MICROKIT_SDK))
 
 ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
 	export UART_DRIVER := meson
@@ -23,9 +23,9 @@ else
 $(error Unsupported MICROKIT_BOARD given)
 endif
 
-export BUILD_DIR:=$(abspath $(BUILD_DIR))
-export MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
-export VIRTIO_EXAMPLE:=$(abspath .)
+BUILD_DIR ?= build
+export BUILD_DIR := $(abspath ${BUILD_DIR})
+export VIRTIO_EXAMPLE := $(abspath .)
 
 export TARGET := aarch64-none-elf
 export CC := clang
@@ -36,8 +36,8 @@ export AR := llvm-ar
 export DTC := dtc
 export RANLIB := llvm-ranlib
 export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
-export SDDF=$(abspath ../../dep/sddf)
-export LIBVMM=$(abspath ../../)
+export SDDF = $(abspath ../../dep/sddf)
+export LIBVMM = $(abspath ../../)
 
 # If on macOS, override backend to `coreaudio`
 export QEMU_SND_BACKEND := alsa

--- a/examples/virtio-snd/virtio_snd.mk
+++ b/examples/virtio-snd/virtio_snd.mk
@@ -73,7 +73,7 @@ include $(LIBVMM_TOOLS)/linux/uio_drivers/snd/uio_snd.mk
 IMAGES := client_vmm.elf snd_driver_vmm.elf \
 	$(SERIAL_IMAGES) $(SND_IMAGES) uart_driver.elf
 
-CHECK_FLAGS_BOARD_MD5:=.board_cflags-$(shell echo -- $(CFLAGS) $(BOARD) $(MICROKIT_CONFIG) | shasum | sed 's/ *-//')
+CHECK_FLAGS_BOARD_MD5 := .board_cflags-$(shell echo -- $(CFLAGS) $(BOARD) $(MICROKIT_CONFIG) | shasum | sed 's/ *-//')
 
 $(CHECK_FLAGS_BOARD_MD5):
 	-rm -f .board_cflags-*

--- a/examples/virtio/Makefile
+++ b/examples/virtio/Makefile
@@ -65,8 +65,8 @@ export AR := llvm-ar
 export DTC := dtc
 export RANLIB := llvm-ranlib
 export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
-export SDDF = $(abspath ../../dep/sddf)
-export LIBVMM = $(abspath ../../)
+export SDDF := $(abspath ../../dep/sddf)
+export LIBVMM := $(abspath ../../)
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt

--- a/examples/virtio/Makefile
+++ b/examples/virtio/Makefile
@@ -10,7 +10,7 @@ export MICROKIT_CONFIG ?= debug
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
-export override MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
+override MICROKIT_SDK := $(abspath $(MICROKIT_SDK))
 
 # Both QEMU and Maaxboard uses the same guest device tree as the guest does not
 # need to access any physical device. The only difference is that QEMU is GICv2 while
@@ -51,9 +51,9 @@ endif
 export LINUX := a3f4bf9e2eb24fa8fc0d3d8cd02e4d8097062e8b-linux
 export INITRD := b6a276df6a0e39f76bc8950e975daa2888ad83df-rootfs.cpio.gz
 
-export BUILD_DIR:=$(abspath $(BUILD_DIR))
-export MICROKIT_SDK:=$(abspath $(MICROKIT_SDK))
-export VIRTIO_EXAMPLE:=$(abspath .)
+BUILD_DIR ?= build
+export BUILD_DIR := $(abspath ${BUILD_DIR})
+export VIRTIO_EXAMPLE := $(abspath .)
 
 export OBJCOPY := llvm-objcopy
 export TARGET := aarch64-none-elf
@@ -65,8 +65,8 @@ export AR := llvm-ar
 export DTC := dtc
 export RANLIB := llvm-ranlib
 export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
-export SDDF=$(abspath ../../dep/sddf)
-export LIBVMM=$(abspath ../../)
+export SDDF = $(abspath ../../dep/sddf)
+export LIBVMM = $(abspath ../../)
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt

--- a/examples/virtio/virtio.mk
+++ b/examples/virtio/virtio.mk
@@ -70,7 +70,7 @@ include $(LIBVMM_TOOLS)/linux/net/net_init.mk
 IMAGES := client_vmm.elf timer_driver.elf blk_driver.elf blk_virt.elf serial_driver.elf serial_virt_tx.elf serial_virt_rx.elf \
 	network_virt_rx.elf network_virt_tx.elf eth_driver.elf network_copy.elf
 
-CHECK_FLAGS_BOARD_MD5:=.board_cflags-$(shell echo -- $(CFLAGS) $(BOARD) $(MICROKIT_CONFIG) | shasum | sed 's/ *-//')
+CHECK_FLAGS_BOARD_MD5 := .board_cflags-$(shell echo -- $(CFLAGS) $(BOARD) $(MICROKIT_CONFIG) | shasum | sed 's/ *-//')
 
 $(CHECK_FLAGS_BOARD_MD5):
 	-rm -f .board_cflags-*


### PR DESCRIPTION
This PR is an extension of the sDDF PR here (https://github.com/au-ts/sddf/pull/423).

This PR removes all `export override` directives from our makefiles, as discussed here #337.

It was found that `export override` is not syntactically correct in older versions of GNU make, which happen to be the default for MacOS. Also, the variables which it was being applied to were mandatory environment or command line variables, therefore the `export` had no effect. 