### PR TITLE
examples: use vIRQ passthrough API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ name: CI
 
 on:
   pull_request:
-    types: [synchronize, labeled]
+    types: [opened, synchronize, labeled]
   push:
     branches: [ "main" ]
   schedule:

--- a/examples/rust/src/vmm.rs
+++ b/examples/rust/src/vmm.rs
@@ -6,7 +6,6 @@
 #![feature(never_type)]
 
 use core::{include_bytes};
-use core::ffi::{c_void};
 
 use sel4_microkit::{protection_domain, MessageInfo, Channel, Child, Handler, debug_println};
 
@@ -38,20 +37,10 @@ extern "C" {
                           dtb_src: usize, dtb_dest: usize, dtb_size: usize,
                           initrd_src: usize, initrd_dest: usize, initrd_size: usize) -> usize;
     fn virq_controller_init() -> bool;
-    fn virq_register(vcpu_id: usize, irq: i32, ack_fn: extern fn(usize, i32, *const c_void), ack_data: *const c_void) -> bool;
-    fn virq_inject(irq: i32) -> bool;
+    fn virq_register_passthrough(vcpu_id: usize, irq: i32, irq_ch: u32) -> bool;
+    fn virq_handle_passthrough(irq_ch: u32) -> bool;
     fn guest_start(kernel_pc: usize, dtb: usize, initrd: usize) -> bool;
     fn fault_handle(vcpu_id: usize, msginfo: MessageInfo) -> bool;
-}
-
-extern "C" fn uart_irq_ack(_: usize, _: i32, _: *const c_void) {
-    match UART_CH.irq_ack() {
-        // Do nothing if there's no problem
-        Ok(()) => {}
-        Err(_e) => {
-            debug_println!("VMM|ERROR: received ack from guest, but could not ack UART IRQ channel: {_e}");
-        }
-    }
 }
 
 #[protection_domain]
@@ -77,14 +66,8 @@ fn init() -> VmmHandler {
                                          );
         let success = virq_controller_init();
         assert!(success);
-        let success = virq_register(GUEST_BOOT_VCPU_ID, UART_IRQ as i32, uart_irq_ack, core::ptr::null());
+        let success = virq_register_passthrough(GUEST_BOOT_VCPU_ID, UART_IRQ as i32, UART_CH.index() as u32);
         assert!(success);
-        match UART_CH.irq_ack() {
-            Ok(()) => {}
-            Err(_e) => {
-                debug_println!("VMM|ERROR: could not ack UART IRQ channel: {_e}");
-            }
-        }
         guest_start(guest_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
     }
 
@@ -100,7 +83,7 @@ impl Handler for VmmHandler {
         match channel {
             UART_CH => {
                 unsafe {
-                    let success = virq_inject(UART_IRQ as i32);
+                    let success = virq_handle_passthrough(UART_CH.index() as u32);
                     if !success {
                         debug_println!("VMM|ERROR: could not inject UART IRQ");
                     }

--- a/examples/simple/vmm.c
+++ b/examples/simple/vmm.c
@@ -55,15 +55,6 @@ extern char _guest_initrd_image_end[];
 /* Microkit will set this variable to the start of the guest RAM memory region. */
 uintptr_t guest_ram_vaddr;
 
-static void serial_ack(size_t vcpu_id, int irq, void *cookie)
-{
-    /*
-     * For now we by default simply ack the serial IRQ, we have not
-     * come across a case yet where more than this needs to be done.
-     */
-    microkit_irq_ack(SERIAL_IRQ_CH);
-}
-
 void init(void)
 {
     /* Initialise the VMM, the VCPU(s), and start the guest */
@@ -85,9 +76,8 @@ void init(void)
         LOG_VMM_ERR("Failed to initialise emulated interrupt controller\n");
         return;
     }
-    success = virq_register(GUEST_BOOT_VCPU_ID, SERIAL_IRQ, &serial_ack, NULL);
-    /* Just in case there is already an interrupt available to handle, we ack it here. */
-    microkit_irq_ack(SERIAL_IRQ_CH);
+    success = virq_register_passthrough(GUEST_BOOT_VCPU_ID, SERIAL_IRQ, SERIAL_IRQ_CH);
+    assert(success);
     /* Finally start the guest */
     guest_start(kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
 }
@@ -96,7 +86,7 @@ void notified(microkit_channel ch)
 {
     switch (ch) {
     case SERIAL_IRQ_CH: {
-        bool success = virq_inject(SERIAL_IRQ);
+        bool success = virq_handle_passthrough(ch);
         if (!success) {
             LOG_VMM_ERR("IRQ %d dropped\n", SERIAL_IRQ);
         }

--- a/examples/zig/src/vmm.zig
+++ b/examples/zig/src/vmm.zig
@@ -84,11 +84,6 @@ const log = struct {
 const SERIAL_IRQ_CH: c.microkit_channel = 1;
 const SERIAL_IRQ: i32 = 33;
 
-fn serial_ack(_: usize, _: c_int, _: ?*anyopaque) callconv(.c) void {
-    // Nothing else needs to be done other than acking the IRQ.
-    c.microkit_irq_ack(SERIAL_IRQ_CH);
-}
-
 export fn init() callconv(.c) void {
     // Initialise the VMM, the VCPU(s), and start the guest
     log.info("starting", .{});
@@ -114,13 +109,10 @@ export fn init() callconv(.c) void {
         return;
     }
     // Register the interrupt for the UART with the virtual interrupt controller
-    if (!c.virq_register(GUEST_BOOT_VCPU_ID, SERIAL_IRQ, &serial_ack, null)) {
+    if (!c.virq_register_passthrough(GUEST_BOOT_VCPU_ID, SERIAL_IRQ, SERIAL_IRQ_CH)) {
         log.err("Failed to register serial IRQ\n", .{});
         return;
     }
-    // Just in case there is already an interrupt from the UART available to
-    // handle, we ack it here.
-    c.microkit_irq_ack(SERIAL_IRQ_CH);
     // Finally we can start the guest
     if (!c.guest_start(kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR)) {
         log.err("Failed to start guest\n", .{});
@@ -131,7 +123,7 @@ export fn init() callconv(.c) void {
 export fn notified(ch: c.microkit_channel) callconv(.c) void {
     switch (ch) {
         SERIAL_IRQ_CH => {
-            const success = c.virq_inject(SERIAL_IRQ);
+            const success = c.virq_handle_passthrough(SERIAL_IRQ_CH);
             if (!success) {
                 log.err("IRQ {x} dropped\n", .{ SERIAL_IRQ });
             }
@@ -140,10 +132,8 @@ export fn notified(ch: c.microkit_channel) callconv(.c) void {
     }
 }
 
-extern fn fault_handle(id: c.microkit_child, msginfo: c.microkit_msginfo) callconv(.c) bool;
-
 export fn fault(id: c.microkit_child, msginfo: c.microkit_msginfo, msginfo_reply: *c.microkit_msginfo) callconv(.c) bool {
-    if (fault_handle(id, msginfo)) {
+    if (c.fault_handle(id, msginfo)) {
         // Now that we have handled the fault, we reply to it so that the guest can resume execution.
         msginfo_reply.* = c.microkit_msginfo_new(0, 0);
         return true;


### PR DESCRIPTION
These examples existed before we had an API for dealing with pass-through IRQs, we should just use those instead now.

Also remove explicit microkit_irq_ack calls, it's not necessary.