### PR TITLE
Optimize register access in fault handler

### DIFF
--- a/include/libvmm/arch/aarch64/fault.h
+++ b/include/libvmm/arch/aarch64/fault.h
@@ -25,7 +25,7 @@ bool fault_register_vm_exception_handler(uintptr_t base, size_t size, vm_excepti
 
 /* Helpers for emulating the fault and getting fault details */
 seL4_Word *decode_rt(size_t reg_idx, seL4_UserContext *regs);
-bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs);
+bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs, size_t regs_size);
 bool fault_advance(size_t vcpu_id, seL4_UserContext *regs, uint64_t addr, uint64_t fsr, uint64_t reg_val);
 uint64_t fault_get_data_mask(uint64_t addr, uint64_t fsr);
 uint64_t fault_get_data(seL4_UserContext *regs, uint64_t fsr);

--- a/src/arch/aarch64/fault.c
+++ b/src/arch/aarch64/fault.c
@@ -23,7 +23,7 @@
 //     return !CPSR_IS_THUMB(regs->spsr);
 // }
 
-bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs)
+bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs, size_t regs_size)
 {
     // For now we just ignore it and continue
     // Assume 32-bit instruction
@@ -32,7 +32,7 @@ bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs)
      * Do not explicitly resume the TCB because we will eventually reply to the
      * fault which will result in the TCB being restarted.
      */
-    int err = seL4_TCB_WriteRegisters(BASE_VM_TCB_CAP + vcpu_id, false, 0, SEL4_USER_CONTEXT_SIZE, regs);
+    int err = seL4_TCB_WriteRegisters(BASE_VM_TCB_CAP + vcpu_id, false, regs_size, SEL4_USER_CONTEXT_SIZE, regs);
     assert(err == seL4_NoError);
 
     return (err == seL4_NoError);
@@ -257,7 +257,12 @@ bool fault_advance(size_t vcpu_id, seL4_UserContext *regs, uint64_t addr, uint64
     seL4_Word *reg_ctx = decode_rt(rt, regs);
     *reg_ctx = fault_emulate(regs, *reg_ctx, addr, fsr, reg_val);
 
-    return fault_advance_vcpu(vcpu_id, regs);
+    size_t regs_size = SEL4_USER_CONTEXT_SIZE;
+    /* Only need regs->pc */
+    if (fault_is_write(fsr)) {
+        regs_size = 1;
+    }
+    return fault_advance_vcpu(vcpu_id, regs, regs_size);
 }
 
 bool fault_handle_vcpu_exception(size_t vcpu_id)
@@ -344,7 +349,7 @@ bool fault_handle_unknown_syscall(size_t vcpu_id)
         return false;
     }
 
-    return fault_advance_vcpu(vcpu_id, &regs);
+    return fault_advance_vcpu(vcpu_id, &regs, SEL4_USER_CONTEXT_SIZE);
 }
 
 #define MAX_VM_EXCEPTION_HANDLERS 16
@@ -439,7 +444,7 @@ bool fault_handle_vm_exception(size_t vcpu_id)
         tcb_print_regs(vcpu_id);
         vcpu_print_regs(vcpu_id);
     } else {
-        return fault_advance_vcpu(vcpu_id, &regs);
+        return fault_advance_vcpu(vcpu_id, &regs, SEL4_USER_CONTEXT_SIZE);
     }
 
     return success;

--- a/src/arch/aarch64/fault.c
+++ b/src/arch/aarch64/fault.c
@@ -23,7 +23,7 @@
 //     return !CPSR_IS_THUMB(regs->spsr);
 // }
 
-bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs)
+bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs, size_t regs_size)
 {
     // For now we just ignore it and continue
     // Assume 32-bit instruction
@@ -32,7 +32,7 @@ bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs)
      * Do not explicitly resume the TCB because we will eventually reply to the
      * fault which will result in the TCB being restarted.
      */
-    int err = seL4_TCB_WriteRegisters(BASE_VM_TCB_CAP + vcpu_id, false, 0, SEL4_USER_CONTEXT_SIZE, regs);
+    int err = seL4_TCB_WriteRegisters(BASE_VM_TCB_CAP + vcpu_id, false, regs_size, SEL4_USER_CONTEXT_SIZE, regs);
     assert(err == seL4_NoError);
 
     return (err == seL4_NoError);
@@ -258,7 +258,12 @@ bool fault_advance(size_t vcpu_id, seL4_UserContext *regs, uint64_t addr, uint64
     seL4_Word *reg_ctx = decode_rt(rt, regs);
     *reg_ctx = fault_emulate(regs, *reg_ctx, addr, fsr, reg_val);
 
-    return fault_advance_vcpu(vcpu_id, regs);
+    size_t regs_size = SEL4_USER_CONTEXT_SIZE;
+    /* Only need regs->pc */
+    if (fault_is_write(fsr)) {
+        regs_size = 1;
+    }
+    return fault_advance_vcpu(vcpu_id, regs, regs_size);
 }
 
 bool fault_handle_vcpu_exception(size_t vcpu_id)
@@ -345,7 +350,7 @@ bool fault_handle_unknown_syscall(size_t vcpu_id)
         return false;
     }
 
-    return fault_advance_vcpu(vcpu_id, &regs);
+    return fault_advance_vcpu(vcpu_id, &regs, SEL4_USER_CONTEXT_SIZE);
 }
 
 #define MAX_VM_EXCEPTION_HANDLERS 16
@@ -440,7 +445,7 @@ bool fault_handle_vm_exception(size_t vcpu_id)
         tcb_print_regs(vcpu_id);
         vcpu_print_regs(vcpu_id);
     } else {
-        return fault_advance_vcpu(vcpu_id, &regs);
+        return fault_advance_vcpu(vcpu_id, &regs, SEL4_USER_CONTEXT_SIZE);
     }
 
     return success;

--- a/src/arch/aarch64/psci.c
+++ b/src/arch/aarch64/psci.c
@@ -133,7 +133,7 @@ bool handle_psci(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number, uin
         return false;
     }
 
-    bool success = fault_advance_vcpu(vcpu_id, regs);
+    bool success = fault_advance_vcpu(vcpu_id, regs, SEL4_USER_CONTEXT_SIZE);
     assert(success);
 
     return success;

--- a/src/arch/aarch64/psci.c
+++ b/src/arch/aarch64/psci.c
@@ -131,7 +131,7 @@ bool handle_psci(size_t vcpu_id, seL4_UserContext *regs, uint64_t fn_number, uin
         return false;
     }
 
-    bool success = fault_advance_vcpu(vcpu_id, regs);
+    bool success = fault_advance_vcpu(vcpu_id, regs, SEL4_USER_CONTEXT_SIZE);
     assert(success);
 
     return success;

--- a/src/arch/aarch64/smc.c
+++ b/src/arch/aarch64/smc.c
@@ -171,7 +171,7 @@ bool smc_sip_forward(size_t vcpu_id, seL4_UserContext *regs, size_t fn_number)
     regs->x6 = response.x6;
     regs->x7 = response.x7;
 
-    bool success = fault_advance_vcpu(vcpu_id, regs);
+    bool success = fault_advance_vcpu(vcpu_id, regs, SEL4_USER_CONTEXT_SIZE);
     assert(success);
 
     return success;

--- a/src/arch/aarch64/vgic/vgic_v3.c
+++ b/src/arch/aarch64/vgic/vgic_v3.c
@@ -89,7 +89,7 @@ static bool vgic_handle_fault_redist_read(size_t vcpu_id, vgic_t *vgic, uint64_t
                     target_vcpu_id);
         assert(false);
         // @ivanv: used to be ignore_fault, double check this is right
-        bool success = fault_advance_vcpu(vcpu_id, regs);
+        bool success = fault_advance_vcpu(vcpu_id, regs, SEL4_USER_CONTEXT_SIZE);
         // @ivanv: todo error handling
         assert(success);
     }

--- a/src/arch/aarch64/vgic/vgic_v3.c
+++ b/src/arch/aarch64/vgic/vgic_v3.c
@@ -90,7 +90,7 @@ static bool vgic_handle_fault_redist_read(size_t vcpu_id, vgic_t *vgic, uint64_t
                     target_vcpu_id);
         assert(false);
         // @ivanv: used to be ignore_fault, double check this is right
-        bool success = fault_advance_vcpu(vcpu_id, regs);
+        bool success = fault_advance_vcpu(vcpu_id, regs, SEL4_USER_CONTEXT_SIZE);
         // @ivanv: todo error handling
         assert(success);
     }

--- a/src/arch/aarch64/vgic/vgic_v3_cpuif.c
+++ b/src/arch/aarch64/vgic/vgic_v3_cpuif.c
@@ -44,7 +44,7 @@ bool icc_sgi1r_el1_write(size_t vcpu_id, seL4_UserContext *regs, uint64_t data)
         }
     }
 
-    return fault_advance_vcpu(vcpu_id, regs);
+    return fault_advance_vcpu(vcpu_id, regs, SEL4_USER_CONTEXT_SIZE);
 }
 
 #endif

--- a/src/arch/aarch64/vgic/vgic_v3_cpuif.c
+++ b/src/arch/aarch64/vgic/vgic_v3_cpuif.c
@@ -42,7 +42,7 @@ bool icc_sgi1r_el1_write(size_t vcpu_id, seL4_UserContext *regs, uint64_t data)
         }
     }
 
-    return fault_advance_vcpu(vcpu_id, regs);
+    return fault_advance_vcpu(vcpu_id, regs, SEL4_USER_CONTEXT_SIZE);
 }
 
 #endif


### PR DESCRIPTION
For write fault we only need to touch a single register for fault_advance, to not do a full write, introduce a regs_size argument to fault_advance_vcpu and pass it to seL4_TCB_WriteRegisters.

The actual optimization depends on this commit in seL4: https://github.com/seL4/seL4/commit/19a520a22bc22597b3a6510d202edb35bf514c50