### PR TITLE
virtio: remove 'mmio' naming from generic device handlers

### DIFF
--- a/include/libvmm/virtio/mmio.h
+++ b/include/libvmm/virtio/mmio.h
@@ -10,12 +10,12 @@
 #include <libvmm/util/util.h>
 #include <libvmm/virtio/virtq.h>
 
+#define VIRTIO_DEV_VENDOR_ID                0x344c6573 // "seL4"
+
 // table 4.1
 #define VIRTIO_MMIO_DEV_MAGIC               0x74726976 // "virt"
 #define VIRTIO_MMIO_DEV_VERSION             0x2
 #define VIRTIO_MMIO_DEV_VERSION_LEGACY      0x1
-#define VIRTIO_MMIO_DEV_VERSION_LEGACY      0x1
-#define VIRTIO_MMIO_DEV_VENDOR_ID           0x344c6573 // "seL4"
 
 #define REG_VIRTIO_MMIO_MAGIC_VALUE         0x000
 #define REG_VIRTIO_MMIO_VERSION             0x004

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -49,13 +49,13 @@ static inline struct virtio_blk_device *device_state(struct virtio_device *dev)
     return (struct virtio_blk_device *)dev->device_data;
 }
 
-static inline void virtio_blk_mmio_reset(struct virtio_device *dev)
+static inline void virtio_blk_reset(struct virtio_device *dev)
 {
     dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].ready = false;
     dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].last_idx = 0;
 }
 
-static inline bool virtio_blk_mmio_get_device_features(struct virtio_device *dev, uint32_t *features)
+static inline bool virtio_blk_get_device_features(struct virtio_device *dev, uint32_t *features)
 {
     if (dev->regs.Status & VIRTIO_CONFIG_S_FEATURES_OK) {
         LOG_BLOCK_ERR("driver somehow wants to read device features after FEATURES_OK\n");
@@ -82,7 +82,7 @@ static inline bool virtio_blk_mmio_get_device_features(struct virtio_device *dev
     return true;
 }
 
-static inline bool virtio_blk_mmio_set_driver_features(struct virtio_device *dev, uint32_t features)
+static inline bool virtio_blk_set_driver_features(struct virtio_device *dev, uint32_t features)
 {
     /* According to virtio initialisation protocol,
        this should check what device features were set, and return the subset of
@@ -118,7 +118,7 @@ static inline bool virtio_blk_mmio_set_driver_features(struct virtio_device *dev
     return success;
 }
 
-static inline bool virtio_blk_mmio_get_device_config(struct virtio_device *dev, uint32_t offset, uint32_t *ret_val)
+static inline bool virtio_blk_get_device_config(struct virtio_device *dev, uint32_t offset, uint32_t *ret_val)
 {
     struct virtio_blk_device *state = device_state(dev);
 
@@ -131,7 +131,7 @@ static inline bool virtio_blk_mmio_get_device_config(struct virtio_device *dev, 
     return true;
 }
 
-static inline bool virtio_blk_mmio_set_device_config(struct virtio_device *dev, uint32_t offset, uint32_t val)
+static inline bool virtio_blk_set_device_config(struct virtio_device *dev, uint32_t offset, uint32_t val)
 {
     struct virtio_blk_device *state = device_state(dev);
 
@@ -551,22 +551,22 @@ stop_processing:
     return !has_dropped;
 }
 
-static bool virtio_blk_mmio_queue_notify(struct virtio_device *dev)
+static bool virtio_blk_queue_notify(struct virtio_device *dev)
 {
     int nums_consumed = 0;
-    LOG_BLOCK("virtio_blk_mmio_queue_notify calling handle_client_requests\n");
+    LOG_BLOCK("virtio_blk_queue_notify calling handle_client_requests\n");
     bool consumption_status = handle_client_requests(dev, &nums_consumed);
 
     bool virq_inject_success = true;
     if (!consumption_status) {
-        LOG_BLOCK("virtio_blk_mmio_queue_notify dropped requests\n");
+        LOG_BLOCK("virtio_blk_queue_notify dropped requests\n");
         virtio_blk_set_interrupt_status(dev, true, false);
         virq_inject_success = virtio_blk_virq_inject(dev);
     }
 
     struct virtio_blk_device *state = device_state(dev);
     if (nums_consumed && !blk_queue_plugged_req(&state->queue_h)) {
-        LOG_BLOCK("virtio_blk_mmio_queue_notify notified virt\n");
+        LOG_BLOCK("virtio_blk_queue_notify notified virt\n");
         microkit_notify(state->server_ch);
     }
 
@@ -830,12 +830,12 @@ static inline void virtio_blk_config_init(struct virtio_blk_device *blk_dev)
 }
 
 static virtio_device_funs_t functions = {
-    .device_reset = virtio_blk_mmio_reset,
-    .get_device_features = virtio_blk_mmio_get_device_features,
-    .set_driver_features = virtio_blk_mmio_set_driver_features,
-    .get_device_config = virtio_blk_mmio_get_device_config,
-    .set_device_config = virtio_blk_mmio_set_device_config,
-    .queue_notify = virtio_blk_mmio_queue_notify,
+    .device_reset = virtio_blk_reset,
+    .get_device_features = virtio_blk_get_device_features,
+    .set_driver_features = virtio_blk_set_driver_features,
+    .get_device_config = virtio_blk_get_device_config,
+    .set_device_config = virtio_blk_set_device_config,
+    .queue_notify = virtio_blk_queue_notify,
 };
 
 static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, virtio_transport_type_t type,
@@ -845,7 +845,7 @@ static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, 
 {
     struct virtio_device *dev = &blk_dev->virtio_device;
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_BLOCK;
-    dev->regs.VendorID = VIRTIO_MMIO_DEV_VENDOR_ID;
+    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
     dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = blk_dev->vqs;

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -242,7 +242,7 @@ static struct virtio_device *virtio_console_init(struct virtio_console_device *c
 {
     struct virtio_device *dev = &console->virtio_device;
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_CONSOLE;
-    dev->regs.VendorID = VIRTIO_MMIO_DEV_VENDOR_ID;
+    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
     dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = console->vqs;

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -419,7 +419,7 @@ static struct virtio_device *virtio_net_init(struct virtio_net_device *net_dev, 
     struct virtio_device *dev = &net_dev->virtio_device;
 
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_NET;
-    dev->regs.VendorID = VIRTIO_MMIO_DEV_VENDOR_ID;
+    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
     dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = net_dev->vqs;

--- a/src/virtio/sound.c
+++ b/src/virtio/sound.c
@@ -34,7 +34,7 @@ static inline struct virtio_snd_device *device_state(struct virtio_device *dev)
     return (struct virtio_snd_device *)dev->device_data;
 }
 
-static void virtio_snd_mmio_reset(struct virtio_device *dev)
+static void virtio_snd_reset(struct virtio_device *dev)
 {
     LOG_SOUND("Resetting virtIO sound device\n");
 
@@ -44,7 +44,7 @@ static void virtio_snd_mmio_reset(struct virtio_device *dev)
     }
 }
 
-static bool virtio_snd_mmio_get_device_features(struct virtio_device *dev, uint32_t *features)
+static bool virtio_snd_get_device_features(struct virtio_device *dev, uint32_t *features)
 {
     switch (dev->regs.DeviceFeaturesSel) {
     case 0:
@@ -62,7 +62,7 @@ static bool virtio_snd_mmio_get_device_features(struct virtio_device *dev, uint3
     return true;
 }
 
-static bool virtio_snd_mmio_set_driver_features(struct virtio_device *dev, uint32_t features)
+static bool virtio_snd_set_driver_features(struct virtio_device *dev, uint32_t features)
 {
     bool success = false;
     switch (dev->regs.DriverFeaturesSel) {
@@ -86,7 +86,7 @@ static bool virtio_snd_mmio_set_driver_features(struct virtio_device *dev, uint3
     return success;
 }
 
-static bool virtio_snd_mmio_get_device_config(struct virtio_device *dev, uint32_t offset, uint32_t *ret_val)
+static bool virtio_snd_get_device_config(struct virtio_device *dev, uint32_t offset, uint32_t *ret_val)
 {
     struct virtio_snd_device *state = device_state(dev);
     uintptr_t config_base_addr = (uintptr_t)&state->config;
@@ -96,7 +96,7 @@ static bool virtio_snd_mmio_get_device_config(struct virtio_device *dev, uint32_
     return true;
 }
 
-static bool virtio_snd_mmio_set_device_config(struct virtio_device *dev, uint32_t offset, uint32_t val)
+static bool virtio_snd_set_device_config(struct virtio_device *dev, uint32_t offset, uint32_t val)
 {
     LOG_SOUND_ERR("Not allowed to change sound config.");
     return false;
@@ -637,7 +637,7 @@ static void handle_virtq(struct virtio_device *dev,
     vq->last_idx = idx;
 }
 
-static bool virtio_snd_mmio_queue_notify(struct virtio_device *dev)
+static bool virtio_snd_queue_notify(struct virtio_device *dev)
 {
     struct virtio_snd_device *state = device_state(dev);
 
@@ -662,27 +662,21 @@ static bool virtio_snd_mmio_queue_notify(struct virtio_device *dev)
 }
 
 static virtio_device_funs_t functions = {
-    .device_reset = virtio_snd_mmio_reset,
-    .get_device_features = virtio_snd_mmio_get_device_features,
-    .set_driver_features = virtio_snd_mmio_set_driver_features,
-    .get_device_config = virtio_snd_mmio_get_device_config,
-    .set_device_config = virtio_snd_mmio_set_device_config,
-    .queue_notify = virtio_snd_mmio_queue_notify,
+    .device_reset = virtio_snd_reset,
+    .get_device_features = virtio_snd_get_device_features,
+    .set_driver_features = virtio_snd_set_driver_features,
+    .get_device_config = virtio_snd_get_device_config,
+    .set_device_config = virtio_snd_set_device_config,
+    .queue_notify = virtio_snd_queue_notify,
 };
 
-bool virtio_mmio_snd_init(struct virtio_snd_device *sound_dev,
-                          uintptr_t region_base,
-                          uintptr_t region_size,
-                          size_t virq,
-                          sound_shared_state_t *shared_state,
-                          sound_queues_t *queues,
-                          uintptr_t data_region,
-                          int server_ch)
+bool virtio_snd_init(struct virtio_snd_device *sound_dev, uintptr_t region_base, uintptr_t region_size, size_t virq,
+                     sound_shared_state_t *shared_state, sound_queues_t *queues, uintptr_t data_region, int server_ch)
 {
     struct virtio_device *dev = &sound_dev->virtio_device;
 
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_SOUND;
-    dev->regs.VendorID = VIRTIO_MMIO_DEV_VENDOR_ID;
+    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
     dev->transport_type = VIRTIO_TRANSPORT_MMIO;
     dev->funs = &functions;
     dev->vqs = sound_dev->vqs;


### PR DESCRIPTION
These functions are all agnostic to the transport type.