### PR TITLE
examples: fix multithreaded builds of virtio

### DIFF
--- a/examples/virtio/virtio.mk
+++ b/examples/virtio/virtio.mk
@@ -55,7 +55,7 @@ CFLAGS += \
 	  -I$(VIRTIO_EXAMPLE)/include
 
 LDFLAGS := -L$(BOARD_DIR)/lib
-LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a libvmm.a --end-group
+LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a --end-group
 
 include $(SDDF)/util/util.mk
 ifeq ($(MICROKIT_BOARD), maaxboard)
@@ -85,7 +85,7 @@ all: ${IMAGE_FILE}
 
 -include vmm.d
 
-$(IMAGES): libsddf_util_debug.a libvmm.a
+$(IMAGES): libsddf_util_debug.a
 
 $(SYSTEM_FILE): $(METAPROGRAM) $(IMAGES) $(DTB) $(CLIENT_DTB)
 	PYTHONPATH=${SDDF}/tools/meta:$$PYTHONPATH $(PYTHON) $(METAPROGRAM) --sddf $(SDDF) --board $(MICROKIT_BOARD) --dtb $(DTB) --client-dtb $(CLIENT_DTB) --output . --sdf $(SYSTEM_FILE) $(PARTITION_ARG)
@@ -160,7 +160,7 @@ client_vm/images.o: $(LIBVMM)/tools/package_guest_images.S $(CHECK_FLAGS_BOARD_M
 					-target $(TARGET) \
 					$(LIBVMM)/tools/package_guest_images.S -o $@
 
-client_vmm.elf: client_vm/vmm.o client_vm/images.o |vm_dir
+client_vmm.elf: client_vm/vmm.o client_vm/images.o libvmm.a |vm_dir
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 # Stop make from deleting intermediate files

--- a/examples/virtio_pci/virtio_pci.mk
+++ b/examples/virtio_pci/virtio_pci.mk
@@ -53,7 +53,7 @@ CFLAGS += \
 	  -I$(VIRTIO_EXAMPLE)/include
 
 LDFLAGS := -L$(BOARD_DIR)/lib
-LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a libvmm.a --end-group
+LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a --end-group
 
 include $(SDDF)/util/util.mk
 include ${SDDF}/drivers/timer/${TIMER_DRIV_DIR}/timer_driver.mk
@@ -81,7 +81,7 @@ all: ${IMAGE_FILE}
 
 -include vmm.d
 
-$(IMAGES): libsddf_util_debug.a libvmm.a
+$(IMAGES): libsddf_util_debug.a
 
 $(SYSTEM_FILE): $(METAPROGRAM) $(IMAGES) $(DTB) $(CLIENT_DTB)
 	PYTHONPATH=${SDDF}/tools/meta:$$PYTHONPATH $(PYTHON) $(METAPROGRAM) --sddf $(SDDF) --board $(MICROKIT_BOARD) --dtb $(DTB) --client-dtb $(CLIENT_DTB) --output . --sdf $(SYSTEM_FILE) $(PARTITION_ARG)
@@ -155,7 +155,7 @@ client_vm/images.o: $(LIBVMM)/tools/package_guest_images.S $(CHECK_FLAGS_BOARD_M
 					-target $(TARGET) \
 					$(LIBVMM)/tools/package_guest_images.S -o $@
 
-client_vmm.elf: client_vm/vmm.o client_vm/images.o |vm_dir
+client_vmm.elf: client_vm/vmm.o client_vm/images.o libvmm.a |vm_dir
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 # Stop make from deleting intermediate files


### PR DESCRIPTION
It would try to link sDDF ELF files against libvmm.a when there was dependency on that file.