### PR TITLE
examples: remove -DMICROKIT_CONFIG

### DIFF
--- a/examples/rust/rust.mk
+++ b/examples/rust/rust.mk
@@ -39,7 +39,6 @@ CFLAGS := \
 	  -ffreestanding \
 	  -g3 -O3 -Wall \
 	  -Wno-unused-function \
-	  -DMICROKIT_CONFIG_$(MICROKIT_CONFIG) \
 	  -DBOARD_$(MICROKIT_BOARD) \
 	  -I$(BOARD_DIR)/include \
 	  -I$(LIBVMM)/include \

--- a/examples/simple/simple.mk
+++ b/examples/simple/simple.mk
@@ -28,7 +28,6 @@ CFLAGS := \
 	  -ffreestanding \
 	  -g3 -O3 -Wall \
 	  -Wno-unused-function \
-	  -DMICROKIT_CONFIG_$(MICROKIT_CONFIG) \
 	  -DBOARD_$(MICROKIT_BOARD) \
 	  -I$(BOARD_DIR)/include \
 	  -I$(LIBVMM)/include \

--- a/examples/virtio-snd/virtio_snd.mk
+++ b/examples/virtio-snd/virtio_snd.mk
@@ -34,7 +34,6 @@ CFLAGS := \
 	  -ffreestanding \
 	  -g3 -O3 -Wall \
 	  -Wno-unused-function \
-	  -DMICROKIT_CONFIG_$(MICROKIT_CONFIG) \
 	  -DBOARD_$(MICROKIT_BOARD) \
 	  -I$(BOARD_DIR)/include \
 	  -I$(SDDF)/include \

--- a/examples/virtio/virtio.mk
+++ b/examples/virtio/virtio.mk
@@ -46,7 +46,6 @@ vpath %.c $(SDDF) $(LIBVMM) $(VIRTIO_EXAMPLE)
 CFLAGS += \
 	  -Wall \
 	  -Wno-unused-function \
-	  -DMICROKIT_CONFIG_$(MICROKIT_CONFIG) \
 	  -DBOARD_$(MICROKIT_BOARD) \
 	  -I$(BOARD_DIR)/include \
 	  -I$(SDDF)/include \

--- a/examples/virtio_pci/virtio_pci.mk
+++ b/examples/virtio_pci/virtio_pci.mk
@@ -45,7 +45,6 @@ vpath %.c $(SDDF) $(LIBVMM) $(VIRTIO_EXAMPLE)
 CFLAGS += \
 	  -Wall \
 	  -Wno-unused-function \
-	  -DMICROKIT_CONFIG_$(MICROKIT_CONFIG) \
 	  -DBOARD_$(MICROKIT_BOARD) \
 	  -I$(BOARD_DIR)/include \
 	  -I$(SDDF)/include \


### PR DESCRIPTION
Not actually used in any of our C code. I think I used to use it but then I realised it's better to just rely on CONFIG_*