### PR TITLE
virtio/pci: fix #185

### DIFF
--- a/examples/virtio_pci/client_vmm.c
+++ b/examples/virtio_pci/client_vmm.c
@@ -96,7 +96,7 @@ void init(void)
         return;
     }
 
-    success = virtio_pci_ecam_init(0x10000000, 0x100000, 0x100000);
+    success = virtio_pci_ecam_init(0x10000000, 0x10000000, 0x100000);
     assert(success);
     success = virtio_pci_register_memory_resource(0x20100000, 0x20100000, 0xFF00000);
     assert(success);

--- a/examples/virtio_pci/meta.py
+++ b/examples/virtio_pci/meta.py
@@ -156,7 +156,7 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree, client_dtb: Device
     ############ VIRTIO PCI ############
     config_space = MemoryRegion(sdf, name="ecam", size=0x100000)
     sdf.add_mr(config_space)
-    vmm_client0.add_map(Map(config_space, vaddr=0x100000, perms="rw"))
+    vmm_client0.add_map(Map(config_space, vaddr=0x10000000, perms="rw"))
 
     memory_resource = MemoryRegion(sdf, name="memory_resource", size=0x10000)
     sdf.add_mr(memory_resource)

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -44,6 +44,11 @@ typedef struct virtio_device {
     bool features_happy;
 } virtio_device_t;
 
+static inline struct virtq *get_current_virtq_by_handler(virtio_device_t *dev)
+{
+    assert(dev->regs.QueueSel < dev->num_vqs);
+    return &dev->vqs[dev->regs.QueueSel].virtq;
+}
 /*
  * Registers a new virtIO device at a given guest-physical region.
  *

--- a/src/virtio/mmio.c
+++ b/src/virtio/mmio.c
@@ -26,12 +26,6 @@
 
 #define REG_RANGE(r0, r1)   r0 ... (r1 - 1)
 
-struct virtq *get_current_virtq_by_handler(virtio_device_t *dev)
-{
-    assert(dev->regs.QueueSel < dev->num_vqs);
-    return &dev->vqs[dev->regs.QueueSel].virtq;
-}
-
 int handle_virtio_mmio_set_status_flag(virtio_device_t *dev, uint32_t reg)
 {
     int success = 1;

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -303,7 +303,15 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
         dev->regs.QueueSel = data;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_SIZE, VIRTIO_PCI_COMMON_Q_ENABLE):
-        // what if different size configured?
+        if (dev->regs.QueueSel < dev->num_vqs) {
+            struct virtq *virtq = get_current_virtq_by_handler(dev);
+            virtq->num = (unsigned int)data;
+        } else {
+            LOG_VMM_ERR("invalid virtq index 0x%lx (number of virtqs is 0x%lx) "
+                        "given when accessing REG_VIRTIO_MMIO_QUEUE_NUM\n",
+                        dev->regs.QueueSel, dev->num_vqs);
+            success = false;
+        }
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_ENABLE, VIRTIO_PCI_COMMON_Q_NOTIF_OFF):
         if (data == 0x1) {


### PR DESCRIPTION
fix the bug of ignoring queue_size writing from the VM, which causes the VMM looking for the descriptors out of scope