### PR TITLE
virtio: prevent a deadlock with host net

### DIFF
--- a/include/libvmm/virtio/net.h
+++ b/include/libvmm/virtio/net.h
@@ -239,13 +239,13 @@ bool virtio_mmio_net_init(struct virtio_net_device *dev,
                           uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ]);
 
 /**
- * Handles the incoming net traffic and queues the data into the virtio queues.
+ * Handles the incoming sDDF net traffic and queues the data into the virtio queues.
  * Will drop the packets if the virtio device is not yet initialized by the guest.
+ * If there are packets to be processed, injects the virtual IRQ into the guest.
  *
  * @param virtio device to use
- * @return whether data has been enqueued into the virtio queue
  */
-bool virtio_net_handle_rx(struct virtio_net_device *dev);
+void virtio_net_handle_rx(struct virtio_net_device *dev);
 
 bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint32_t pci_dev_slot, size_t virq, net_queue_handle_t *rx,
                          net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data, microkit_channel rx_ch,

--- a/include/libvmm/virtio/net.h
+++ b/include/libvmm/virtio/net.h
@@ -238,6 +238,13 @@ bool virtio_mmio_net_init(struct virtio_net_device *dev,
                           microkit_channel tx_ch,
                           uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ]);
 
+/**
+ * Handles the incoming net traffic and queues the data into the virtio queues.
+ * Will drop the packets if the virtio device is not yet initialized by the guest.
+ *
+ * @param virtio device to use
+ * @return whether data has been enqueued into the virtio queue
+ */
 bool virtio_net_handle_rx(struct virtio_net_device *dev);
 
 bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint32_t pci_dev_slot, size_t virq, net_queue_handle_t *rx,

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -322,7 +322,7 @@ static void handle_rx_buffer(struct virtio_device *dev,
     *respond_to_guest = true;
 }
 
-bool virtio_net_handle_rx(struct virtio_net_device *state)
+void virtio_net_handle_rx(struct virtio_net_device *state)
 {
     struct virtio_device *dev = &state->virtio_device;
     net_buff_desc_t sddf_buffer;
@@ -351,10 +351,8 @@ bool virtio_net_handle_rx(struct virtio_net_device *state)
     }
 
     if (respond_to_guest) {
-        return virtio_net_respond(dev);
+        virtio_net_respond(dev);
     }
-
-    return respond_to_guest;
 }
 
 static virtio_device_funs_t functions = {

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -325,23 +325,17 @@ static void handle_rx_buffer(struct virtio_device *dev,
 bool virtio_net_handle_rx(struct virtio_net_device *state)
 {
     struct virtio_device *dev = &state->virtio_device;
-
-    if (!driver_ok(dev)) {
-        return false;
-    }
-    if (!dev->vqs[VIRTIO_NET_RX_VIRTQ].ready) {
-        /* vq is not initialised, drop the packet */
-        return false;
-    }
-
     net_buff_desc_t sddf_buffer;
     bool reprocess = true;
     bool respond_to_guest = false;
 
     while (reprocess) {
         while (net_dequeue_active(&state->rx, &sddf_buffer) != -1) {
-            /* On failure, drop packet since we don't know how long until next interrupt */
-            handle_rx_buffer(dev, sddf_buffer.io_or_offset, sddf_buffer.len, &respond_to_guest);
+            /* this is likely most of the time, we don't want to pay the branch misprediction cost */
+            if (likely(driver_ok(dev) && dev->vqs[VIRTIO_NET_RX_VIRTQ].ready)) {
+                /* On failure, drop packet since we don't know how long until next interrupt */
+                handle_rx_buffer(dev, sddf_buffer.io_or_offset, sddf_buffer.len, &respond_to_guest);
+            }
 
             sddf_buffer.len = 0;
             net_enqueue_free(&state->rx, sddf_buffer);
@@ -360,7 +354,7 @@ bool virtio_net_handle_rx(struct virtio_net_device *state)
         return virtio_net_respond(dev);
     }
 
-    return true;
+    return respond_to_guest;
 }
 
 static virtio_device_funs_t functions = {


### PR DESCRIPTION
In some cases virtq initialization happens after the host already sent data to the guest. The virtio should both drop the incoming packet and reset the active signal to keep the host sending future incoming packets even if the virtq is not yet initialized. 

In case this the initialization happens after the data has been already sent, the `net_require_signal_active` on the host side (e.g. in the Copier) will never return true and the guest will never be notified. This results in a deadlock. The sane way of handling this is to drop the packets and call `net_request_signal_active` to reset the signal value.