### PR TITLE
virtio: added utility functions for manipulating virtqueue

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,6 +14,7 @@ const src = [_][]const u8{
     "src/virtio/console.c",
     "src/virtio/net.c",
     "src/virtio/sound.c",
+    "src/virtio/virtio.c",
 };
 
 const src_aarch64 = [_][]const u8{

--- a/include/libvmm/util/util.h
+++ b/include/libvmm/util/util.h
@@ -25,7 +25,7 @@
 #endif
 
 #define LOG_VMM(...) do{ printf("%s|INFO: ", microkit_name); printf(__VA_ARGS__); }while(0)
-#define LOG_VMM_ERR(...) do{ printf("%s|ERROR: ", microkit_name); printf(__VA_ARGS__); }while(0)
+#define LOG_VMM_ERR(...) do{ printf("%s|ERROR (%s:%lu): ", microkit_name, __FUNCTION__, __LINE__); printf(__VA_ARGS__); }while(0)
 
 static void assert_fail(
     const char  *assertion,

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -63,3 +63,28 @@ static inline struct virtq *get_current_virtq_by_handler(virtio_device_t *dev)
  * and virtual IRQ associated with the device has been registered.
  */
 bool virtio_mmio_register_device(virtio_device_t *dev, uintptr_t region_base, uintptr_t region_size, size_t virq);
+
+/* Given a descriptor head, walk the descriptor chain and compute the sum of the length of all the desciptor chain's buffers */
+uint64_t virtio_desc_chain_payload_len(virtio_queue_handler_t *vq_handler, uint16_t desc_head);
+
+/* Given a scatter gather list of a virtio request in the form of a descriptor head, copy a chunk of data from the list,
+ * starting from `read_off` into `data`. For example, if you want the body of a virtio block read or write request,
+ * `read_off` should be `sizeof(struct virtio_blk_outhdr)`.
+ * Return true if the operation completed successfully, false if the amount of data overflows the
+ * scatter gather list. */
+bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint64_t bytes_to_read,
+                                      uint64_t read_off, char *data);
+
+/* Same idea as above but we are now writing to the scatter gather buffers in guest RAM */
+bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint64_t bytes_to_write,
+                                     uint64_t write_off, char *data);
+
+/* Peek an available descriptor head from a virtq */
+bool virtio_virtq_peek_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret);
+
+/* Pop an available descriptor head from a virtq */
+bool virtio_virtq_pop_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret);
+
+/* Given a descriptor head and the number of bytes that were written to it by the VMM, place it
+ * in the used queue */
+void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint32_t bytes_written);

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -56,6 +56,7 @@ static inline struct virtq *get_current_virtq_by_handler(virtio_device_t *dev)
     assert(dev->regs.QueueSel < dev->num_vqs);
     return &dev->vqs[dev->regs.QueueSel].virtq;
 }
+
 /*
  * Registers a new virtIO device at a given guest-physical region.
  *
@@ -64,14 +65,22 @@ static inline struct virtq *get_current_virtq_by_handler(virtio_device_t *dev)
  */
 bool virtio_mmio_register_device(virtio_device_t *dev, uintptr_t region_base, uintptr_t region_size, size_t virq);
 
-/* Given a descriptor head, walk the descriptor chain and compute the sum of the length of all the desciptor chain's buffers */
+/*
+ * Given a descriptor head, walk the descriptor chain and compute the sum of the
+ * length of all the desciptor chain's buffers
+ */
 uint64_t virtio_desc_chain_payload_len(virtio_queue_handler_t *vq_handler, uint16_t desc_head);
 
-/* Given a scatter gather list of a virtio request in the form of a descriptor head, copy a chunk of data from the list,
- * starting from `read_off` into `data`. For example, if you want the body of a virtio block read or write request,
+/*
+ * Given a scatter gather list of a virtio request in the form of a descriptor
+ * head, copy a chunk of data from the list, starting from `read_off` into `data`.
+ *
+ * For example, if you want the body of a virtio block read or write request,
  * `read_off` should be `sizeof(struct virtio_blk_outhdr)`.
- * Return true if the operation completed successfully, false if the amount of data overflows the
- * scatter gather list. */
+ *
+ * Return true if the operation completed successfully, false if the amount of data
+ * overflows the scatter gather list or invalid descriptor chain.
+ */
 bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint64_t bytes_to_read,
                                       uint64_t read_off, char *data);
 
@@ -85,6 +94,8 @@ bool virtio_virtq_peek_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret);
 /* Pop an available descriptor head from a virtq */
 bool virtio_virtq_pop_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret);
 
-/* Given a descriptor head and the number of bytes that were written to it by the VMM, place it
- * in the used queue */
+/*
+ * Given a descriptor head and the number of bytes that were written to it by the VMM,
+ * place it in the used queue
+ */
 void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint32_t bytes_written);

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -10,6 +10,7 @@
 #include <libvmm/virtio/config.h>
 #include <libvmm/virtio/mmio.h>
 #include <libvmm/virtio/console.h>
+#include <libvmm/virtio/virtio.h>
 #include <sddf/serial/queue.h>
 
 /* Uncomment this to enable debug logging */
@@ -62,7 +63,8 @@ static bool virtio_console_get_device_features(struct virtio_device *dev, uint32
         *features = BIT_HIGH(VIRTIO_F_VERSION_1);
         break;
     default:
-        LOG_CONSOLE_ERR("driver sets DeviceFeaturesSel to 0x%x, which doesn't make sense\n", dev->regs.DeviceFeaturesSel);
+        LOG_CONSOLE_ERR("driver sets DeviceFeaturesSel to 0x%x, which doesn't make sense\n",
+                        dev->regs.DeviceFeaturesSel);
         return false;
     }
 
@@ -87,7 +89,8 @@ static bool virtio_console_set_driver_features(struct virtio_device *dev, uint32
         success = (features == BIT_HIGH(VIRTIO_F_VERSION_1));
         break;
     default:
-        LOG_CONSOLE_ERR("driver sets DriverFeaturesSel to 0x%x, which doesn't make sense\n", dev->regs.DriverFeaturesSel);
+        LOG_CONSOLE_ERR("driver sets DriverFeaturesSel to 0x%x, which doesn't make sense\n",
+                        dev->regs.DriverFeaturesSel);
         return false;
     }
 
@@ -123,40 +126,65 @@ static bool virtio_console_handle_tx(struct virtio_device *dev)
     /* Transmit all available descriptors possible */
     LOG_CONSOLE("processing available buffers from index [0x%lx..0x%lx)\n", vq->last_idx, vq->virtq.avail->idx);
     bool transferred = false;
-    while (vq->last_idx != vq->virtq.avail->idx && !serial_queue_full(console->txq, console->txq->queue->head)) {
-        uint16_t desc_idx = vq->virtq.avail->ring[vq->last_idx % vq->virtq.num];
-        struct virtq_desc desc;
-        /* Traverse chained descriptors */
-        do {
-            desc = vq->virtq.desc[desc_idx];
-            // @ivanv: to the debug logging, we should actually print out the buffer contents
-            LOG_CONSOLE("processing descriptor (0x%lx) with buffer [0x%lx..0x%lx)\n", desc_idx, desc.addr, desc.addr + desc.len);
+    uint16_t desc_head;
+    while (virtio_virtq_peek_avail(vq, &desc_head) && !serial_queue_full(console->txq, console->txq->queue->head)) {
+        uint64_t payload_len = virtio_desc_chain_payload_len(vq, desc_head);
 
-            uint32_t bytes_remain = desc.len;
-            /* Copy all contiguous data */
-            while (bytes_remain > 0 && !serial_queue_full(console->txq, console->txq->queue->head)) {
-                uint32_t free = serial_queue_contiguous_free(console->txq);
-                uint32_t to_transfer = (bytes_remain < free) ? bytes_remain : free;
-                if (to_transfer) {
-                    transferred = true;
-                }
+        if (payload_len > console->txq->capacity) {
+            // @billn, fix properly by partial TX, bookkeep, then continue once serial virt notifies?
+            LOG_CONSOLE_ERR(
+                "payload length 0x%lx bytes of desciptor %u is larger than serial TX queue capacity of 0x%lx bytes\n",
+                payload_len, desc_head, console->txq->capacity);
+            assert(false);
+        }
 
-                memcpy(console->txq->data_region + (console->txq->queue->tail % console->txq->capacity),
-                       (char *)(desc.addr + (desc.len - bytes_remain)), to_transfer);
+        uint32_t serial_txq_free_len = serial_queue_free(console->txq);
 
-                serial_update_shared_tail(console->txq, console->txq->queue->tail + to_transfer);
-                bytes_remain -= to_transfer;
-            }
+        if (payload_len > serial_txq_free_len) {
+            /* Can't consume this descriptor in full for now, just wait for serial TXQ to drain. */
+            LOG_CONSOLE("payload length 0x%lx bytes of desciptor %u is larger than serial TX queue contiguous free "
+                        "length of 0x%lx bytes, won't consume for now.\n",
+                        payload_len, desc_head, serial_txq_free_len);
+            serial_request_consumer_signal(console->txq);
+            break;
+        }
+        /* Ok there is enough space in TX queue for this descriptor */
 
-            desc_idx = desc.next;
+        uint32_t serial_txq_contiguous_free_len = serial_queue_contiguous_free(console->txq);
+        bool copy_twice = false;
+        if (payload_len > serial_txq_contiguous_free_len) {
+            /* Handle case where the free space wraps around */
+            copy_twice = true;
+        }
 
-        } while (desc.flags & VIRTQ_DESC_F_NEXT && !serial_queue_full(console->txq, console->txq->queue->head));
+        uint32_t bytes_copied = 0;
 
-        struct virtq_used_elem used_elem = {vq->virtq.avail->ring[vq->last_idx % vq->virtq.num], 0};
-        vq->virtq.used->ring[vq->virtq.used->idx % vq->virtq.num] = used_elem;
-        vq->virtq.used->idx++;
+        /* Copy data until no more to copy or until the queue wraps around */
+        char *serial_txq_dest = (char *)(console->txq->data_region
+                                         + (console->txq->queue->tail % console->txq->capacity));
+        uint32_t copy_len = MIN(payload_len, serial_txq_contiguous_free_len);
+        assert(virtio_read_data_from_desc_chain(vq, desc_head, copy_len, bytes_copied, serial_txq_dest));
+        bytes_copied += copy_len;
+        serial_update_shared_tail(console->txq, console->txq->queue->tail + copy_len);
 
-        vq->last_idx++;
+        if (copy_twice) {
+            /* Need to copy more data after the queue wraps around */
+            serial_txq_dest = (char *)(console->txq->data_region
+                                       + (console->txq->queue->tail % console->txq->capacity));
+            copy_len = payload_len - bytes_copied;
+            assert(copy_len <= serial_queue_contiguous_free(console->txq));
+            assert(virtio_read_data_from_desc_chain(vq, desc_head, copy_len, bytes_copied, serial_txq_dest));
+            bytes_copied += copy_len;
+            serial_update_shared_tail(console->txq, console->txq->queue->tail + copy_len);
+        }
+
+        assert(bytes_copied == payload_len);
+
+        LOG_CONSOLE("processed descriptor %u with content: %s\n", desc_head, serial_txq_dest);
+
+        virtio_virtq_add_used(vq, desc_head, 0);
+        virtio_virtq_pop_avail(vq, &desc_head);
+        transferred = true;
     }
 
     /* While unlikely, it is possible that we could not consume any of the
@@ -179,6 +207,12 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
     LOG_CONSOLE("operation: handle rx\n");
     assert(console->virtio_device.num_vqs > RX_QUEUE);
 
+    /* Previously if a TX request have payload length:
+     * TX queue free length < payload length <= TX queue capacity
+     * We request the serial virtualiser to notify us once it has consumed data from the TX queue.
+     * So try to reprocess such requests. */
+    virtio_console_handle_tx(&(console->virtio_device));
+
     /* Used to know whether to set the IRQ status. */
     bool transferred = false;
 
@@ -194,24 +228,20 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
     }
 
     LOG_CONSOLE("processing available buffers from index [0x%lx..0x%lx)\n", vq->last_idx, vq->virtq.avail->idx);
-    while (vq->last_idx != vq->virtq.avail->idx && !serial_queue_empty(console->rxq, console->rxq->queue->head)) {
+    uint16_t desc_head;
+    while (!serial_queue_empty(console->rxq, console->rxq->queue->head) && virtio_virtq_pop_avail(vq, &desc_head)) {
         transferred = true;
-
-        uint16_t desc_head = vq->virtq.avail->ring[vq->last_idx % vq->virtq.num];
         struct virtq_desc desc = vq->virtq.desc[desc_head];
-        LOG_CONSOLE("processing descriptor (0x%lx) with buffer [0x%lx..0x%lx)\n", desc_head, desc.addr, desc.addr + desc.len);
+        LOG_CONSOLE("processing descriptor (0x%lx) with buffer [0x%lx..0x%lx)\n", desc_head, desc.addr,
+                    desc.addr + desc.len);
         uint32_t bytes_written = 0;
         char c;
         while (bytes_written < desc.len && !serial_dequeue(console->rxq, &c)) {
-            *(char *)(desc.addr + bytes_written) = c;
+            assert(virtio_write_data_to_desc_chain(vq, desc_head, 1, bytes_written, &c));
             bytes_written++;
         }
 
-        struct virtq_used_elem used_elem = {desc_head, bytes_written};
-        vq->virtq.used->ring[vq->virtq.used->idx % vq->virtq.num] = used_elem;
-        vq->virtq.used->idx++;
-
-        vq->last_idx++;
+        virtio_virtq_add_used(vq, desc_head, bytes_written);
     }
 
     /* While unlikely, it is possible that we could not consume any of the

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -11,9 +11,6 @@
 #include <libvmm/virtio/virtq.h>
 #include <libvmm/virtio/virtio.h>
 
-/* Prevent the guest from hanging us by passing a descriptor loop */
-#define MAX_WALK_LEN VIRTIO_DEFAULT_QUEUE_SIZE
-
 uint64_t virtio_desc_chain_payload_len(virtio_queue_handler_t *vq_handler, uint16_t desc_head)
 {
     assert(vq_handler->ready);
@@ -23,14 +20,16 @@ uint64_t virtio_desc_chain_payload_len(virtio_queue_handler_t *vq_handler, uint1
     uint64_t payload_len = 0;
     uint16_t curr_desc = desc_head;
     while (true) {
+        if (loop_iter_count > virtq->num || curr_desc >= virtq->num) {
+            LOG_VMM_ERR("bad descriptor chain starting at %u\n", desc_head);
+            return 0;
+        }
+
         payload_len += virtq->desc[curr_desc].len;
         if (!(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT)) {
             break;
         }
-        if (loop_iter_count > MAX_WALK_LEN) {
-            LOG_VMM_ERR("virtio_desc_chain_payload_len(): infinite loop at desc head %u\n", desc_head);
-            return 0;
-        }
+
         curr_desc = virtq->desc[curr_desc].next;
         loop_iter_count++;
     };
@@ -50,6 +49,11 @@ bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16
     uint16_t curr_desc = desc_head;
     uint64_t loop_iter_count = 0;
     while (true) {
+        if (loop_iter_count > virtq->num || curr_desc >= virtq->num) {
+            LOG_VMM_ERR("bad descriptor chain starting at %u\n", desc_head);
+            return false;
+        }
+
         struct virtq_desc *desc = &virtq->desc[curr_desc];
         uint64_t current_desc_end_byte = current_desc_start_byte + desc->len;
 
@@ -67,11 +71,6 @@ bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16
         if (current_list_byte == end_list_byte) {
             break;
         }
-        if (loop_iter_count > MAX_WALK_LEN) {
-            LOG_VMM_ERR("virtio_read_data_from_desc_chain(): infinite loop at desc head %u\n", desc_head);
-            return 0;
-        }
-
         loop_iter_count++;
         current_desc_start_byte += desc->len;
         curr_desc = virtq->desc[curr_desc].next;
@@ -93,6 +92,11 @@ bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_
     uint16_t curr_desc = desc_head;
     uint64_t loop_iter_count = 0;
     while (true) {
+        if (loop_iter_count > virtq->num || curr_desc >= virtq->num) {
+            LOG_VMM_ERR("bad descriptor chain starting at %u\n", desc_head);
+            return false;
+        }
+
         struct virtq_desc *desc = &virtq->desc[curr_desc];
         uint64_t current_desc_end_byte = current_desc_start_byte + desc->len;
 
@@ -109,10 +113,6 @@ bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_
         assert(current_list_byte <= end_list_byte);
         if (current_list_byte == end_list_byte) {
             break;
-        }
-        if (loop_iter_count > MAX_WALK_LEN) {
-            LOG_VMM_ERR("virtio_read_data_from_desc_chain(): infinite loop at desc head %u\n", desc_head);
-            return 0;
         }
 
         loop_iter_count++;
@@ -151,13 +151,13 @@ bool virtio_virtq_pop_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret)
     return available;
 }
 
-void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint32_t bytes_written)
+void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint32_t len)
 {
     assert(vq_handler->ready);
     struct virtq *virtq = &vq_handler->virtq;
 
     struct virtq_used_elem *used_elem = &virtq->used->ring[virtq->used->idx % virtq->num];
     used_elem->id = desc_head;
-    used_elem->len = bytes_written;
+    used_elem->len = len;
     virtq->used->idx++;
 }

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <microkit.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <libvmm/virtio/virtq.h>
+#include <libvmm/virtio/virtio.h>
+
+/* Prevent the guest from hanging us by passing a descriptor loop */
+#define MAX_WALK_LEN VIRTIO_DEFAULT_QUEUE_SIZE
+
+uint64_t virtio_desc_chain_payload_len(virtio_queue_handler_t *vq_handler, uint16_t desc_head)
+{
+    assert(vq_handler->ready);
+    struct virtq *virtq = &vq_handler->virtq;
+
+    uint64_t loop_iter_count = 0;
+    uint64_t payload_len = 0;
+    uint16_t curr_desc = desc_head;
+    while (true) {
+        payload_len += virtq->desc[curr_desc].len;
+        if (!(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT)) {
+            break;
+        }
+        if (loop_iter_count > MAX_WALK_LEN) {
+            LOG_VMM_ERR("virtio_desc_chain_payload_len(): infinite loop at desc head %u\n", desc_head);
+            return 0;
+        }
+        curr_desc = virtq->desc[curr_desc].next;
+        loop_iter_count++;
+    };
+    return payload_len;
+}
+
+bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint64_t bytes_to_read,
+                                      uint64_t read_off, char *data)
+{
+    assert(vq_handler->ready);
+    struct virtq *virtq = &vq_handler->virtq;
+
+    uint64_t current_list_byte = read_off;
+    uint64_t end_list_byte = read_off + bytes_to_read;
+    uint64_t current_desc_start_byte = 0;
+
+    uint16_t curr_desc = desc_head;
+    uint64_t loop_iter_count = 0;
+    while (true) {
+        struct virtq_desc *desc = &virtq->desc[curr_desc];
+        uint64_t current_desc_end_byte = current_desc_start_byte + desc->len;
+
+        if (current_list_byte >= current_desc_start_byte && current_list_byte < current_desc_end_byte) {
+            /* This descriptor have what we need, copy it over to `data`. */
+            uint64_t copy_size = MIN(current_desc_end_byte, end_list_byte) - current_list_byte;
+            uint64_t src_gpa = desc->addr + (current_list_byte - current_desc_start_byte);
+            char *dest = data + (current_list_byte - read_off);
+
+            memcpy(dest, (char *)src_gpa, copy_size);
+            current_list_byte += copy_size;
+        }
+
+        assert(current_list_byte <= end_list_byte);
+        if (current_list_byte == end_list_byte) {
+            break;
+        }
+        if (loop_iter_count > MAX_WALK_LEN) {
+            LOG_VMM_ERR("virtio_read_data_from_desc_chain(): infinite loop at desc head %u\n", desc_head);
+            return 0;
+        }
+
+        loop_iter_count++;
+        current_desc_start_byte += desc->len;
+        curr_desc = virtq->desc[curr_desc].next;
+    }
+
+    return current_list_byte == end_list_byte;
+}
+
+bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint64_t bytes_to_write,
+                                     uint64_t write_off, char *data)
+{
+    assert(vq_handler->ready);
+    struct virtq *virtq = &vq_handler->virtq;
+
+    uint64_t current_list_byte = write_off;
+    uint64_t end_list_byte = write_off + bytes_to_write;
+    uint64_t current_desc_start_byte = 0;
+
+    uint16_t curr_desc = desc_head;
+    uint64_t loop_iter_count = 0;
+    while (true) {
+        struct virtq_desc *desc = &virtq->desc[curr_desc];
+        uint64_t current_desc_end_byte = current_desc_start_byte + desc->len;
+
+        if (current_list_byte >= current_desc_start_byte && current_list_byte < current_desc_end_byte) {
+            /* This descriptor have what we need, copy `data` to guest RAM. */
+            uint64_t copy_size = MIN(current_desc_end_byte, end_list_byte) - current_list_byte;
+            char *src = data + (current_list_byte - write_off);
+            uint64_t dest_gpa = desc->addr + (current_list_byte - current_desc_start_byte);
+
+            memcpy((char *)dest_gpa, src, copy_size);
+            current_list_byte += copy_size;
+        }
+
+        assert(current_list_byte <= end_list_byte);
+        if (current_list_byte == end_list_byte) {
+            break;
+        }
+        if (loop_iter_count > MAX_WALK_LEN) {
+            LOG_VMM_ERR("virtio_read_data_from_desc_chain(): infinite loop at desc head %u\n", desc_head);
+            return 0;
+        }
+
+        loop_iter_count++;
+        current_desc_start_byte += desc->len;
+        curr_desc = virtq->desc[curr_desc].next;
+    }
+
+    return true;
+}
+
+bool virtio_virtq_peek_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret)
+{
+    assert(vq_handler->ready);
+    struct virtq *virtq = &vq_handler->virtq;
+
+    if (vq_handler->last_idx != virtq->avail->idx) {
+        *ret = virtq->avail->ring[vq_handler->last_idx % virtq->num];
+        return true;
+    }
+
+    return false;
+}
+
+bool virtio_virtq_pop_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret)
+{
+    assert(vq_handler->ready);
+
+    uint16_t desc_head;
+    bool available = virtio_virtq_peek_avail(vq_handler, &desc_head);
+
+    if (available) {
+        *ret = desc_head;
+        vq_handler->last_idx++;
+    }
+
+    return available;
+}
+
+void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint32_t bytes_written)
+{
+    assert(vq_handler->ready);
+    struct virtq *virtq = &vq_handler->virtq;
+
+    struct virtq_used_elem *used_elem = &virtq->used->ring[virtq->used->idx % virtq->num];
+    used_elem->id = desc_head;
+    used_elem->len = bytes_written;
+    virtq->used->idx++;
+}

--- a/vmm.mk
+++ b/vmm.mk
@@ -43,6 +43,7 @@ ARCH_INDEP_FILES := src/util/printf.c \
 		    src/virtio/pci.c \
 		    src/virtio/net.c \
 		    src/virtio/sound.c \
+		    src/virtio/virtio.c \
 		    src/guest.c
 
 CFILES := ${AARCH64_FILES} ${ARCH_INDEP_FILES}


### PR DESCRIPTION
Depends on https://github.com/au-ts/libvmm/pull/213 for `VIRTIO_QUEUE_SIZE`.

This PR add utility functions for manipulating virtqueue, which include common operations done across console, block and network virtio devices. So that we can get rid of most of the double/triple nested loops inside device implementations and make the code easier to read.

This PR will only apply the new utility functions to the console device as it is simple and doesn't have any pending updates in our pipeline (AFAIK). I've also made the console device more robust against TX queue full conditions. For block, I've applied them in https://github.com/au-ts/libvmm/pull/212. Network is WIP.

While simplifying the console device to use the new utility function, I found that with the existing code, if a descriptor's length exceeds the capacity of the serial TX queue. The device would just copy what it can and silently drop the rest of the data. I've added a check then crash for this condition. I'm not sure if it's worth fixing in this PR or opening an issue for future work as it would involve bookkeeping the offending request then partially servicing it every virtualiser notification.