### PR TITLE
Don't specify page size in SDF for guest RAM

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -69,7 +69,7 @@ The following is essentially what is in
 [the QEMU example system](../examples/simple/board/qemu_virt_aarch64/simple.system):
 
 ```xml
-<memory_region name="guest_ram" size="0x10_000_000" page_size="0x200_000" />
+<memory_region name="guest_ram" size="0x10_000_000" />
 <memory_region name="serial" size="0x1_000" phys_addr="0x9000000" />
 <memory_region name="gic_vcpu" size="0x1_000" phys_addr="0x8040000" />
 

--- a/examples/simple/board/maaxboard/simple.system
+++ b/examples/simple/board/maaxboard/simple.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <!-- We allocate 256MiB of RAM for the guest. -->
-    <memory_region name="guest_ram" size="0x10000000" page_size="0x200000" />
+    <memory_region name="guest_ram" size="0x10000000" />
     <!-- We want to map in the UART to get input/output. -->
     <memory_region name="uart" size="0x10000" phys_addr="0x30860000" />
     <!-- To boot Linux, we need to map in the GIC virtual CPU interface. -->

--- a/examples/simple/board/odroidc4/simple.system
+++ b/examples/simple/board/odroidc4/simple.system
@@ -6,7 +6,7 @@
 -->
 <system>
     <!-- We allocate 256MiB of RAM for the guest. -->
-    <memory_region name="guest_ram" size="0x10_000_000" page_size="0x200_000" />
+    <memory_region name="guest_ram" size="0x10_000_000" />
     <!-- We want to map in the serial (/soc/bus@ff800000/serial@3000) to get input/output. -->
     <!--
         In addition to the serial device, the default Linux image requires access to

--- a/examples/simple/board/qemu_virt_aarch64/simple.system
+++ b/examples/simple/board/qemu_virt_aarch64/simple.system
@@ -9,7 +9,7 @@
      Here we give the guest 256MiB to use as RAM. Note that we use 2MiB page
      sizes for efficiency, it does not have any functional effect.
     -->
-    <memory_region name="guest_ram" size="0x10_000_000" page_size="0x200_000" />
+    <memory_region name="guest_ram" size="0x10_000_000" />
 
     <!--
      We intend to map in this UART into the guest's virtual address space so


### PR DESCRIPTION
Because the Microkit tool will default to the largest possible page size anyways.