### PR TITLE
Add libvmm.h to make it easier for users

### DIFF
--- a/examples/simple/build.zig
+++ b/examples/simple/build.zig
@@ -104,6 +104,12 @@ pub fn build(b: *std.Build) !void {
     });
     const libvmm = libvmm_dep.artifact("vmm");
 
+    const sddf_dep = b.dependency("sddf", .{
+        .target = target,
+        .optimize = optimize,
+        .microkit_board_dir = microkit_board_dir,
+    });
+
     const exe = b.addExecutable(.{
         .name = "vmm.elf",
         .root_module = b.createModule(.{
@@ -143,6 +149,8 @@ pub fn build(b: *std.Build) !void {
 
     // Link the libvmm library, this will automatically add the libvmm headers as well.
     exe.linkLibrary(libvmm);
+    // Link sDDF util library for libc functionality
+    exe.linkLibrary(sddf_dep.artifact("util"));
 
     exe.addCSourceFiles(.{
         .files = &.{"vmm.c"},

--- a/examples/simple/build.zig.zon
+++ b/examples/simple/build.zig.zon
@@ -6,6 +6,9 @@
         .libvmm = .{
             .path = "../../"
         },
+        .sddf = .{
+            .path = "../../dep/sddf",
+        },
         .linux = .{
             .url = "https://trustworthy.systems/Downloads/libvmm/images/85000f3f42a882e4476e57003d53f2bbec8262b0-linux.tar.gz",
             .hash = "linux-0.0.0-AAAAAACKHwKLhs9sy_2Ma-_f1lh-vvTVxNfPElIDod2h",

--- a/examples/simple/vmm.c
+++ b/examples/simple/vmm.c
@@ -7,11 +7,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <microkit.h>
-#include <libvmm/guest.h>
-#include <libvmm/virq.h>
-#include <libvmm/util/util.h>
-#include <libvmm/arch/aarch64/linux.h>
-#include <libvmm/arch/aarch64/fault.h>
+#include <libvmm/libvmm.h>
 
 /*
  * As this is just an example, for simplicity we just make the size of the

--- a/examples/virtio/client_vmm.c
+++ b/examples/virtio/client_vmm.c
@@ -6,16 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <microkit.h>
-#include <libvmm/config.h>
-#include <libvmm/guest.h>
-#include <libvmm/virq.h>
-#include <libvmm/util/util.h>
-#include <libvmm/virtio/virtio.h>
-#include <libvmm/virtio/console.h>
-#include <libvmm/virtio/block.h>
-#include <libvmm/virtio/net.h>
-#include <libvmm/arch/aarch64/linux.h>
-#include <libvmm/arch/aarch64/fault.h>
+#include <libvmm/libvmm.h>
 #include <sddf/serial/queue.h>
 #include <sddf/serial/config.h>
 #include <sddf/blk/queue.h>

--- a/examples/virtio_pci/client_vmm.c
+++ b/examples/virtio_pci/client_vmm.c
@@ -6,16 +6,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <microkit.h>
-#include <libvmm/config.h>
-#include <libvmm/guest.h>
-#include <libvmm/virq.h>
-#include <libvmm/util/util.h>
-#include <libvmm/virtio/virtio.h>
-#include <libvmm/virtio/console.h>
-#include <libvmm/virtio/block.h>
-#include <libvmm/virtio/net.h>
-#include <libvmm/arch/aarch64/linux.h>
-#include <libvmm/arch/aarch64/fault.h>
+#include <libvmm/libvmm.h>
 #include <sddf/serial/queue.h>
 #include <sddf/serial/config.h>
 #include <sddf/blk/queue.h>

--- a/examples/zig/build.zig
+++ b/examples/zig/build.zig
@@ -59,6 +59,12 @@ pub fn build(b: *std.Build) !void {
     });
     const libvmm = libvmm_dep.artifact("vmm");
 
+    const sddf_dep = b.dependency("sddf", .{
+        .target = target,
+        .optimize = optimize,
+        .microkit_board_dir = microkit_board_dir,
+    });
+
     const exe = b.addExecutable(.{
         .name = "vmm.elf",
         .root_module = b.createModule(.{
@@ -117,6 +123,7 @@ pub fn build(b: *std.Build) !void {
     exe.setLinkerScript(libmicrokit_linker_script);
 
     exe.linkLibrary(libvmm);
+    exe.linkLibrary(sddf_dep.artifact("util"));
 
     b.installArtifact(exe);
 

--- a/examples/zig/build.zig.zon
+++ b/examples/zig/build.zig.zon
@@ -6,6 +6,9 @@
         .libvmm = .{
             .path = "../../"
         },
+        .sddf = .{
+            .path = "../../dep/sddf",
+        },
         .linux = .{
             .url = "https://trustworthy.systems/Downloads/libvmm/images/85000f3f42a882e4476e57003d53f2bbec8262b0-linux.tar.gz",
             .hash = "linux-0.0.0-AAAAAACKHwKLhs9sy_2Ma-_f1lh-vvTVxNfPElIDod2h",

--- a/examples/zig/src/vmm.zig
+++ b/examples/zig/src/vmm.zig
@@ -4,9 +4,7 @@
 const std = @import("std");
 const c = @cImport({
     @cInclude("microkit.h");
-    @cInclude("libvmm/virq.h");
-    @cInclude("libvmm/guest.h");
-    @cInclude("libvmm/arch/aarch64/linux.h");
+    @cInclude("libvmm/libvmm.h");
 });
 
 // In this example we only have one virtual CPU

--- a/include/libvmm/libvmm.h
+++ b/include/libvmm/libvmm.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#pragma once
+
+#include <sel4/sel4.h>
+
+#include <libvmm/config.h>
+#include <libvmm/guest.h>
+#include <libvmm/tcb.h>
+#include <libvmm/vcpu.h>
+#include <libvmm/virq.h>
+
+#include <libvmm/virtio/virtio.h>
+#include <libvmm/virtio/block.h>
+#include <libvmm/virtio/console.h>
+#include <libvmm/virtio/net.h>
+#include <libvmm/virtio/sound.h>
+
+#if defined(CONFIG_ARCH_ARM)
+#include <libvmm/arch/aarch64/linux.h>
+#include <libvmm/arch/aarch64/fault.h>
+#endif


### PR DESCRIPTION
Automatically include basic public functionality of the library and virtIO etc. Should make it a bit easier to use the library.

Changes related to the build.zig is to do with sddf/serial/queue.h needing string.h which requires libc, so add missing links to sDDF's custom libc.

I think this is okay since a majority of user's will either use virtIO which means they already need sDDF and the library already has a pretty high coupling with sDDF.