### PR TITLE
Update sDDF submodule

### DIFF
--- a/examples/rust/rust.mk
+++ b/examples/rust/rust.mk
@@ -24,6 +24,7 @@ vpath %.c $(LIBVMM) $(EXAMPLE_DIR)
 IMAGES := vmm.elf
 
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+ARCH := ${shell grep 'CONFIG_SEL4_ARCH  ' $(BOARD_DIR)/include/kernel/gen_config.h | cut -d' ' -f4}
 SYSTEM_FILE := $(EXAMPLE_DIR)/rust_vmm.system
 
 DTS := $(EXAMPLE_DIR)/images/linux.dts
@@ -43,6 +44,7 @@ CFLAGS := \
 	  -I$(BOARD_DIR)/include \
 	  -I$(LIBVMM)/include \
 	  -I$(SDDF)/include \
+	  -I$(SDDF)/include/sddf/util/custom_libc \
 	  -I$(SDDF)/include/microkit \
 	  -MD \
 	  -MP \
@@ -75,7 +77,7 @@ all: $(IMAGE_FILE)
 
 -include vmm.d
 
-$(IMAGES): libvmm.a
+$(IMAGES): libvmm.a libsddf_util_debug.a
 
 qemu: $(IMAGE_FILE)
 	$(QEMU) -machine virt,virtualization=on,highmem=off,secure=off \
@@ -103,6 +105,7 @@ $(DTB): $(DTS)
 	$(DTC) -q -I dts -O dtb $< > $@
 
 include $(LIBVMM)/vmm.mk
+include $(SDDF)/util/util.mk
 
 vmm.elf: ${EXAMPLE_DIR}/src/vmm.rs ${LINUX} ${INITRD} $(DTB)
 	cp ${EXAMPLE_DIR}/rust-toolchain.toml .

--- a/examples/simple/simple.mk
+++ b/examples/simple/simple.mk
@@ -8,10 +8,13 @@ QEMU := qemu-system-aarch64
 MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
 
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+ARCH := ${shell grep 'CONFIG_SEL4_ARCH  ' $(BOARD_DIR)/include/kernel/gen_config.h | cut -d' ' -f4}
 SYSTEM_DIR := $(EXAMPLE_DIR)/board/$(MICROKIT_BOARD)
 SYSTEM_FILE := $(SYSTEM_DIR)/simple.system
 IMAGE_FILE := loader.img
 REPORT_FILE := report.txt
+
+SDDF_CUSTOM_LIBC := 1
 
 vpath %.c $(LIBVMM) $(EXAMPLE_DIR)
 
@@ -38,13 +41,14 @@ CFLAGS := \
 	  -I$(BOARD_DIR)/include \
 	  -I$(LIBVMM)/include \
 	  -I$(SDDF)/include \
+	  -I$(SDDF)/include/sddf/util/custom_libc \
 	  -I$(SDDF)/include/microkit \
 	  -MD \
 	  -MP \
 	  -target $(TARGET)
 
 LDFLAGS := -L$(BOARD_DIR)/lib
-LIBS := --start-group -lmicrokit -Tmicrokit.ld libvmm.a --end-group
+LIBS := --start-group -lmicrokit -Tmicrokit.ld libvmm.a libsddf_util_debug.a --end-group
 
 CHECK_FLAGS_BOARD_MD5:=.board_cflags-$(shell echo -- $(CFLAGS) $(BOARD) $(MICROKIT_CONFIG) | shasum | sed 's/ *-//')
 
@@ -59,7 +63,7 @@ all: loader.img
 
 -include vmm.d
 
-$(IMAGES): libvmm.a
+$(IMAGES): libvmm.a libsddf_util_debug.a
 
 $(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)
 	$(MICROKIT_TOOL) $(SYSTEM_FILE) --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
@@ -94,6 +98,7 @@ images.o: $(LIBVMM)/tools/package_guest_images.S $(LINUX) $(INITRD) vm.dtb
 					$(LIBVMM)/tools/package_guest_images.S -o $@
 
 include $(LIBVMM)/vmm.mk
+include ${SDDF}/util/util.mk
 
 qemu: $(IMAGE_FILE)
 	if ! command -v $(QEMU) > /dev/null 2>&1; then echo "Could not find dependency: qemu-system-aarch64"; exit 1; fi

--- a/examples/virtio/build.zig
+++ b/examples/virtio/build.zig
@@ -152,6 +152,7 @@ pub fn build(b: *std.Build) !void {
     client_vmm.addObjectFile(libmicrokit);
     client_vmm.setLinkerScript(libmicrokit_linker_script);
     client_vmm.linkLibrary(libvmm);
+    client_vmm.linkLibrary(sddf_dep.artifact("util"));
 
     client_vmm.addCSourceFiles(.{
         .files = &.{"client_vmm.c"},

--- a/examples/virtio/virtio.mk
+++ b/examples/virtio/virtio.mk
@@ -22,6 +22,7 @@ BLK_COMPONENTS := $(SDDF)/blk/components
 NET_COMPONENTS := $(SDDF)/network/components
 
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+ARCH := ${shell grep 'CONFIG_SEL4_ARCH  ' $(BOARD_DIR)/include/kernel/gen_config.h | cut -d' ' -f4}
 SYSTEM_FILE := virtio.system
 IMAGE_FILE := loader.img
 REPORT_FILE := report.txt
@@ -30,6 +31,8 @@ DTB_FILE := $(MICROKIT_BOARD).dtb
 CLIENT_VM := $(VIRTIO_EXAMPLE)/client_vm
 CLIENT_DTB := client_vm/vm.dtb
 METAPROGRAM := $(VIRTIO_EXAMPLE)/meta.py
+
+SDDF_CUSTOM_LIBC := 1
 
 CLIENT_VM_USERLEVEL_INIT := blk_client_init net_client_init
 

--- a/include/libvmm/util/queue.h
+++ b/include/libvmm/util/queue.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <string.h>
 #include <stdbool.h>
 #include <libvmm/util/util.h>
 

--- a/include/libvmm/util/util.h
+++ b/include/libvmm/util/util.h
@@ -27,9 +27,6 @@
 #define LOG_VMM(...) do{ printf("%s|INFO: ", microkit_name); printf(__VA_ARGS__); }while(0)
 #define LOG_VMM_ERR(...) do{ printf("%s|ERROR: ", microkit_name); printf(__VA_ARGS__); }while(0)
 
-void *memcpy(void *restrict dest, const void *restrict src, size_t n);
-void *memset(void *dest, int c, size_t n);
-
 static void assert_fail(
     const char  *assertion,
     const char  *file,

--- a/src/arch/aarch64/linux.c
+++ b/src/arch/aarch64/linux.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
-
+#include <string.h>
 #include <libvmm/dtb.h>
 #include <libvmm/util/util.h>
 #include <libvmm/arch/aarch64/linux.h>

--- a/src/arch/aarch64/vgic/vgic_v2.c
+++ b/src/arch/aarch64/vgic/vgic_v2.c
@@ -39,7 +39,7 @@
  *         destroy our state. The affects of this will be an IRQ that is never acknowledged and hence,
  *         will never occur again.
  */
-
+#include <string.h>
 #include <stdint.h>
 #include <microkit.h>
 

--- a/src/guest.c
+++ b/src/guest.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
+#include <string.h>
 #include <microkit.h>
 #include <libvmm/vcpu.h>
 #include <libvmm/guest.h>

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -15,25 +15,6 @@ void _putchar(char character)
     microkit_dbg_putc(character);
 }
 
-void *memset(void *dest, int c, size_t n)
-{
-    unsigned char *s = dest;
-    for (; n; n--, s++) {
-        *s = c;
-    }
-    return dest;
-}
-
-void *memcpy(void *restrict dest, const void *restrict src, size_t n)
-{
-    unsigned char *d = dest;
-    const unsigned char *s = src;
-    for (; n; n--) {
-        *d++ = *s++;
-    }
-    return dest;
-}
-
 void print_mem_hex(uintptr_t addr, size_t size)
 {
 #ifdef CONFIG_DEBUG_BUILD

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
-
 #include <microkit.h>
+#include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <libvmm/guest.h>

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
+#include <string.h>
 #include <libvmm/guest.h>
 #include <libvmm/virq.h>
 #include <libvmm/util/util.h>


### PR DESCRIPTION
Main changes are to do with re-organising how we depend on basic libc functionality such as memcpy/memset, etc.