### PR TITLE
flake.nix: add a way to build Linux images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,17 @@ jobs:
           name: MANUAL
           path: docs/MANUAL.pdf
 
+  build_guest_images:
+    name: Build guest images (Nix)
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v27
+      - name: Build guest images
+        run: nix build .#images
+
   build_macos_arm64:
     name: Build examples (macOS ARM64)
     runs-on: macos-14

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ rust/target/
 compile_commands.json
 *.orig
 __pycache__/
+result

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,60 @@
       forAllSystems = with nixpkgs.lib; genAttrs (builtins.attrNames microkit-platforms);
     in
     {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+
+          linux-613 = pkgs.fetchFromGitHub {
+            owner = "torvalds";
+            repo = "linux";
+            rev = "v6.13";
+            hash = "sha256-FD22KmTFrIhED5X3rcjPTot1UOq1ir1zouEpRWZkRC0=";
+          };
+
+          linux-518 = pkgs.fetchFromGitHub {
+            owner = "torvalds";
+            repo = "linux";
+            rev = "v5.18";
+            hash = "sha256-EB4nc9eHNAY2bHZVAnTckh/WpUkZN5EUj3rXZFR0E0M=";
+          };
+
+          linux-aarch64-example-simple = (pkgs.pkgsCross.aarch64-multiplatform.callPackage ./tools/linux/linux.nix {}) {
+            version = "5.18";
+            src = linux-518;
+            arch = "arm64";
+            configFile = ./examples/simple/images/linux_config;
+          };
+
+          linux-aarch64-example-virtio = (pkgs.pkgsCross.aarch64-multiplatform.callPackage ./tools/linux/linux.nix {}) {
+            version = "6.13";
+            src = linux-613;
+            arch = "arm64";
+            configFile = ./examples/virtio/client_vm/linux_config;
+          };
+
+          allImages = pkgs.runCommand "all-images" { nativeBuildInputs = with pkgs; [ gnutar gzip ]; }
+            ''
+              mkdir -p $out
+
+              mkdir -p $out/linux-aarch64-example-simple/
+              cp ${linux-aarch64-example-simple}/* $out/linux-aarch64-example-simple/
+
+              mkdir -p $out/linux-aarch64-example-virtio/
+              cp ${linux-aarch64-example-virtio}/* $out/linux-aarch64-example-virtio/
+
+              cd $out
+              for f in linux-*; do tar cf - $f | gzip -9 > `basename $f`.tar.gz; done
+            ''
+          ;
+        in
+        {
+          images = allImages;
+        }
+      );
       devShells = forAllSystems (
         system:
         let

--- a/tools/linux/linux.nix
+++ b/tools/linux/linux.nix
@@ -1,0 +1,116 @@
+#
+# Copyright 2026, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+#
+{
+  stdenv,
+  lib,
+  elfutils,
+  bc,
+  bison,
+  dtc,
+  fetchFromGitHub,
+  fetchpatch,
+  fetchurl,
+  flex,
+  perl,
+  gnutls,
+  installShellFiles,
+  libuuid,
+  meson-tools,
+  ncurses,
+  openssl,
+  python3,
+  pkg-config,
+  which,
+  buildPackages,
+  callPackages,
+}@pkgs:
+
+  lib.makeOverridable (
+    {
+      arch,
+      version,
+      src,
+      installDir ? "$out",
+      configFile,
+      extraPatches ? [ ],
+      extraMakeFlags ? [ ],
+      stdenv ? pkgs.stdenv,
+      # TODO: actually implement
+      extraFilesToInstall ? [ ],
+      ...
+    }@args:
+    stdenv.mkDerivation (
+      {
+        inherit version src;
+
+        pname = "linux-${arch}-${configFile}";
+
+        patches = extraPatches;
+
+        # postPatch = ''
+        #   ${lib.concatMapStrings (script: ''
+        #     substituteInPlace ${script} \
+        #     --replace "#!/usr/bin/env python3" "#!${pythonScriptsToInstall.${script}}/bin/python3"
+        #   '') (builtins.attrNames pythonScriptsToInstall)}
+        #   patchShebangs tools
+        #   patchShebangs scripts
+        # '';
+
+        nativeBuildInputs = [
+          ncurses # tools/kwboot
+          perl
+          bc
+          bison
+          openssl
+          pkg-config
+          flex
+          installShellFiles
+          python3
+          which
+          elfutils
+        ];
+        depsBuildBuild = [ buildPackages.gccStdenv.cc ]; # gccStdenv is needed for Darwin buildPlatform
+
+        hardeningDisable = [ "all" ];
+
+        enableParallelBuilding = true;
+
+        makeFlags = [
+          "ARCH=${arch}"
+          "DTC=${lib.getExe buildPackages.dtc}"
+          "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+          "HOSTCFLAGS=-fcommon"
+        ]
+        ++ extraMakeFlags;
+
+        passAsFile = [ "extraConfig" ];
+
+        configurePhase = ''
+          runHook preConfigure
+
+          cp ${configFile} .config
+          make $makeFlags -j$NIX_BUILD_CORES
+
+          runHook postConfigure
+        '';
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p ${installDir}
+          cp .config ${installDir}/config
+          cp vmlinux ${installDir}
+          ls -l arch/${arch}/boot/Image && cp arch/${arch}/boot/Image ${installDir}
+          ls -l arch/${arch}/boot/Image.gz && cp arch/${arch}/boot/Image.gz ${installDir}
+          ls -l arch/${arch}/boot/bzImage && cp arch/${arch}/boot/bzImage ${installDir}
+
+          runHook postInstall
+        '';
+
+        dontStrip = true;
+
+      }
+    )
+  )


### PR DESCRIPTION
This isn't hooked up to the images that end up on the TS downloads (yet, could be done in the future).

However, it is pretty convenient to have a way to easily reproduce the images that we host and at least we could test that it all builds.