### PR TITLE
nix: Add missing dependency for gdisk

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
                 qemu
                 gnumake
                 dosfstools
+                gptfdisk
                 # for git-clang-format.
                 llvm.libclang.python
                 llvm.lld


### PR DESCRIPTION
Without it virtio example does not boot.