### PR TITLE
vgic: removed assert in vgic_inject_irq() to prevent VMMs from spuriously crashing

### DIFF
--- a/src/arch/aarch64/vgic/vgic.c
+++ b/src/arch/aarch64/vgic/vgic.c
@@ -100,8 +100,5 @@ bool vgic_inject_irq(size_t vcpu_id, int irq)
 {
     LOG_IRQ("(vCPU %d) injecting IRQ %d\n", vcpu_id, irq);
 
-    bool success = vgic_dist_set_pending_irq(&vgic, vcpu_id, irq);
-    assert(success);
-
-    return success;
+    return vgic_dist_set_pending_irq(&vgic, vcpu_id, irq);
 }


### PR DESCRIPTION
This was added in commit b737eec as a debugging relic. But it is incorrect as certain passthrough hardware devices may raise IRQs before the guest fully boots. Which can cause the VMM to crash when the corresponding IRQ isn't enabled in the GIC distributor.