### PR TITLE
virtio: unified virtqueue size between MMIO and PCI

### DIFF
--- a/include/libvmm/virtio/mmio.h
+++ b/include/libvmm/virtio/mmio.h
@@ -48,12 +48,6 @@
 #define VIRTIO_DEVICE_ID_CONSOLE      3
 #define VIRTIO_DEVICE_ID_SOUND        25
 
-/* The maximum size (number of elements) of a virtqueue. It is set
- * to 128 because I copied it from the camkes virtio device. If you find
- * out that the virtqueue gets full easily, increase the number.
- */
-#define QUEUE_SIZE 128
-
 /* handler of a virtqueue */
 // @ivanv: we can pack/bitfield this struct
 typedef struct virtio_queue_handler {

--- a/include/libvmm/virtio/pci.h
+++ b/include/libvmm/virtio/pci.h
@@ -144,7 +144,6 @@
 #define VIRTIO_PCI_CONSOLE_DEV_ID       0x1003
 #define VIRTIO_PCI_NOTIF_OFF_MULTIPLIER 0x2
 #define VIRTIO_PCI_QUEUE_NUM_MAX        0x2
-#define VIRTIO_PCI_QUEUE_SIZE           0x100
 
 // Type 0 headers for endpoints
 struct pci_config_space {

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -9,6 +9,12 @@
 #include <libvmm/virtio/mmio.h>
 #include <libvmm/virtio/pci.h>
 
+/* The maximum size (number of elements) of a virtqueue. It is set
+* to 128 because I copied it from the camkes virtio device. If you find
+* out that the virtqueue gets full easily, increase the number.
+*/
+#define VIRTIO_QUEUE_SIZE 128
+
 /*
  * All terminology used and functionality of the virtIO device implementation
  * adheres with the following specification:

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -9,11 +9,12 @@
 #include <libvmm/virtio/mmio.h>
 #include <libvmm/virtio/pci.h>
 
-/* The maximum size (number of elements) of a virtqueue. It is set
-* to 128 because I copied it from the camkes virtio device. If you find
-* out that the virtqueue gets full easily, increase the number.
-*/
-#define VIRTIO_QUEUE_SIZE 128
+/*
+ * Default maximum capacity of each virtIO queue. Currently applies to all
+ * virtIO queues for all virtIO devices. In the future, this could be
+ * configurable but our use-cases have not required it yet.
+ */
+#define VIRTIO_DEFAULT_QUEUE_SIZE 128
 
 /*
  * All terminology used and functionality of the virtIO device implementation

--- a/src/virtio/mmio.c
+++ b/src/virtio/mmio.c
@@ -106,7 +106,7 @@ static bool handle_virtio_mmio_reg_read(virtio_device_t *dev, size_t vcpu_id, si
         success = dev->funs->get_device_features(dev, &reg);
         break;
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_NUM_MAX, REG_VIRTIO_MMIO_QUEUE_NUM):
-        reg = QUEUE_SIZE;
+        reg = VIRTIO_QUEUE_SIZE;
         break;
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_READY, REG_VIRTIO_MMIO_QUEUE_NOTIFY):
         if (dev->regs.QueueSel < dev->num_vqs) {

--- a/src/virtio/mmio.c
+++ b/src/virtio/mmio.c
@@ -106,7 +106,7 @@ static bool handle_virtio_mmio_reg_read(virtio_device_t *dev, size_t vcpu_id, si
         success = dev->funs->get_device_features(dev, &reg);
         break;
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_NUM_MAX, REG_VIRTIO_MMIO_QUEUE_NUM):
-        reg = VIRTIO_QUEUE_SIZE;
+        reg = VIRTIO_DEFAULT_QUEUE_SIZE;
         break;
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_READY, REG_VIRTIO_MMIO_QUEUE_NOTIFY):
         if (dev->regs.QueueSel < dev->num_vqs) {

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -258,7 +258,7 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t vcpu_id, siz
         reg = dev->regs.ConfigGeneration;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_SIZE, VIRTIO_PCI_COMMON_Q_ENABLE):
-        reg = VIRTIO_QUEUE_SIZE;
+        reg = VIRTIO_DEFAULT_QUEUE_SIZE;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_ENABLE, VIRTIO_PCI_COMMON_Q_NOTIF_OFF):
         reg = dev->vqs[dev->regs.QueueSel].ready;

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -258,7 +258,7 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t vcpu_id, siz
         reg = dev->regs.ConfigGeneration;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_SIZE, VIRTIO_PCI_COMMON_Q_ENABLE):
-        reg = VIRTIO_PCI_QUEUE_SIZE;
+        reg = VIRTIO_QUEUE_SIZE;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_ENABLE, VIRTIO_PCI_COMMON_Q_NOTIF_OFF):
         reg = dev->vqs[dev->regs.QueueSel].ready;


### PR DESCRIPTION
Previously virtio MMIO devices have a virtqueue size of 128 while PCI have 256. Now we make them both 128 for consistency.