### PR TITLE
virtio: fix/improve setting of transport type

### DIFF
--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -16,9 +16,9 @@
  */
 
 typedef enum virtio_transport_type {
-    VIRTIO_TRANSPORT_PCI,
-    VIRTIO_TRANSPORT_MMIO,
-    VIRTIO_TRANSPORT_CCW,    // For future expansion
+    VIRTIO_TRANSPORT_PCI = 1,
+    VIRTIO_TRANSPORT_MMIO = 2,
+    VIRTIO_TRANSPORT_CCW = 3,
 } virtio_transport_type_t;
 
 typedef union virtio_transport_data {

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -838,13 +838,15 @@ static virtio_device_funs_t functions = {
     .queue_notify = virtio_blk_mmio_queue_notify,
 };
 
-static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, size_t virq, uintptr_t data_region,
-                                             size_t data_region_size, blk_storage_info_t *storage_info,
-                                             blk_queue_handle_t *queue_h, uint32_t queue_capacity, int server_ch)
+static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, virtio_transport_type_t type,
+                                             size_t virq, uintptr_t data_region, size_t data_region_size,
+                                             blk_storage_info_t *storage_info, blk_queue_handle_t *queue_h,
+                                             uint32_t queue_capacity, int server_ch)
 {
     struct virtio_device *dev = &blk_dev->virtio_device;
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_BLOCK;
     dev->regs.VendorID = VIRTIO_MMIO_DEV_VENDOR_ID;
+    dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = blk_dev->vqs;
     dev->num_vqs = VIRTIO_BLK_NUM_VIRTQ;
@@ -877,8 +879,8 @@ bool virtio_mmio_blk_init(struct virtio_blk_device *blk_dev, uintptr_t region_ba
                           uintptr_t data_region, size_t data_region_size, blk_storage_info_t *storage_info,
                           blk_queue_handle_t *queue_h, uint32_t queue_capacity, int server_ch)
 {
-    struct virtio_device *dev = virtio_blk_init(blk_dev, virq, data_region, data_region_size, storage_info, queue_h,
-                                                queue_capacity, server_ch);
+    struct virtio_device *dev = virtio_blk_init(blk_dev, VIRTIO_TRANSPORT_MMIO, virq, data_region, data_region_size,
+                                                storage_info, queue_h, queue_capacity, server_ch);
 
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
@@ -887,10 +889,9 @@ bool virtio_pci_blk_init(struct virtio_blk_device *blk_dev, uint32_t dev_slot, s
                          size_t data_region_size, blk_storage_info_t *storage_info, blk_queue_handle_t *queue_h,
                          uint32_t queue_capacity, int server_ch)
 {
-    struct virtio_device *dev = virtio_blk_init(blk_dev, virq, data_region, data_region_size, storage_info, queue_h,
-                                                queue_capacity, server_ch);
+    struct virtio_device *dev = virtio_blk_init(blk_dev, VIRTIO_TRANSPORT_PCI, virq, data_region, data_region_size,
+                                                storage_info, queue_h, queue_capacity, server_ch);
 
-    dev->transport_type = VIRTIO_TRANSPORT_PCI;
     dev->transport.pci.device_id = VIRTIO_PCI_BLK_DEV_ID;
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_STORAGE_SCSI;

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -226,12 +226,14 @@ virtio_device_funs_t functions = {
     .queue_notify = virtio_console_handle_tx,
 };
 
-static struct virtio_device *virtio_console_init(struct virtio_console_device *console, size_t virq,
-                                                 serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch)
+static struct virtio_device *virtio_console_init(struct virtio_console_device *console, virtio_transport_type_t type,
+                                                 size_t virq, serial_queue_handle_t *rxq, serial_queue_handle_t *txq,
+                                                 int tx_ch)
 {
     struct virtio_device *dev = &console->virtio_device;
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_CONSOLE;
     dev->regs.VendorID = VIRTIO_MMIO_DEV_VENDOR_ID;
+    dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = console->vqs;
     dev->num_vqs = VIRTIO_CONSOLE_NUM_VIRTQ;
@@ -248,7 +250,7 @@ static struct virtio_device *virtio_console_init(struct virtio_console_device *c
 bool virtio_mmio_console_init(struct virtio_console_device *console, uintptr_t region_base, uintptr_t region_size,
                               size_t virq, serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch)
 {
-    struct virtio_device *dev = virtio_console_init(console, virq, rxq, txq, tx_ch);
+    struct virtio_device *dev = virtio_console_init(console, VIRTIO_TRANSPORT_MMIO, virq, rxq, txq, tx_ch);
 
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
@@ -256,9 +258,8 @@ bool virtio_mmio_console_init(struct virtio_console_device *console, uintptr_t r
 bool virtio_pci_console_init(struct virtio_console_device *console, uint32_t dev_slot, size_t virq,
                              serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch)
 {
-    struct virtio_device *dev = virtio_console_init(console, virq, rxq, txq, tx_ch);
+    struct virtio_device *dev = virtio_console_init(console, VIRTIO_TRANSPORT_PCI, virq, rxq, txq, tx_ch);
 
-    dev->transport_type = VIRTIO_TRANSPORT_PCI;
     dev->transport.pci.device_id = VIRTIO_PCI_CONSOLE_DEV_ID;
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_COMMUNICATION_OTHER;

--- a/src/virtio/mmio.c
+++ b/src/virtio/mmio.c
@@ -309,6 +309,7 @@ bool virtio_mmio_register_device(virtio_device_t *dev,
                                  size_t virq)
 {
     bool success;
+    assert(dev->transport_type == VIRTIO_TRANSPORT_MMIO);
     success = fault_register_vm_exception_handler(region_base,
                                                   region_size,
                                                   &virtio_mmio_fault_handle,

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -372,15 +372,16 @@ static virtio_device_funs_t functions = {
     .queue_notify = virtio_net_queue_notify,
 };
 
-static struct virtio_device *virtio_net_init(struct virtio_net_device *net_dev, size_t virq, net_queue_handle_t *rx,
-                                             net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data,
-                                             microkit_channel rx_ch, microkit_channel tx_ch,
-                                             uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ])
+static struct virtio_device *virtio_net_init(struct virtio_net_device *net_dev, virtio_transport_type_t type,
+                                             size_t virq, net_queue_handle_t *rx, net_queue_handle_t *tx,
+                                             uintptr_t rx_data, uintptr_t tx_data, microkit_channel rx_ch,
+                                             microkit_channel tx_ch, uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ])
 {
     struct virtio_device *dev = &net_dev->virtio_device;
 
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_NET;
     dev->regs.VendorID = VIRTIO_MMIO_DEV_VENDOR_ID;
+    dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = net_dev->vqs;
     dev->num_vqs = VIRTIO_NET_NUM_VIRTQ;
@@ -403,7 +404,8 @@ bool virtio_mmio_net_init(struct virtio_net_device *net_dev, uintptr_t region_ba
                           net_queue_handle_t *rx, net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data,
                           microkit_channel rx_ch, microkit_channel tx_ch, uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ])
 {
-    struct virtio_device *dev = virtio_net_init(net_dev, virq, rx, tx, rx_data, tx_data, rx_ch, tx_ch, mac);
+    struct virtio_device *dev = virtio_net_init(net_dev, VIRTIO_TRANSPORT_MMIO, virq, rx, tx, rx_data, tx_data, rx_ch,
+                                                tx_ch, mac);
 
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
@@ -412,9 +414,9 @@ bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint32_t dev_slot, s
                          net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data, microkit_channel rx_ch,
                          microkit_channel tx_ch, uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ])
 {
-    struct virtio_device *dev = virtio_net_init(net_dev, virq, rx, tx, rx_data, tx_data, rx_ch, tx_ch, mac);
+    struct virtio_device *dev = virtio_net_init(net_dev, VIRTIO_TRANSPORT_PCI, virq, rx, tx, rx_data, tx_data, rx_ch,
+                                                tx_ch, mac);
 
-    dev->transport_type = VIRTIO_TRANSPORT_PCI;
     dev->transport.pci.device_id = VIRTIO_PCI_NET_DEV_ID;
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_NETWORK_ETHERNET;

--- a/src/virtio/sound.c
+++ b/src/virtio/sound.c
@@ -683,6 +683,7 @@ bool virtio_mmio_snd_init(struct virtio_snd_device *sound_dev,
 
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_SOUND;
     dev->regs.VendorID = VIRTIO_MMIO_DEV_VENDOR_ID;
+    dev->transport_type = VIRTIO_TRANSPORT_MMIO;
     dev->funs = &functions;
     dev->vqs = sound_dev->vqs;
     dev->num_vqs = VIRTIO_SND_NUM_VIRTQ;


### PR DESCRIPTION
MMIO devices were never getting the transport type set which meant some internal functions that I have added in other branches thought they were dealing with a PCI device instead since it had a value of zero and the device structs are zero initialised.

So, a couple things:
* set the transport type properly everywhere
* more asserts
* make the enum entries start at one.