### PR TITLE
Preserve user MICROKIT_SDK in the nix dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ There is a Nix flake available in the repository, so you can get a development s
 nix develop
 ```
 
-Note that this will set the `MICROKIT_SDK` environment variable to the SDK path, you do not
-need to download the Microkit SDK manually.
+Note that if the `MICROKIT_SDK` environment variable is not set, this will automatically
+download the Microkit SDK for you and point `MICROKIT_SDK` to it.
 
 ### Building and running
 

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,18 @@
             pysdfgen
             ts_ci
           ]);
+
+          microkit-sdk = pkgs.fetchzip {
+            url = "${microkit-url}/microkit-sdk-${microkit-version}-${microkit-platforms.${system}}.tar.gz";
+            hash =
+              {
+                aarch64-darwin = "sha256-UZBEwS3vAQqJe6Xj+13smJRS0RYfoc0uCK7hB8ujbvA=";
+                x86_64-darwin = "sha256-aE2mYToK2ne9vzw6d3YQDzJvhpnI8IHOR9+VqZxwlfY=";
+                aarch64-linux = "sha256-U1hA7Vk/TlSWgV7KiEeG7AkA7t5IR/x89mSE0YHBRNA=";
+                x86_64-linux = "sha256-dxPu2Q01qjKhME6Z6kgG4ASDUe12ytZmh5tCtFva/L0=";
+              }
+              .${system} or (throw "Unsupported system: ${system}");
+          };
         in
         {
             docs = pkgs.mkShell rec {
@@ -93,17 +105,11 @@
 
               microkit-platform = microkit-platforms.${system} or (throw "Unsupported system: ${system}");
 
-              env.MICROKIT_SDK = pkgs.fetchzip {
-                url = "${microkit-url}/microkit-sdk-${microkit-version}-${microkit-platform}.tar.gz";
-                hash =
-                  {
-                    aarch64-darwin = "sha256-UZBEwS3vAQqJe6Xj+13smJRS0RYfoc0uCK7hB8ujbvA=";
-                    x86_64-darwin = "sha256-aE2mYToK2ne9vzw6d3YQDzJvhpnI8IHOR9+VqZxwlfY=";
-                    aarch64-linux = "sha256-U1hA7Vk/TlSWgV7KiEeG7AkA7t5IR/x89mSE0YHBRNA=";
-                    x86_64-linux = "sha256-dxPu2Q01qjKhME6Z6kgG4ASDUe12ytZmh5tCtFva/L0=";
-                  }
-                  .${system} or (throw "Unsupported system: ${system}");
-              };
+              shellHook = ''
+                if [ -z "$MICROKIT_SDK" ]; then
+                  export MICROKIT_SDK=${microkit-sdk}
+                fi
+              '';
 
               nativeBuildInputs = with pkgs; [
                 rust


### PR DESCRIPTION
Stop the Nix dev shell from unconditionally overwriting `MICROKIT_SDK` with the fetched SDK path.
If `MICROKIT_SDK` is already set by the user, the shell now keeps it, otherwise it falls back to the default fetched SDK.