### PR TITLE
Better management of guest RAM + other fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,8 @@ const LazyPath = std.Build.LazyPath;
 
 const src = [_][]const u8{
     "src/guest.c",
+    "src/guest_ram.c",
+    "src/util/util.c",
     "src/virtio/mmio.c",
     "src/virtio/pci.c",
     "src/virtio/block.c",

--- a/docs/INTERFACE.md
+++ b/docs/INTERFACE.md
@@ -6,79 +6,89 @@
 # Virtual machine Library
 The virtual machine library provides the following interfaces:
 
-` uintptr_t linux_setup_images(uintptr_t` *ram\_start*,
-                             uintptr_t *kernel*,
-                             size_t *kernel\_size*,
-                             uintptr_t *dtb\_src*,
-                             uintptr_t *dtb\_dest*,
-                             size_t *dtb\_size*,
-                             uintptr_t *initrd\_src*,
-                             uintptr_t *initrd\_dest*,
-                             size_t *initrd\_size*)`
-							 
-
+```c
+uint64_t linux_setup_images(uint64_t ram_start_gpa,
+                            uintptr_t kernel,
+                            size_t kernel_size,
+                            uintptr_t dtb_src,
+                            uint64_t dtb_dest_gpa,
+                            size_t dtb_size,
+                            uintptr_t initrd_src,
+                            uint64_t initrd_dest_gpa,
+                            size_t initrd_size)
+```
 
 `linux_setup_images` is used to copy Linux kernel, initial RAM disk
-and device tree into guest RAM ready for execution.  The first
-argument *ram\_start* is the virtual address of the guest RAM.
+and device tree into guest RAM ready for execution. The first
+argument *ram\_start\_gpa* is the guest physical address of the guest RAM.
 
 The memory pointed to by *kernel* is checked to see that it is a Linux
-kernel `vmlinux`-style
-image before it is copied into an appropriate place in the guest RAM.
+kernel image before it is copied into an appropriate place in the guest RAM.
 
-
-*initrd\_dest* and *dtb\_dest* should match what is in the Device
+*dtb\_dest\_gpa* and *initrd\_dest\_gpa* should match what is in the Device
 Tree.
 
-`linux_setup_images()` returns the kernel entry point if successful,
-otherwise -1.
+`linux_setup_images()` returns the kernel entry point as guest physical address
+if successful, otherwise 0.
 
 
-`bool virq_controller_init(size_t cpu_id)`
-Call to initialise the interrupt controller for a guest. This must be
-done before calling `virq_register()`
+```c
+bool virq_controller_init()
+```
+Call to initialise the virtual interrupt controller for a guest. This must be
+done before calling `virq_register()`.
 
-`bool virq_register(size_t vcpu_id, size_t virq_num, 
-	virq_ack_fn_t ack_fn, 
-	void *ack_data);`
-
+```c
+bool virq_register(size_t vcpu_id, size_t virq_num, virq_ack_fn_t ack_fn, void *ack_data)
+```
 Register an interrupt with the virtual interrupt controller.
 The arguments are:
 
-  `vpcu_id` the virtual CPU number to devlvier interrupts to
+  `vpcu_id` the virtual CPU number to devlvier interrupts to.
 
-  `virq_num` the IRQ number to deliver
-  
+  `virq_num` the IRQ number to deliver.
+
   `ack_fn` a function to be called when the guest acknowledges the
-  interrupt
-  
-	`ack_data` a cookie to be passed to the `ack_fn` when called.
+  interrupt.
+
+  `ack_data` a cookie to be passed to the `ack_fn` when called.
 
 
-`bool virq_inject(size_t vcpu_id, int irq)`
+```c
+bool virq_inject(int irq)
+```
 
-Inject interrupt `irq` into the virtual interrupt controller on virtual
-cpu `vcpu_id`
+Inject an IRQ into the boot virtual CPU. Note that this API requires that
+the IRQ has been registered (with virq_register).
 
-`bool virq_register_passthrough(size_t vcpu_id, size_t irq,
-microkit_channel irq_ch);`
+```c
+bool virq_inject_vcpu(size_t vcpu_id, int irq)
+```
+
+The same functionality as `virq_inject`, but will inject the virtual IRQ into a specific virtual CPU.
+
+```c
+bool virq_register_passthrough(size_t vcpu_id, size_t irq, microkit_channel irq_ch)
+```
 
 Tell the system that interrupt request `irq` is a hardware interrupt
 that will be passed through to the guest.  `irq_ch` is the channel in
 the System Description File that maps to that interrupt.
 
-`bool virq_handle_passthrough(microkit_channel irq_ch)`
-Perform an interrupt injection for the interrupt registered with 
-`virq_register_passthrough()` for channel `irq_ch`
+```c
+bool virq_handle_passthrough(microkit_channel irq_ch)
+```
 
-`bool guest_start(size_t boot_vcpu_id, uintptr_t kernel_pc, uintptr_t
-dtb, uintptr_t initrd);`
+Perform an interrupt injection for the interrupt registered with
+`virq_register_passthrough()` for channel `irq_ch`.
+
+```c
+bool guest_start(uintptr_t kernel_pc, uintptr_t dtb, uintptr_t initrd)
+```
 Start a guest Linux system, by passing control to the kernel entry
 point.
 
-`void guest_stop(size_t boot_vcpu_id);`
+```c
+void guest_stop()
+```
 Stop executing the guest.
-
-`bool guest_restart(size_t boot_vcpu_id, uintptr_t guest_ram_vaddr,
-size_t guest_ram_size);`
-Restart the guest, possibly with a different image.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -112,11 +112,9 @@ that it has access to its own RAM.
 
 We can see that the region is mapped into the VMM with
 `setvar_vaddr="guest_ram_vaddr"`. The VMM expects that variable to contain
-the starting address of the guest's RAM. With the current implementation of the
-VMM, it expects that the virtual address of the guest RAM that is mapped into
-the VMM as well as the guest physical address of the guest RAM to be the same.
-This is done for simplicity at the moment, but could be changed in the future
-if someone had a strong desire for the two values to not be coupled.
+the starting address of the guest's RAM. There is no requirements for the
+VMM virtual address and guest physical address of RAM to match, as the VMM
+will automatically translate them as necessary during the fault handling process.
 
 ## UART device region
 
@@ -206,7 +204,7 @@ Devices which communicate through DMA see the world through host physical
 addresses, however virtual machines will give devices guest physical addresses
 (i.e., host virtual addresses).  In order for DMA passthrough to work, these two
 addresses must be aligned. This can be done by setting the `phys_addr` of the
-guest's RAM to be the same as its mapped virtual address.
+guest's RAM to be the same as what you declares as RAM start in the guest DTS.
 ```xml
 <memory_region name="guest_ram" size="0x10_000_000" phys_addr="0x20000000" page_size="0x200_000" />
 <protection_domain ...>

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -66,21 +66,23 @@ The first step before writing code is to have a system description that contains
 a virtual machine and the VMM protection domain (PD).
 
 The following is essentially what is in
-[the QEMU example system](../board/qemu_virt_aarch64/systems/simple.system),
+[the QEMU example system](../examples/simple/board/qemu_virt_aarch64/simple.system):
 
 ```xml
-<memory_region name="guest_ram" size="0x10_000_000" />
-<memory_region name="uart" size="0x1_000" phys_addr="0x9000000" />
+<memory_region name="guest_ram" size="0x10_000_000" page_size="0x200_000" />
+<memory_region name="serial" size="0x1_000" phys_addr="0x9000000" />
 <memory_region name="gic_vcpu" size="0x1_000" phys_addr="0x8040000" />
 
 <protection_domain name="VMM" priority="254">
     <program_image path="vmm.elf" />
     <map mr="guest_ram" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
-    <virtual_machine name="linux" id="0">
+    <virtual_machine name="linux" >
+        <vcpu id="0" />
         <map mr="guest_ram" vaddr="0x40000000" perms="rwx" />
-        <map mr="uart" vaddr="0x9000000" perms="rw" />
-        <map mr="gic_vcpu" vaddr="0x8010000" perms="rw" />
+        <map mr="serial" vaddr="0x9000000" perms="rw" cached="false" />
+        <map mr="gic_vcpu" vaddr="0x8010000" perms="rw" cached="false" />
     </virtual_machine>
+    <irq irq="33" id="1" />
 </protection_domain>
 ```
 
@@ -91,7 +93,7 @@ interrupts to the guest and restarting the guest.
 
 You will also see that three memory regions (MRs) exist in the system.
 1. `guest_ram` for the guest's RAM region
-2. `uart` for the UART serial device
+2. `serial` for the UART serial device
 3. `gic_vcpu` for the Generic Interrupt Controller vCPU interface
 
 ## Guest RAM region
@@ -272,6 +274,9 @@ The following feature bits are implemented:
 
 * VIRTIO_BLK_F_FLUSH
 * VIRTIO_BLK_F_BLK_SIZE
+* VIRTIO_BLK_F_SIZE_MAX
+* VIRTIO_BLK_F_SEG_MAX
+* VIRTIO_BLK_F_TOPOLOGY
 
 The legacy interface is not supported.
 

--- a/examples/rust/src/vmm.rs
+++ b/examples/rust/src/vmm.rs
@@ -6,12 +6,16 @@
 #![feature(never_type)]
 
 use core::{include_bytes};
+use core::ffi::c_void;
 
 use sel4_microkit::{protection_domain, MessageInfo, Channel, Child, Handler, debug_println};
 
-const GUEST_RAM_VADDR: usize = 0x40000000;
-const GUEST_DTB_VADDR: usize = 0x4f000000;
-const GUEST_INIT_RAM_DISK_VADDR: usize = 0x4d700000;
+const GUEST_RAM_VMM_VADDR: usize = 0x40000000;
+/* For ARM, these constants depends on what's defined in your DTB. */
+const GUEST_RAM_START_GPA: usize = 0x40000000;
+const GUEST_DTB_GPA: usize = 0x4f000000;
+const GUEST_INIT_RAM_DISK_GPA: usize = 0x4d700000;
+const GUEST_RAM_SIZE: usize = 0x10000000;
 const GUEST_BOOT_VCPU_ID: usize = 0;
 
 /// On the QEMU virt AArch64 platform the UART we are using has an IRQ number of 33.
@@ -33,20 +37,31 @@ const UART_CH: Channel = Channel::new(1);
 #[link(name = "sddf_util_debug", kind = "static")]
 #[link(name = "microkit", kind = "static")]
 extern "C" {
+    fn guest_init(init_args: arch_guest_init) -> bool;
     fn linux_setup_images(ram_start: usize,
                           kernel: usize, kernel_size: usize,
                           dtb_src: usize, dtb_dest: usize, dtb_size: usize,
                           initrd_src: usize, initrd_dest: usize, initrd_size: usize) -> usize;
-    fn guest_init(init_args: arch_guest_init) -> bool;
     fn virq_register_passthrough(vcpu_id: usize, irq: i32, irq_ch: u32) -> bool;
     fn virq_handle_passthrough(irq_ch: u32) -> bool;
     fn guest_start(kernel_pc: usize, dtb: usize, initrd: usize) -> bool;
     fn fault_handle(vcpu_id: usize, msginfo: MessageInfo) -> bool;
 }
 
+pub const GUEST_MAX_RAM_REGIONS: usize = 1;
+
 #[repr(C)]
-struct arch_guest_init {
-    num_vcpus: usize
+pub struct guest_ram_region {
+    pub gpa_start: usize,
+    pub size: usize,
+    pub vmm_vaddr: *mut c_void,
+}
+
+#[repr(C)]
+pub struct arch_guest_init {
+    pub num_vcpus: usize,
+    pub num_guest_ram_regions: usize,
+    pub guest_ram_regions: [guest_ram_region; GUEST_MAX_RAM_REGIONS],
 }
 
 #[protection_domain]
@@ -65,18 +80,27 @@ fn init() -> VmmHandler {
     let initrd_addr = initrd.as_ptr() as usize;
 
     unsafe {
-        let guest_pc = linux_setup_images(GUEST_RAM_VADDR,
-                                            linux_addr, linux.len(),
-                                            dtb_addr, GUEST_DTB_VADDR, dtb.len(),
-                                            initrd_addr, GUEST_INIT_RAM_DISK_VADDR, initrd.len()
-                                         );
         let success = guest_init(arch_guest_init {
             num_vcpus: 1,
+            num_guest_ram_regions: 1,
+            guest_ram_regions: [guest_ram_region {
+                gpa_start: GUEST_RAM_START_GPA,
+                size: GUEST_RAM_SIZE,
+                vmm_vaddr: GUEST_RAM_VMM_VADDR as *mut _,
+            }],
         });
         assert!(success);
+
+        let guest_pc = linux_setup_images(GUEST_RAM_START_GPA,
+                                            linux_addr, linux.len(),
+                                            dtb_addr, GUEST_DTB_GPA, dtb.len(),
+                                            initrd_addr, GUEST_INIT_RAM_DISK_GPA, initrd.len()
+                                         );
+        assert!(guest_pc != 0);
+
         let success = virq_register_passthrough(GUEST_BOOT_VCPU_ID, UART_IRQ as i32, UART_CH.index() as u32);
         assert!(success);
-        guest_start(guest_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
+        guest_start(guest_pc, GUEST_DTB_GPA, GUEST_INIT_RAM_DISK_GPA);
     }
 
     VmmHandler {}

--- a/examples/simple/board/qemu_virt_aarch64/simple.system
+++ b/examples/simple/board/qemu_virt_aarch64/simple.system
@@ -28,13 +28,9 @@
 
     <protection_domain name="VMM" priority="254">
         <program_image path="vmm.elf" />
-        <!--
-            Currently the VMM is expecting the address set to the variable
-            "guest_ram_vaddr" to be the same as the address of where the guest
-            sees RAM from its perspective. In this case the guest physical
-            starting address of RAM is 0x40000000, so we map in the guest RAM
-            at the same address in the VMMs virutal address space.
-        -->
+        <!-- Map guest RAM into the VMM so that we can copy in the Linux kernel and initrd.
+        There is no requirement for the virtual address to match the guest physical address,
+        as they will be translated by the VMM -->
         <map mr="guest_ram" vaddr="0x40000000" perms="rw" setvar_vaddr="guest_ram_vaddr" />
         <virtual_machine name="linux" >
             <vcpu id="0" />

--- a/examples/simple/vmm.c
+++ b/examples/simple/vmm.c
@@ -16,15 +16,19 @@
  */
 #define GUEST_RAM_SIZE 0x10000000
 
+/* For ARM, these constants depends on what's defined in your DTB. */
 #if defined(BOARD_qemu_virt_aarch64)
-#define GUEST_DTB_VADDR 0x4f000000
-#define GUEST_INIT_RAM_DISK_VADDR 0x4d000000
+#define GUEST_RAM_START_GPA 0x40000000
+#define GUEST_DTB_GPA 0x4f000000
+#define GUEST_INIT_RAM_DISK_GPA 0x4d000000
 #elif defined(BOARD_odroidc4)
-#define GUEST_DTB_VADDR 0x2f000000
-#define GUEST_INIT_RAM_DISK_VADDR 0x2d700000
+#define GUEST_RAM_START_GPA 0x20000000
+#define GUEST_DTB_GPA 0x2f000000
+#define GUEST_INIT_RAM_DISK_GPA 0x2d700000
 #elif defined(BOARD_maaxboard)
-#define GUEST_DTB_VADDR 0x4f000000
-#define GUEST_INIT_RAM_DISK_VADDR 0x4c000000
+#define GUEST_RAM_START_GPA 0x40000000
+#define GUEST_DTB_GPA 0x4f000000
+#define GUEST_INIT_RAM_DISK_GPA 0x4c000000
 #else
 #error Need to define guest kernel image address and DTB address
 #endif
@@ -59,27 +63,35 @@ void init(void)
 {
     /* Initialise the VMM, the VCPU(s), and start the guest */
     LOG_VMM("starting \"%s\"\n", microkit_name);
-    /* Place all the binaries in the right locations before starting the guest */
-    size_t kernel_size = _guest_kernel_image_end - _guest_kernel_image;
-    size_t dtb_size = _guest_dtb_image_end - _guest_dtb_image;
-    size_t initrd_size = _guest_initrd_image_end - _guest_initrd_image;
-    uintptr_t kernel_pc = linux_setup_images(guest_ram_vaddr, (uintptr_t)_guest_kernel_image, kernel_size,
-                                             (uintptr_t)_guest_dtb_image, GUEST_DTB_VADDR, dtb_size,
-                                             (uintptr_t)_guest_initrd_image, GUEST_INIT_RAM_DISK_VADDR, initrd_size);
-    if (!kernel_pc) {
-        LOG_VMM_ERR("Failed to initialise guest images\n");
-        return;
-    }
-    arch_guest_init_t args = { .num_vcpus = 1 };
+
+    arch_guest_init_t args = {
+        .num_vcpus = 1,
+        .num_guest_ram_regions = 1,
+        .guest_ram_regions = { (struct guest_ram_region) {
+            .gpa_start = GUEST_RAM_START_GPA, .size = GUEST_RAM_SIZE, .vmm_vaddr = (void *)guest_ram_vaddr } }
+    };
     bool success = guest_init(args);
     if (!success) {
         LOG_VMM_ERR("Failed to initialise guest\n");
         return;
     }
+
+    /* Place all the binaries in the right locations before starting the guest */
+    size_t kernel_size = _guest_kernel_image_end - _guest_kernel_image;
+    size_t dtb_size = _guest_dtb_image_end - _guest_dtb_image;
+    size_t initrd_size = _guest_initrd_image_end - _guest_initrd_image;
+    uintptr_t kernel_pc = linux_setup_images(GUEST_RAM_START_GPA, (uintptr_t)_guest_kernel_image, kernel_size,
+                                             (uintptr_t)_guest_dtb_image, GUEST_DTB_GPA, dtb_size,
+                                             (uintptr_t)_guest_initrd_image, GUEST_INIT_RAM_DISK_GPA, initrd_size);
+    if (!kernel_pc) {
+        LOG_VMM_ERR("Failed to initialise guest images\n");
+        return;
+    }
+
     success = virq_register_passthrough(GUEST_BOOT_VCPU_ID, SERIAL_IRQ, SERIAL_IRQ_CH);
     assert(success);
     /* Finally start the guest */
-    guest_start(kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
+    guest_start(kernel_pc, GUEST_DTB_GPA, GUEST_INIT_RAM_DISK_GPA);
 }
 
 void notified(microkit_channel ch)

--- a/examples/smp/vmm.c
+++ b/examples/smp/vmm.c
@@ -17,14 +17,17 @@
 #define GUEST_RAM_SIZE 0x10000000
 
 #if defined(BOARD_qemu_virt_aarch64)
-#define GUEST_DTB_VADDR 0x4f000000
-#define GUEST_INIT_RAM_DISK_VADDR 0x4d000000
+#define GUEST_RAM_START_GPA 0x40000000
+#define GUEST_DTB_GPA 0x4f000000
+#define GUEST_INIT_RAM_DISK_GPA 0x4d000000
 #elif defined(BOARD_odroidc4)
-#define GUEST_DTB_VADDR 0x2f000000
-#define GUEST_INIT_RAM_DISK_VADDR 0x2d700000
+#define GUEST_RAM_START_GPA 0x20000000
+#define GUEST_DTB_GPA 0x2f000000
+#define GUEST_INIT_RAM_DISK_GPA 0x2d700000
 #elif defined(BOARD_maaxboard)
-#define GUEST_DTB_VADDR 0x4f000000
-#define GUEST_INIT_RAM_DISK_VADDR 0x4c000000
+#define GUEST_RAM_START_GPA 0x40000000
+#define GUEST_DTB_GPA 0x4f000000
+#define GUEST_INIT_RAM_DISK_GPA 0x4c000000
 #else
 #error Need to define guest kernel image address and DTB address
 #endif
@@ -59,27 +62,35 @@ void init(void)
 {
     /* Initialise the VMM, the VCPU(s), and start the guest */
     LOG_VMM("starting \"%s\"\n", microkit_name);
-    /* Place all the binaries in the right locations before starting the guest */
-    size_t kernel_size = _guest_kernel_image_end - _guest_kernel_image;
-    size_t dtb_size = _guest_dtb_image_end - _guest_dtb_image;
-    size_t initrd_size = _guest_initrd_image_end - _guest_initrd_image;
-    uintptr_t kernel_pc = linux_setup_images(guest_ram_vaddr, (uintptr_t)_guest_kernel_image, kernel_size,
-                                             (uintptr_t)_guest_dtb_image, GUEST_DTB_VADDR, dtb_size,
-                                             (uintptr_t)_guest_initrd_image, GUEST_INIT_RAM_DISK_VADDR, initrd_size);
-    if (!kernel_pc) {
-        LOG_VMM_ERR("Failed to initialise guest images\n");
-        return;
-    }
-    arch_guest_init_t args = { .num_vcpus = 4 };
+
+    arch_guest_init_t args = {
+        .num_vcpus = 4,
+        .num_guest_ram_regions = 1,
+        .guest_ram_regions = { (struct guest_ram_region) {
+            .gpa_start = GUEST_RAM_START_GPA, .size = GUEST_RAM_SIZE, .vmm_vaddr = (void *)guest_ram_vaddr } }
+    };
     bool success = guest_init(args);
     if (!success) {
         LOG_VMM_ERR("Failed to initialise guest\n");
         return;
     }
+
+    /* Place all the binaries in the right locations before starting the guest */
+    size_t kernel_size = _guest_kernel_image_end - _guest_kernel_image;
+    size_t dtb_size = _guest_dtb_image_end - _guest_dtb_image;
+    size_t initrd_size = _guest_initrd_image_end - _guest_initrd_image;
+    uintptr_t kernel_pc = linux_setup_images(GUEST_RAM_START_GPA, (uintptr_t)_guest_kernel_image, kernel_size,
+                                             (uintptr_t)_guest_dtb_image, GUEST_DTB_GPA, dtb_size,
+                                             (uintptr_t)_guest_initrd_image, GUEST_INIT_RAM_DISK_GPA, initrd_size);
+    if (!kernel_pc) {
+        LOG_VMM_ERR("Failed to initialise guest images\n");
+        return;
+    }
+
     success = virq_register_passthrough(GUEST_BOOT_VCPU_ID, SERIAL_IRQ, SERIAL_IRQ_CH);
     assert(success);
     /* Finally start the guest */
-    guest_start(kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
+    guest_start(kernel_pc, GUEST_DTB_GPA, GUEST_INIT_RAM_DISK_GPA);
 }
 
 void notified(microkit_channel ch)

--- a/examples/virtio/client_vmm.c
+++ b/examples/virtio/client_vmm.c
@@ -20,6 +20,9 @@ __attribute__((__section__(".blk_client_config"))) blk_client_config_t blk_confi
 __attribute__((__section__(".net_client_config"))) net_client_config_t net_config;
 __attribute__((__section__(".vmm_config"))) vmm_config_t vmm_config;
 
+/* RAM base in guest physical address space depends on what's defined in your DTB. */
+#define GUEST_RAM_START_GPA 0x40000000
+
 /* Data for the guest's kernel image. */
 extern char _guest_kernel_image[];
 extern char _guest_kernel_image_end[];
@@ -54,6 +57,18 @@ void init(void)
     assert(vmm_config_check_magic(&vmm_config));
     assert(net_config_check_magic(&net_config));
 
+    arch_guest_init_t args = {
+        .num_vcpus = 1,
+        .num_guest_ram_regions = 1,
+        .guest_ram_regions = { (struct guest_ram_region) {
+            .gpa_start = GUEST_RAM_START_GPA, .size = vmm_config.ram_size, .vmm_vaddr = (void *)vmm_config.ram } }
+    };
+    bool success = guest_init(args);
+    if (!success) {
+        LOG_VMM_ERR("Failed to initialise guest\n");
+        return;
+    }
+
     blk_queue_init(&blk_queue, blk_config.virt.req_queue.vaddr, blk_config.virt.resp_queue.vaddr,
                    blk_config.virt.num_buffers);
     /* Want to print out configuration information, so wait until the config is ready. */
@@ -68,25 +83,11 @@ void init(void)
     size_t kernel_size = _guest_kernel_image_end - _guest_kernel_image;
     size_t dtb_size = _guest_dtb_image_end - _guest_dtb_image;
     size_t initrd_size = _guest_initrd_image_end - _guest_initrd_image;
-    uintptr_t kernel_pc = linux_setup_images(vmm_config.ram,
-                                             (uintptr_t) _guest_kernel_image,
-                                             kernel_size,
-                                             (uintptr_t) _guest_dtb_image,
-                                             vmm_config.dtb,
-                                             dtb_size,
-                                             (uintptr_t) _guest_initrd_image,
-                                             vmm_config.initrd,
-                                             initrd_size
-                                            );
+    uintptr_t kernel_pc = linux_setup_images(GUEST_RAM_START_GPA, (uintptr_t)_guest_kernel_image, kernel_size,
+                                             (uintptr_t)_guest_dtb_image, vmm_config.dtb, dtb_size,
+                                             (uintptr_t)_guest_initrd_image, vmm_config.initrd, initrd_size);
     if (!kernel_pc) {
         LOG_VMM_ERR("Failed to initialise guest images\n");
-        return;
-    }
-
-    arch_guest_init_t args = { .num_vcpus = 1 };
-    bool success = guest_init(args);
-    if (!success) {
-        LOG_VMM_ERR("Failed to initialise the guest\n");
         return;
     }
 
@@ -118,12 +119,10 @@ void init(void)
                       serial_config.tx.data.vaddr);
 
     /* Initialise virtIO console device */
-    success = virtio_mmio_console_init(&virtio_console,
-                                       vmm_config.virtio_mmio_devices[console_vdev_idx].base,
+    success = virtio_mmio_console_init(&virtio_console, vmm_config.virtio_mmio_devices[console_vdev_idx].base,
                                        vmm_config.virtio_mmio_devices[console_vdev_idx].size,
-                                       vmm_config.virtio_mmio_devices[console_vdev_idx].irq,
-                                       &serial_rx_queue, &serial_tx_queue,
-                                       serial_config.tx.id);
+                                       vmm_config.virtio_mmio_devices[console_vdev_idx].irq, &serial_rx_queue,
+                                       &serial_tx_queue, serial_config.tx.id);
     assert(success);
 
     /* Initialise virtIO block device */
@@ -140,15 +139,11 @@ void init(void)
     net_queue_init(&net_tx_queue, net_config.tx.free_queue.vaddr, net_config.tx.active_queue.vaddr,
                    net_config.tx.num_buffers);
     net_buffers_init(&net_tx_queue, 0);
-    success = virtio_mmio_net_init(&virtio_net,
-                                   vmm_config.virtio_mmio_devices[net_vdev_idx].base,
+    success = virtio_mmio_net_init(&virtio_net, vmm_config.virtio_mmio_devices[net_vdev_idx].base,
                                    vmm_config.virtio_mmio_devices[net_vdev_idx].size,
-                                   vmm_config.virtio_mmio_devices[net_vdev_idx].irq,
-                                   &net_rx_queue, &net_tx_queue,
+                                   vmm_config.virtio_mmio_devices[net_vdev_idx].irq, &net_rx_queue, &net_tx_queue,
                                    (uintptr_t)net_config.rx_data.vaddr, (uintptr_t)net_config.tx_data.vaddr,
-                                   net_config.rx.id, net_config.tx.id,
-                                   net_config.mac_addr
-                                  );
+                                   net_config.rx.id, net_config.tx.id, net_config.mac_addr);
     assert(success);
 
     /* Finally start the guest */

--- a/examples/virtio_pci/client_vmm.c
+++ b/examples/virtio_pci/client_vmm.c
@@ -20,6 +20,9 @@ __attribute__((__section__(".blk_client_config"))) blk_client_config_t blk_confi
 __attribute__((__section__(".net_client_config"))) net_client_config_t net_config;
 __attribute__((__section__(".vmm_config"))) vmm_config_t vmm_config;
 
+/* RAM base in guest physical address space depends on what's defined in your DTB. */
+#define GUEST_RAM_START_GPA 0x40000000
+
 /* Data for the guest's kernel image. */
 extern char _guest_kernel_image[];
 extern char _guest_kernel_image_end[];
@@ -58,6 +61,18 @@ void init(void)
     assert(vmm_config_check_magic(&vmm_config));
     assert(net_config_check_magic(&net_config));
 
+    arch_guest_init_t args = {
+        .num_vcpus = 1,
+        .num_guest_ram_regions = 1,
+        .guest_ram_regions = { (struct guest_ram_region) {
+            .gpa_start = GUEST_RAM_START_GPA, .size = vmm_config.ram_size, .vmm_vaddr = (void *)vmm_config.ram } }
+    };
+    bool success = guest_init(args);
+    if (!success) {
+        LOG_VMM_ERR("Failed to initialise guest\n");
+        return;
+    }
+
     blk_queue_init(&blk_queue, blk_config.virt.req_queue.vaddr, blk_config.virt.resp_queue.vaddr,
                    blk_config.virt.num_buffers);
     /* Want to print out configuration information, so wait until the config is ready. */
@@ -72,18 +87,11 @@ void init(void)
     size_t kernel_size = _guest_kernel_image_end - _guest_kernel_image;
     size_t dtb_size = _guest_dtb_image_end - _guest_dtb_image;
     size_t initrd_size = _guest_initrd_image_end - _guest_initrd_image;
-    uintptr_t kernel_pc = linux_setup_images(vmm_config.ram, (uintptr_t)_guest_kernel_image, kernel_size,
+    uintptr_t kernel_pc = linux_setup_images(GUEST_RAM_START_GPA, (uintptr_t)_guest_kernel_image, kernel_size,
                                              (uintptr_t)_guest_dtb_image, vmm_config.dtb, dtb_size,
                                              (uintptr_t)_guest_initrd_image, vmm_config.initrd, initrd_size);
     if (!kernel_pc) {
         LOG_VMM_ERR("Failed to initialise guest images\n");
-        return;
-    }
-
-    arch_guest_init_t args = { .num_vcpus = 1 };
-    bool success = guest_init(args);
-    if (!success) {
-        LOG_VMM_ERR("Failed to initialise the guest\n");
         return;
     }
 

--- a/examples/zig/src/vmm.zig
+++ b/examples/zig/src/vmm.zig
@@ -12,9 +12,11 @@ const GUEST_BOOT_VCPU_ID = 0;
 // There are the hard-coded addresses that both the VMM and Linux guest need
 // to be aware of. For example the address of the DTB and initial RAM disk are
 // passed to Linux when booting it.
-const GUEST_RAM_VADDR: usize = 0x40000000;
-const GUEST_DTB_VADDR: usize = 0x4f000000;
-const GUEST_INIT_RAM_DISK_VADDR: usize = 0x4d700000;
+const GUEST_RAM_VMM_VADDR: usize = 0x40000000;
+// For ARM, these constants depends on what's defined in your DTB.
+const GUEST_RAM_START_GPA: usize = 0x40000000;
+const GUEST_DTB_GPA: usize = 0x4f000000;
+const GUEST_INIT_RAM_DISK_GPA: usize = 0x4d700000;
 const GUEST_RAM_SIZE: usize = 0x10000000;
 
 // Below we make use of Zig's '@embedFile' builtin functions to easily include
@@ -87,33 +89,46 @@ const SERIAL_IRQ: i32 = 33;
 export fn init() callconv(.c) void {
     // Initialise the VMM, the VCPU(s), and start the guest
     log.info("starting", .{});
+
+    if (!c.guest_init(.{
+        .num_vcpus = 1,
+        .num_guest_ram_regions = 1,
+        .guest_ram_regions = .{
+            .{
+                .gpa_start = GUEST_RAM_START_GPA,
+                .size = GUEST_RAM_SIZE,
+                .vmm_vaddr = @ptrFromInt(GUEST_RAM_VMM_VADDR),
+            },
+        }
+    })) {
+        log.err("Failed to initialise guest\n", .{});
+        return;
+    }
+
     // Place all the binaries in the right locations before starting the guest
     const kernel_pc = c.linux_setup_images(
-                GUEST_RAM_VADDR,
+                GUEST_RAM_START_GPA,
                 @intFromPtr(guest_kernel_image),
                 guest_kernel_image.len,
                 @intFromPtr(guest_dtb_image),
-                GUEST_DTB_VADDR,
+                GUEST_DTB_GPA,
                 guest_dtb_image.len,
                 @intFromPtr(guest_initrd_image),
-                GUEST_INIT_RAM_DISK_VADDR,
+                GUEST_INIT_RAM_DISK_GPA,
                 guest_initrd_image.len
             );
     if (kernel_pc == 0) {
         log.err("Failed to initialise guest images\n", .{});
         return;
     }
-    if (!c.guest_init(.{ .num_vcpus = 1 })) {
-        log.err("Failed to initialise guest\n", .{});
-        return;
-    }
+
     // Register the interrupt for the UART with the virtual interrupt controller
     if (!c.virq_register_passthrough(GUEST_BOOT_VCPU_ID, SERIAL_IRQ, SERIAL_IRQ_CH)) {
         log.err("Failed to register serial IRQ\n", .{});
         return;
     }
     // Finally we can start the guest
-    if (!c.guest_start(kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR)) {
+    if (!c.guest_start(kernel_pc, GUEST_DTB_GPA, GUEST_INIT_RAM_DISK_GPA)) {
         log.err("Failed to start guest\n", .{});
         return;
     }

--- a/examples/zig/zig_vmm.system
+++ b/examples/zig/zig_vmm.system
@@ -28,13 +28,9 @@
 
     <protection_domain name="VMM" priority="254">
         <program_image path="vmm.elf" />
-        <!--
-            Currently the VMM is expecting the address set to the variable
-            "guest_ram_vaddr" to be the same as the address of where the guest
-            sees RAM from its perspective. In this case the guest physical
-            starting address of RAM is 0x40000000, so we map in the guest RAM
-            at the same address in the VMMs virutal address space.
-        -->
+        <!-- Map guest RAM into the VMM so that we can copy in the Linux kernel and initrd.
+        There is no requirement for the virtual address to match the guest physical address,
+        as they will be translated by the VMM -->
         <map mr="guest_ram" vaddr="0x40000000" perms="rw" />
         <virtual_machine name="linux">
             <vcpu id="0" />

--- a/include/libvmm/arch/aarch64/linux.h
+++ b/include/libvmm/arch/aarch64/linux.h
@@ -34,12 +34,6 @@ struct linux_image_header {
 // Note that this function assumes that the `kernel` parameter is aligned
 // to at least the alignment of `struct linux_image_header`. The `dtb_src`
 // paramter must be aligned to at least the alignment of `struct dtb_header`.
-uintptr_t linux_setup_images(uintptr_t ram_start,
-                             uintptr_t kernel,
-                             size_t kernel_size,
-                             uintptr_t dtb_src,
-                             uintptr_t dtb_dest,
-                             size_t dtb_size,
-                             uintptr_t initrd_src,
-                             uintptr_t initrd_dest,
-                             size_t initrd_size);
+uint64_t linux_setup_images(uint64_t ram_start_gpa, uintptr_t kernel, size_t kernel_size, uintptr_t dtb_src,
+                            uint64_t dtb_dest_gpa, size_t dtb_size, uintptr_t initrd_src, uint64_t initrd_dest_gpa,
+                            size_t initrd_size);

--- a/include/libvmm/guest.h
+++ b/include/libvmm/guest.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <libvmm/guest_ram.h>
 
 #define GUEST_BOOT_VCPU_ID 0UL
 
@@ -23,10 +24,16 @@
 typedef struct guest {
     size_t num_vcpus;
     bool vcpu_on_state[GUEST_MAX_NUM_VCPUS];
+
+    size_t guest_ram_regions_len;
+    struct guest_ram_region guest_ram_regions[GUEST_MAX_RAM_REGIONS];
 } guest_t;
 
 typedef struct arch_guest_init {
     size_t num_vcpus;
+
+    size_t num_guest_ram_regions;
+    struct guest_ram_region guest_ram_regions[GUEST_MAX_RAM_REGIONS];
 } arch_guest_init_t;
 
 /* Initialise the architecture specific subsystems of the VMM library such as the

--- a/include/libvmm/guest_ram.h
+++ b/include/libvmm/guest_ram.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <microkit.h>
+#include <libvmm/util/util.h>
+
+/* Enough for now */
+#define GUEST_MAX_RAM_REGIONS 1
+
+struct guest_ram_region {
+    uint64_t gpa_start;
+    uint64_t size;
+    void *vmm_vaddr;
+};
+
+/* Tell libvmm valid guest physical RAM region */
+bool guest_ram_add_region(struct guest_ram_region guest_ram_region);
+
+/* Convert guest physical address to the VMM's virtual memory address.
+ * `bytes_remaining` will contain the number of bytes to the end of the region. */
+void *gpa_to_vaddr(uint64_t gpa, size_t *bytes_remaining);
+void *gpa_to_vaddr_or_crash(uint64_t gpa, size_t *bytes_remaining);
+
+/* Returns the list of guest RAM regions registered. The number of regions
+ * in the list will be written to `num_regions_ret`. */
+struct guest_ram_region *guest_ram_get_regions(int *num_regions_ret);

--- a/include/libvmm/util/util.h
+++ b/include/libvmm/util/util.h
@@ -68,3 +68,6 @@ static void assert_fail(
 
 #endif
 #endif
+
+/* Returns true if two [x..y) ranges overlap. */
+bool ranges_overlap(uint64_t left_start, uint64_t left_size, uint64_t right_start, uint64_t right_size);

--- a/include/libvmm/virtio/virtq.h
+++ b/include/libvmm/virtio/virtq.h
@@ -122,39 +122,3 @@ struct virtq {
  *  uint16_t avail_event_idx;
  * };
  */
-/* We publish the used event index at the end of the available ring, and vice
- * versa. They are at the end for backwards compatibility. */
-#define virtq_used_event(vr) ((vr)->avail->ring[(vr)->num])
-#define virtq_avail_event(vr) (*(uint16_t *)&(vr)->used->ring[(vr)->num])
-
-static inline void virtq_init(struct virtq *vr, unsigned int num, void *p,
-                              unsigned long align)
-{
-    vr->num = num;
-    vr->desc = p;
-    vr->avail = p + num * sizeof(struct virtq_desc);
-    vr->used = (void *)(((unsigned long)&vr->avail->ring[num] + sizeof(uint16_t)
-                         + align - 1) & ~(align - 1));
-}
-
-static inline unsigned virtq_size(unsigned int num, unsigned long align)
-{
-    return ((sizeof(struct virtq_desc) * num + sizeof(uint16_t) * (3 + num)
-             + align - 1) & ~(align - 1))
-           + sizeof(uint16_t) * 3 + sizeof(struct virtq_used_elem) * num;
-}
-
-/* The following is used with USED_EVENT_IDX and AVAIL_EVENT_IDX */
-/* Assuming a given event_idx value from the other size, if
- * we have just incremented index from old to new_idx,
- * should we trigger an event? */
-static inline int virtq_need_event(uint16_t event_idx, uint16_t new_idx, uint16_t old)
-{
-    /* Note: Xen has similar logic for notification hold-off
-     * in include/xen/interface/io/ring.h with req_event and req_prod
-     * corresponding to event_idx + 1 and new_idx respectively.
-     * Note also that req_event and req_prod in Xen start at 1,
-     * event indexes in virtio start at 0. */
-    return (uint16_t)(new_idx - event_idx - 1) < (uint16_t)(new_idx - old);
-}
-

--- a/src/arch/aarch64/linux.c
+++ b/src/arch/aarch64/linux.c
@@ -5,27 +5,20 @@
  */
 #include <string.h>
 #include <libvmm/dtb.h>
+#include <libvmm/guest_ram.h>
 #include <libvmm/util/util.h>
 #include <libvmm/arch/aarch64/linux.h>
 
-uintptr_t linux_setup_images(uintptr_t ram_start,
-                             uintptr_t kernel,
-                             size_t kernel_size,
-                             uintptr_t dtb_src,
-                             uintptr_t dtb_dest,
-                             size_t dtb_size,
-                             uintptr_t initrd_src,
-                             uintptr_t initrd_dest,
-                             size_t initrd_size)
+uint64_t linux_setup_images(uint64_t ram_start_gpa, uintptr_t kernel, size_t kernel_size, uintptr_t dtb_src,
+                            uint64_t dtb_dest_gpa, size_t dtb_size, uintptr_t initrd_src, uint64_t initrd_dest_gpa,
+                            size_t initrd_size)
 {
     // Before doing any copying, let's sanity check the addresses.
-    // First we'll check that everything actually lives inside RAM.
-    // @ivanv: TODO
     // Check that the kernel and DTB to do not overlap
-    uintptr_t dtb_start = dtb_dest;
-    uintptr_t dtb_end = dtb_start + dtb_size;
-    uintptr_t kernel_start = kernel;
-    uintptr_t kernel_end = kernel_start + kernel_size;
+    uint64_t dtb_start = dtb_dest_gpa;
+    uint64_t dtb_end = dtb_start + dtb_size;
+    uint64_t kernel_start = kernel;
+    uint64_t kernel_end = kernel_start + kernel_size;
     if (!(dtb_start >= kernel_end || dtb_end <= kernel_start)) {
         LOG_VMM_ERR("Linux kernel image [0x%lx..0x%lx)"
                     " overlaps with the destination of the DTB [0x%lx, 0x%lx)\n",
@@ -33,8 +26,8 @@ uintptr_t linux_setup_images(uintptr_t ram_start,
         return 0;
     }
     // Check that the kernel and initrd do not overlap
-    uintptr_t initrd_start = initrd_dest;
-    uintptr_t initrd_end = initrd_start + initrd_size;
+    uint64_t initrd_start = initrd_dest_gpa;
+    uint64_t initrd_end = initrd_start + initrd_size;
     if (!(initrd_start >= kernel_end || initrd_end <= kernel_start)) {
         LOG_VMM_ERR("Linux kernel image [0x%lx..0x%lx) overlaps"
                     " with the destination of the initial RAM disk [0x%lx, 0x%lx)\n",
@@ -48,53 +41,90 @@ uintptr_t linux_setup_images(uintptr_t ram_start,
                     dtb_start, dtb_end, initrd_start, initrd_end);
         return 0;
     }
+
     // First we inspect the kernel image header to confirm it is a valid image
     // and to determine where in memory to place the image.
     // The pointer to the kernel image may be unaligned, so to avoid undefined
     // behaviour, we do an explicit copy.
     struct linux_image_header image_header = {};
     memcpy((char *)&image_header, (char *)kernel, sizeof(struct linux_image_header));
-    assert(image_header.magic == LINUX_IMAGE_MAGIC);
     if (image_header.magic != LINUX_IMAGE_MAGIC) {
         LOG_VMM_ERR("Linux kernel image magic check failed\n");
         return 0;
     }
-    // Copy the guest kernel image into the right location
-    uintptr_t kernel_dest = ram_start + image_header.text_offset;
+
+    // Check that the kernel image destination is in valid guest RAM, then copy
+    size_t bytes_remaining;
+    uint64_t kernel_dest_gpa = ram_start_gpa + image_header.text_offset;
+    void *kernel_dest_vmm = gpa_to_vaddr(kernel_dest_gpa, &bytes_remaining);
+    if (kernel_dest_vmm == NULL) {
+        LOG_VMM_ERR("Linux kernel copy destination 0x%lx not in valid guest RAM\n", kernel_dest_gpa);
+        return 0;
+    }
+    if (bytes_remaining < kernel_size) {
+        LOG_VMM_ERR("Not enough guest RAM to copy Linux kernel\n");
+        return 0;
+    }
+
     // This check is because the Linux kernel image requires to be placed at text_offset of
     // a 2MB aligned base address anywhere in usable system RAM and called there.
     // In this case, we place the image at the text_offset of the start of the guest's RAM,
     // so we need to make sure that the start of guest RAM is 2MiB aligned.
-    assert((ram_start & ((1 << 20) - 1)) == 0);
-    LOG_VMM("Copying guest kernel image to 0x%lx (0x%lx bytes)\n", kernel_dest, kernel_size);
-    memcpy((char *)kernel_dest, (char *)kernel, kernel_size);
+    if ((ram_start_gpa & ((1 << 20) - 1)) != 0) {
+        LOG_VMM_ERR("Linux requires that guest RAM starting GPA must be 2MiB aligned, got 0x%lx\n", ram_start_gpa);
+        return 0;
+    }
+    LOG_VMM("Copying guest kernel image to 0x%lx (0x%lx bytes)\n", (uintptr_t)kernel_dest_vmm, kernel_size);
+    memcpy((char *)kernel_dest_vmm, (char *)kernel, kernel_size);
+
     // Copy the guest device tree blob into the right location
     // First check that the DTB given is actually a DTB!
     struct dtb_header dtb_header = {};
     memcpy((char *)&dtb_header, (char *)dtb_src, sizeof(struct dtb_header));
-    assert(dtb_check_magic(&dtb_header));
     if (!dtb_check_magic(&dtb_header)) {
         LOG_VMM_ERR("Given DTB does not match DTB magic.\n");
         return 0;
     }
+
     // Linux does not allow the DTB to be greater than 2 megabytes in size.
     assert(dtb_size <= (1 << 21));
     if (dtb_size > (1 << 21)) {
         LOG_VMM_ERR("Linux expects size of DTB to be less than 2MB, DTB size is 0x%lx bytes\n", dtb_size);
         return 0;
     }
+
     // Linux expects the address of the DTB to be on an 8-byte boundary.
-    assert(dtb_dest % 0x8 == 0);
-    if (dtb_dest % 0x8) {
-        LOG_VMM_ERR("Linux expects DTB address to be on an 8-byte boundary, DTB address is 0x%lx\n", dtb_dest);
+    assert(dtb_dest_gpa % 0x8 == 0);
+    if (dtb_dest_gpa % 0x8) {
+        LOG_VMM_ERR("Linux expects DTB address to be on an 8-byte boundary, DTB address is 0x%lx\n", dtb_dest_gpa);
         return 0;
     }
-    LOG_VMM("Copying guest DTB to 0x%lx (0x%lx bytes)\n", dtb_dest, dtb_size);
-    memcpy((char *)dtb_dest, (char *)dtb_src, dtb_size);
+
+    void *dtb_dest_vmm = gpa_to_vaddr(dtb_dest_gpa, &bytes_remaining);
+    if (dtb_dest_vmm == NULL) {
+        LOG_VMM_ERR("DTB copy destination 0x%lx not in valid guest RAM\n", dtb_dest_gpa);
+        return 0;
+    }
+    if (bytes_remaining < dtb_size) {
+        LOG_VMM_ERR("Not enough guest RAM to copy DTB\n");
+        return 0;
+    }
+    LOG_VMM("Copying guest DTB to GPA 0x%lx (0x%zx bytes)\n", dtb_dest_gpa, dtb_size);
+    memcpy((char *)dtb_dest_vmm, (char *)dtb_src, dtb_size);
+
     // Copy the initial RAM disk into the right location
     // @ivanv: add checks for initrd according to Linux docs
-    LOG_VMM("Copying guest initial RAM disk to 0x%lx (0x%lx bytes)\n", initrd_dest, initrd_size);
-    memcpy((char *)initrd_dest, (char *)initrd_src, initrd_size);
+    void *initrd_dest_vmm = gpa_to_vaddr(initrd_dest_gpa, &bytes_remaining);
+    if (initrd_dest_vmm == NULL) {
+        LOG_VMM_ERR("Initrd copy destination 0x%lx not in valid guest RAM\n", initrd_dest_gpa);
+        return 0;
+    }
+    if (bytes_remaining < initrd_size) {
+        LOG_VMM_ERR("Not enough guest RAM to copy initrd\n");
+        return 0;
+    }
+    LOG_VMM("Copying guest initial RAM disk to GPA 0x%lx (0x%zx bytes)\n", (uintptr_t)initrd_dest_vmm, initrd_size);
+    memcpy((char *)initrd_dest_vmm, (char *)initrd_src, initrd_size);
 
-    return kernel_dest;
+    return kernel_dest_gpa;
 }

--- a/src/guest.c
+++ b/src/guest.c
@@ -22,9 +22,27 @@ bool guest_init(arch_guest_init_t init_args)
         return false;
     }
 
+    if (init_args.num_guest_ram_regions == 0) {
+        LOG_VMM_ERR("number of guest RAM regions must be greater than zero");
+        return false;
+    }
+
+    if (init_args.num_guest_ram_regions > GUEST_MAX_RAM_REGIONS) {
+        LOG_VMM_ERR("number of guest RAM regions (%lu) is more than maximum (%d)", init_args.num_guest_ram_regions,
+                    GUEST_MAX_RAM_REGIONS);
+        return false;
+    }
+
     guest.num_vcpus = init_args.num_vcpus;
     for (int i = 0; i < guest.num_vcpus; i++) {
         guest.vcpu_on_state[i] = false;
+    }
+
+    for (int i = 0; i < init_args.num_guest_ram_regions; i++) {
+        if (!guest_ram_add_region(init_args.guest_ram_regions[i])) {
+            LOG_VMM_ERR("failed to bookkeep RAM region\n");
+            return false;
+        }
     }
 
     /* Initialise the virtual GIC driver */
@@ -44,7 +62,7 @@ bool guest_start(uintptr_t kernel_pc, uintptr_t dtb, uintptr_t initrd)
      * any other kind of guest. However, even though the library is open to supporting other
      * guests, there is no point in prematurely generalising this code.
      */
-    seL4_UserContext regs = {0};
+    seL4_UserContext regs = { 0 };
     regs.x0 = dtb;
     regs.spsr = 5; // PMODE_EL1h
     regs.pc = kernel_pc;

--- a/src/guest_ram.c
+++ b/src/guest_ram.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <microkit.h>
+#include <libvmm/guest.h>
+#include <libvmm/guest_ram.h>
+#include <libvmm/util/util.h>
+
+extern guest_t guest;
+
+bool guest_ram_add_region(struct guest_ram_region guest_ram_region)
+{
+    if (guest.guest_ram_regions_len == GUEST_MAX_RAM_REGIONS) {
+        LOG_VMM_ERR("bookkeeping array is full\n");
+        return false;
+    }
+
+    if (guest_ram_region.size == 0) {
+        LOG_VMM_ERR("size is 0\n");
+        return false;
+    }
+
+    if (guest_ram_region.vmm_vaddr == NULL) {
+        LOG_VMM_ERR("vmm_vaddr is NULL\n");
+        return false;
+    }
+
+    uint64_t this_gpa_start = guest_ram_region.gpa_start;
+    uint64_t this_gpa_end = this_gpa_start + guest_ram_region.size;
+
+    for (int i = 0; i < guest.guest_ram_regions_len; i++) {
+        uint64_t other_start = guest.guest_ram_regions[i].gpa_start;
+        uint64_t other_end = other_start + guest.guest_ram_regions[i].size;
+        if (ranges_overlap(this_gpa_start, this_gpa_end, other_start, other_end)) {
+            LOG_VMM_ERR("guest_ram_add_region(): region [0x%lx..0x%lx) overlaps with existing region [0x%lx..0x%lx)\n",
+                        this_gpa_start, this_gpa_end, other_start, other_end);
+        }
+        return false;
+    }
+
+    memcpy(&guest.guest_ram_regions[guest.guest_ram_regions_len], &guest_ram_region, sizeof(struct guest_ram_region));
+    guest.guest_ram_regions_len++;
+
+    return true;
+}
+
+struct guest_ram_region *guest_ram_get_regions(int *num_regions)
+{
+    *num_regions = guest.guest_ram_regions_len;
+    return guest.guest_ram_regions;
+}
+
+void *gpa_to_vaddr(uint64_t gpa, size_t *bytes_remaining)
+{
+    assert(guest.guest_ram_regions_len);
+
+    for (int i = 0; i < guest.guest_ram_regions_len; i++) {
+        uint64_t this_region_gpa_start = guest.guest_ram_regions[i].gpa_start;
+        uint64_t this_region_gpa_end = this_region_gpa_start + guest.guest_ram_regions[i].size;
+        if (gpa >= this_region_gpa_start && gpa < this_region_gpa_end) {
+            uint64_t offset = gpa - this_region_gpa_start;
+            *bytes_remaining = this_region_gpa_end - gpa;
+            return (void *)((uintptr_t)guest.guest_ram_regions[i].vmm_vaddr + offset);
+        }
+    }
+    return NULL;
+}
+
+void *gpa_to_vaddr_or_crash(uint64_t gpa, size_t *bytes_remaining)
+{
+    void *ret = gpa_to_vaddr(gpa, bytes_remaining);
+    assert(ret);
+    return ret;
+}

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <libvmm/util/util.h>
+
+bool ranges_overlap(uint64_t left_start, uint64_t left_end, uint64_t right_start, uint64_t right_end)
+{
+    return !(left_end <= right_start || right_end <= left_start);
+}

--- a/vmm.mk
+++ b/vmm.mk
@@ -43,13 +43,15 @@ ARCH_INDEP_FILES := \
 		    src/virtio/net.c \
 		    src/virtio/sound.c \
 		    src/virtio/virtio.c \
-		    src/guest.c
+			src/util/util.c \
+		    src/guest.c \
+			src/guest_ram.c
 
 CFILES := ${AARCH64_FILES} ${ARCH_INDEP_FILES}
 OBJECTS := $(subst src,libvmm,${CFILES:.c=.o})
 
 # Enable LLVM UBSAN to trap on detected undefined behaviour
-CFLAGS += -fsanitize=undefined -fsanitize-trap=undefined
+CFLAGS += -fsanitize=undefined -fsanitize-trap=undefined -Wall -Werror -Wno-unused-function
 
 # Generate dependencies automatically
 CFLAGS += -MD


### PR DESCRIPTION
- Added a guest RAM management library, the VMM now no longer requires that the guest RAM starting guest physical address to be equal to the VMM's mapping virtual address.
     - This also make x86_64 support later easier, as GPA starts from 0 for that arch.
- Fixed bit rots in the manual and documented the above improvement.
- Made the Linux kernel and initrd loading process more robust against user error and OOM conditions.
- virtio/virtq.h: removed unused functions

The guest RAM management changes in [src/arch/aarch64/linux.c](https://github.com/au-ts/libvmm/compare/arm_improvements?expand=1#diff-c021bd913701342d87707b28bc414afba5c397172b12a25f54f004efe8fe25e2) should be applied to all the virtio code as well. But since https://github.com/au-ts/libvmm/pull/212 haven't been merged I haven't touched the virtio code yet as there are other clean ups I want to apply in the virtio as well.