### PR TITLE
virtio: use GPA to HVA translation 

### DIFF
--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -65,6 +65,10 @@ static inline struct virtq *get_current_virtq_by_handler(virtio_device_t *dev)
  */
 bool virtio_mmio_register_device(virtio_device_t *dev, uintptr_t region_base, uintptr_t region_size, size_t virq);
 
+struct virtq_desc *virtio_get_desc_ring(struct virtq *virtq);
+struct virtq_avail *virtio_get_avail_ring(struct virtq *virtq);
+struct virtq_used *virtio_get_used_ring(struct virtq *virtq);
+
 /*
  * Given a descriptor head, walk the descriptor chain and compute the sum of the
  * length of all the desciptor chain's buffers

--- a/include/libvmm/virtio/virtq.h
+++ b/include/libvmm/virtio/virtq.h
@@ -92,10 +92,11 @@ struct virtq_used {
 };
 
 struct virtq {
+    /* queue capacity */
     unsigned int num;
-    struct virtq_desc *desc;
-    struct virtq_avail *avail;
-    struct virtq_used *used;
+    struct virtq_desc *desc_gpa;
+    struct virtq_avail *avail_gpa;
+    struct virtq_used *used_gpa;
 };
 
 /* The standard layout for the ring is a continuous chunk of memory which looks

--- a/src/virtio/mmio.c
+++ b/src/virtio/mmio.c
@@ -202,9 +202,9 @@ static bool handle_virtio_mmio_reg_write(virtio_device_t *dev, size_t vcpu_id, s
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_DESC_LOW, REG_VIRTIO_MMIO_QUEUE_DESC_HIGH): {
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = get_current_virtq_by_handler(dev);
-            uintptr_t ptr = (uintptr_t)virtq->desc;
+            uintptr_t ptr = (uintptr_t)virtq->desc_gpa;
             ptr |= data;
-            virtq->desc = (struct virtq_desc *)ptr;
+            virtq->desc_gpa = (struct virtq_desc *)ptr;
         } else {
             LOG_VMM_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_MMIO_QUEUE_DESC_LOW\n",
@@ -216,9 +216,9 @@ static bool handle_virtio_mmio_reg_write(virtio_device_t *dev, size_t vcpu_id, s
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_DESC_HIGH, REG_VIRTIO_MMIO_QUEUE_AVAIL_LOW): {
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = get_current_virtq_by_handler(dev);
-            uintptr_t ptr = (uintptr_t)virtq->desc;
+            uintptr_t ptr = (uintptr_t)virtq->desc_gpa;
             ptr |= (uintptr_t)data << 32;
-            virtq->desc = (struct virtq_desc *)ptr;
+            virtq->desc_gpa = (struct virtq_desc *)ptr;
         } else {
             LOG_VMM_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_MMIO_QUEUE_DESC_HIGH\n",
@@ -230,9 +230,9 @@ static bool handle_virtio_mmio_reg_write(virtio_device_t *dev, size_t vcpu_id, s
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_AVAIL_LOW, REG_VIRTIO_MMIO_QUEUE_AVAIL_HIGH): {
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = get_current_virtq_by_handler(dev);
-            uintptr_t ptr = (uintptr_t)virtq->avail;
+            uintptr_t ptr = (uintptr_t)virtq->avail_gpa;
             ptr |= data;
-            virtq->avail = (struct virtq_avail *)ptr;
+            virtq->avail_gpa = (struct virtq_avail *)ptr;
         } else {
             LOG_VMM_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_MMIO_QUEUE_AVAIL_LOW\n",
@@ -244,9 +244,9 @@ static bool handle_virtio_mmio_reg_write(virtio_device_t *dev, size_t vcpu_id, s
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_AVAIL_HIGH, REG_VIRTIO_MMIO_QUEUE_USED_LOW): {
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = get_current_virtq_by_handler(dev);
-            uintptr_t ptr = (uintptr_t)virtq->avail;
+            uintptr_t ptr = (uintptr_t)virtq->avail_gpa;
             ptr |= (uintptr_t)data << 32;
-            virtq->avail = (struct virtq_avail *)ptr;
+            virtq->avail_gpa = (struct virtq_avail *)ptr;
         } else {
             LOG_VMM_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_MMIO_QUEUE_AVAIL_HIGH\n",
@@ -258,9 +258,9 @@ static bool handle_virtio_mmio_reg_write(virtio_device_t *dev, size_t vcpu_id, s
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_USED_LOW, REG_VIRTIO_MMIO_QUEUE_USED_HIGH): {
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = get_current_virtq_by_handler(dev);
-            uintptr_t ptr = (uintptr_t)virtq->used;
+            uintptr_t ptr = (uintptr_t)virtq->used_gpa;
             ptr |= data;
-            virtq->used = (struct virtq_used *)ptr;
+            virtq->used_gpa = (struct virtq_used *)ptr;
         } else {
             LOG_VMM_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_MMIO_QUEUE_USED_LOW\n",
@@ -272,9 +272,9 @@ static bool handle_virtio_mmio_reg_write(virtio_device_t *dev, size_t vcpu_id, s
     case REG_RANGE(REG_VIRTIO_MMIO_QUEUE_USED_HIGH, REG_VIRTIO_MMIO_CONFIG_GENERATION): {
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = get_current_virtq_by_handler(dev);
-            uintptr_t ptr = (uintptr_t)virtq->used;
+            uintptr_t ptr = (uintptr_t)virtq->used_gpa;
             ptr |= (uintptr_t)data << 32;
-            virtq->used = (struct virtq_used *)ptr;
+            virtq->used_gpa = (struct virtq_used *)ptr;
         } else {
             LOG_VMM_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_MMIO_QUEUE_USED_HIGH\n",

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -322,9 +322,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_DESC_LO, VIRTIO_PCI_COMMON_Q_DESC_HI):
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
-            uintptr_t ptr = (uintptr_t)virtq->desc;
+            uintptr_t ptr = (uintptr_t)virtq->desc_gpa;
             ptr |= data;
-            virtq->desc = (struct virtq_desc *)ptr;
+            virtq->desc_gpa = (struct virtq_desc *)ptr;
         } else {
             LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
@@ -335,9 +335,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_DESC_HI, VIRTIO_PCI_COMMON_Q_AVAIL_LO):
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
-            uintptr_t ptr = (uintptr_t)virtq->desc;
+            uintptr_t ptr = (uintptr_t)virtq->desc_gpa;
             ptr |= (uintptr_t)data << 32;
-            virtq->desc = (struct virtq_desc *)ptr;
+            virtq->desc_gpa = (struct virtq_desc *)ptr;
         } else {
             LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_MMIO_QUEUE_DESC_HIGH\n",
@@ -348,9 +348,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_AVAIL_LO, VIRTIO_PCI_COMMON_Q_AVAIL_HI):
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
-            uintptr_t ptr = (uintptr_t)virtq->avail;
+            uintptr_t ptr = (uintptr_t)virtq->avail_gpa;
             ptr |= data;
-            virtq->avail = (struct virtq_avail *)ptr;
+            virtq->avail_gpa = (struct virtq_avail *)ptr;
         } else {
             LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
@@ -361,9 +361,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_AVAIL_HI, VIRTIO_PCI_COMMON_Q_USED_LO):
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
-            uintptr_t ptr = (uintptr_t)virtq->avail;
+            uintptr_t ptr = (uintptr_t)virtq->avail_gpa;
             ptr |= (uintptr_t)data << 32;
-            virtq->avail = (struct virtq_avail *)ptr;
+            virtq->avail_gpa = (struct virtq_avail *)ptr;
         } else {
             LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
@@ -374,9 +374,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_USED_LO, VIRTIO_PCI_COMMON_Q_USED_HI):
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
-            uintptr_t ptr = (uintptr_t)virtq->used;
+            uintptr_t ptr = (uintptr_t)virtq->used_gpa;
             ptr |= data;
-            virtq->used = (struct virtq_used *)ptr;
+            virtq->used_gpa = (struct virtq_used *)ptr;
         } else {
             LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
@@ -387,9 +387,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_USED_HI, VIRTIO_PCI_COMMON_Q_NOTIF_DATA):
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
-            uintptr_t ptr = (uintptr_t)virtq->used;
+            uintptr_t ptr = (uintptr_t)virtq->used_gpa;
             ptr |= (uintptr_t)data << 32;
-            virtq->used = (struct virtq_used *)ptr;
+            virtq->used_gpa = (struct virtq_used *)ptr;
         } else {
             LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
                         "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",

--- a/src/virtio/sound.c
+++ b/src/virtio/sound.c
@@ -224,7 +224,7 @@ static uint8_t virtio_direction_from_sddf(uint8_t direction)
         return VIRTIO_SND_D_OUTPUT;
     }
     LOG_SOUND_ERR("Unknown direction %u\n", direction);
-    return (uint8_t) -1;
+    return (uint8_t)-1;
 }
 
 static uint32_t virtio_status_from_sddf(sound_status_t status)
@@ -241,7 +241,7 @@ static uint32_t virtio_status_from_sddf(sound_status_t status)
     case SOUND_S_BUSY:
         return VIRTIO_SOUND_S_IO_ERR;
     }
-    return (uint32_t) -1;
+    return (uint32_t)-1;
 }
 
 static void get_pcm_info(struct virtio_snd_pcm_info *dest, const sound_pcm_info_t *src)
@@ -254,16 +254,11 @@ static void get_pcm_info(struct virtio_snd_pcm_info *dest, const sound_pcm_info_
     dest->channels_max = src->channels_max;
 }
 
-static int handle_pcm_info(struct virtio_device *dev,
-                           struct virtq *virtq,
-                           struct virtio_snd_query_info *query_info,
-                           struct virtio_snd_pcm_info *responses,
-                           uint32_t response_count,
-                           uint32_t *bytes_written)
+static int handle_pcm_info(struct virtio_device *dev, struct virtq *virtq, struct virtio_snd_query_info *query_info,
+                           struct virtio_snd_pcm_info *responses, uint32_t response_count, uint32_t *bytes_written)
 {
     if (response_count < query_info->count) {
-        LOG_SOUND_ERR("Control message response descriptor too small (%d < %d)\n",
-                      response_count, query_info->count);
+        LOG_SOUND_ERR("Control message response descriptor too small (%d < %d)\n", response_count, query_info->count);
         return -SOUND_S_BAD_MSG;
     }
 
@@ -285,8 +280,7 @@ static int handle_pcm_info(struct virtio_device *dev,
     return i;
 }
 
-static int handle_pcm_set_params(struct virtio_device *dev,
-                                 uint16_t desc_head,
+static int handle_pcm_set_params(struct virtio_device *dev, uint16_t desc_head,
                                  struct virtio_snd_pcm_set_params *set_params)
 {
     struct virtio_snd_device *state = device_state(dev);
@@ -322,10 +316,7 @@ static int handle_pcm_set_params(struct virtio_device *dev,
     return 0;
 }
 
-static int handle_basic_cmd(struct virtio_device *dev,
-                            uint16_t desc_head,
-                            uint32_t stream_id,
-                            sound_cmd_code_t code)
+static int handle_basic_cmd(struct virtio_device *dev, uint16_t desc_head, uint32_t stream_id, sound_cmd_code_t code)
 {
     struct virtio_snd_device *state = device_state(dev);
 
@@ -359,20 +350,19 @@ static int handle_basic_cmd(struct virtio_device *dev,
 
 static void virtq_enqueue_used(struct virtq *virtq, uint32_t desc_head, uint32_t bytes_written)
 {
-    struct virtq_used_elem *used_elem = &virtq->used->ring[virtq->used->idx % virtq->num];
+    struct virtq_used *used_ring = virtio_get_used_ring(virtq);
+    struct virtq_used_elem *used_elem = &used_ring->ring[used_ring->idx % virtq->num];
     used_elem->id = desc_head;
     used_elem->len = bytes_written;
-    virtq->used->idx++;
+    used_ring->idx++;
 }
 
 // Returns number of bytes written to virtq
-static void handle_control_msg(struct virtio_device *dev,
-                               struct virtq *virtq,
-                               uint16_t desc_head,
-                               bool *notify_driver,
+static void handle_control_msg(struct virtio_device *dev, struct virtq *virtq, uint16_t desc_head, bool *notify_driver,
                                bool *respond)
 {
-    struct virtq_desc *req_desc = &virtq->desc[desc_head];
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
+    struct virtq_desc *req_desc = &desc_ring[desc_head];
     struct virtio_snd_hdr *hdr = (void *)req_desc->addr;
     struct virtio_snd_pcm_hdr *pcm_hdr = (void *)hdr;
 
@@ -385,7 +375,7 @@ static void handle_control_msg(struct virtio_device *dev,
         return;
     }
 
-    struct virtq_desc *status_desc = &virtq->desc[req_desc->next];
+    struct virtq_desc *status_desc = &desc_ring[req_desc->next];
     uint32_t *status_ptr = (void *)status_desc->addr;
 
     int result;
@@ -399,12 +389,9 @@ static void handle_control_msg(struct virtio_device *dev,
             break;
         }
 
-        struct virtq_desc *response_desc = &virtq->desc[status_desc->next];
-        result = handle_pcm_info(dev, virtq,
-                                 (void *)hdr,
-                                 (void *)response_desc->addr,
-                                 response_desc->len / sizeof(struct virtio_snd_pcm_info),
-                                 &bytes_written);
+        struct virtq_desc *response_desc = &desc_ring[status_desc->next];
+        result = handle_pcm_info(dev, virtq, (void *)hdr, (void *)response_desc->addr,
+                                 response_desc->len / sizeof(struct virtio_snd_pcm_info), &bytes_written);
         if (result >= 0) {
             bytes_written += result * sizeof(struct virtio_snd_pcm_info);
         }
@@ -456,15 +443,11 @@ static void handle_control_msg(struct virtio_device *dev,
     *respond = immediate;
 }
 
-static bool perform_xfer(struct virtio_device *dev,
-                         struct virtq *virtq,
-                         struct virtq_desc *desc,
-                         bool transmit,
-                         int stream_id,
-                         int cookie,
-                         int *sent)
+static bool perform_xfer(struct virtio_device *dev, struct virtq *virtq, struct virtq_desc *desc, bool transmit,
+                         int stream_id, int cookie, int *sent)
 {
     struct virtio_snd_device *state = device_state(dev);
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
 
     uintptr_t buf_offset;
     if (!queue_dequeue_front(&state->free_buffers, &buf_offset)) {
@@ -476,9 +459,7 @@ static bool perform_xfer(struct virtio_device *dev,
     uint32_t pcm_remaining = SOUND_PCM_BUFFER_SIZE;
 
     // Decompose descriptor chain into one or more sDDF requests.
-    for (;
-         desc->flags & VIRTQ_DESC_F_NEXT;
-         desc = &virtq->desc[desc->next]) {
+    for (; desc->flags & VIRTQ_DESC_F_NEXT; desc = &desc_ring[desc->next]) {
         if (!!(desc->flags & VIRTQ_DESC_F_WRITE) == transmit) {
             LOG_SOUND_ERR("Incorrect xfer buffer type\n");
             return false;
@@ -493,8 +474,7 @@ static bool perform_xfer(struct virtio_device *dev,
 
             if (transmit) {
                 void *pcm_buffer = state->data_region + buf_offset;
-                memcpy(pcm_buffer + pcm_transmitted,
-                       (void *)desc->addr + desc_transmitted, to_xfer);
+                memcpy(pcm_buffer + pcm_transmitted, (void *)desc->addr + desc_transmitted, to_xfer);
             }
             desc_transmitted += to_xfer;
             desc_remaining -= to_xfer;
@@ -550,13 +530,11 @@ static bool perform_xfer(struct virtio_device *dev,
     return true;
 }
 
-static void handle_xfer(struct virtio_device *dev,
-                        struct virtq *virtq,
-                        uint16_t desc_head,
-                        bool transmit,
+static void handle_xfer(struct virtio_device *dev, struct virtq *virtq, uint16_t desc_head, bool transmit,
                         bool *notify_driver, bool *respond)
 {
-    struct virtq_desc *req_desc = &virtq->desc[desc_head];
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
+    struct virtq_desc *req_desc = &desc_ring[desc_head];
     struct virtio_snd_pcm_xfer *hdr = (void *)req_desc->addr;
 
     struct virtio_snd_device *state = device_state(dev);
@@ -573,16 +551,13 @@ static void handle_xfer(struct virtio_device *dev,
         return;
     }
 
-    struct virtq_desc *desc = &virtq->desc[req_desc->next];
+    struct virtq_desc *desc = &desc_ring[req_desc->next];
     int sent = 0;
-    bool success = perform_xfer(dev, virtq, desc, transmit,
-                                hdr->stream_id, cookie, &sent);
+    bool success = perform_xfer(dev, virtq, desc, transmit, hdr->stream_id, cookie, &sent);
 
     if (sent == 0) {
         // If we sent zero, respond immediately.
-        for (;
-             desc->flags & VIRTQ_DESC_F_NEXT;
-             desc = &virtq->desc[desc->next]);
+        for (; desc->flags & VIRTQ_DESC_F_NEXT; desc = &desc_ring[desc->next]);
 
         assert(desc->flags & VIRTQ_DESC_F_WRITE);
 
@@ -609,16 +584,16 @@ static void handle_xfer(struct virtio_device *dev,
     *notify_driver = true;
 }
 
-static void handle_virtq(struct virtio_device *dev,
-                         int index, bool *notify_driver, bool *respond)
+static void handle_virtq(struct virtio_device *dev, int index, bool *notify_driver, bool *respond)
 {
     virtio_queue_handler_t *vq = &dev->vqs[index];
     struct virtq *virtq = &vq->virtq;
+    struct virtq_avail *avail_ring = virtio_get_avail_ring(virtq);
 
     uint16_t idx = vq->last_idx;
-    for (; idx != virtq->avail->idx; idx++) {
+    for (; idx != avail_ring->idx; idx++) {
 
-        uint16_t desc_head = virtq->avail->ring[idx % virtq->num];
+        uint16_t desc_head = avail_ring->ring[idx % virtq->num];
 
         switch (index) {
         case CONTROLQ:
@@ -688,14 +663,9 @@ bool virtio_snd_init(struct virtio_snd_device *sound_dev, uintptr_t region_base,
     sound_dev->config.streams = shared_state->streams;
     sound_dev->config.chmaps = 0;
 
-    ialloc_init(&sound_dev->free_requests,
-                sound_dev->free_requests_data,
-                VIRTIO_SND_MAX_REQUESTS);
+    ialloc_init(&sound_dev->free_requests, sound_dev->free_requests_data, VIRTIO_SND_MAX_REQUESTS);
 
-    queue_init(&sound_dev->free_buffers,
-               sizeof(uintptr_t),
-               sound_dev->free_buffers_data,
-               SOUND_PCM_QUEUE_CAPACITY);
+    queue_init(&sound_dev->free_buffers, sizeof(uintptr_t), sound_dev->free_buffers_data, SOUND_PCM_QUEUE_CAPACITY);
 
     sound_dev->shared_state = shared_state;
     sound_dev->cmd_req = queues->cmd_req;
@@ -713,16 +683,13 @@ bool virtio_snd_init(struct virtio_snd_device *sound_dev, uintptr_t region_base,
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
 
-static unsigned copy_rx_data(struct virtq *virtq,
-                             struct virtq_desc *desc,
-                             virtio_snd_request_t *req,
-                             void *pcm, unsigned pcm_len)
+static unsigned copy_rx_data(struct virtq *virtq, struct virtq_desc *desc, virtio_snd_request_t *req, void *pcm,
+                             unsigned pcm_len)
 {
     uint32_t desc_position = 0;
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
 
-    for (;
-         desc->flags & VIRTQ_DESC_F_NEXT;
-         desc = &virtq->desc[desc->next]) {
+    for (; desc->flags & VIRTQ_DESC_F_NEXT; desc = &desc_ring[desc->next]) {
         if ((desc->flags & VIRTQ_DESC_F_WRITE) == 0) {
             LOG_SOUND_ERR("Expected VIRTQ_DESC_F_WRITE on RX buffer\n");
             req->status = SOUND_S_BAD_MSG;
@@ -755,9 +722,8 @@ static unsigned copy_rx_data(struct virtq *virtq,
             req->status = SOUND_S_BAD_MSG;
         }
         if (desc_position != req->bytes_received) {
-            LOG_SOUND_ERR(
-                "Did not receive enough PCM for RX: desc_position %u, bytes_received %u\n",
-                desc_position, req->bytes_received);
+            LOG_SOUND_ERR("Did not receive enough PCM for RX: desc_position %u, bytes_received %u\n", desc_position,
+                          req->bytes_received);
 
             req->status = SOUND_S_BAD_MSG;
         }
@@ -773,9 +739,7 @@ static unsigned copy_rx_data(struct virtq *virtq,
     return desc_position;
 }
 
-static bool respond_to_request(virtio_snd_request_t *req,
-                               struct virtio_device *dev,
-                               void *pcm, unsigned pcm_len,
+static bool respond_to_request(virtio_snd_request_t *req, struct virtio_device *dev, void *pcm, unsigned pcm_len,
                                void *response, unsigned response_len)
 {
     if (req->ref_count == 0) {
@@ -787,9 +751,10 @@ static bool respond_to_request(virtio_snd_request_t *req,
 
     assert(req->virtq_idx < VIRTIO_SND_NUM_VIRTQ);
     struct virtq *virtq = &dev->vqs[req->virtq_idx].virtq;
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
 
-    struct virtq_desc *req_desc = &virtq->desc[desc_head];
-    struct virtq_desc *res_desc = &virtq->desc[req_desc->next];
+    struct virtq_desc *req_desc = &desc_ring[desc_head];
+    struct virtq_desc *res_desc = &desc_ring[req_desc->next];
 
     unsigned used;
     if (req->virtq_idx == RXQ) {
@@ -803,9 +768,7 @@ static bool respond_to_request(virtio_snd_request_t *req,
     }
 
     struct virtq_desc *status_desc = res_desc;
-    for (;
-         status_desc->flags & VIRTQ_DESC_F_NEXT;
-         status_desc = &virtq->desc[status_desc->next]);
+    for (; status_desc->flags & VIRTQ_DESC_F_NEXT; status_desc = &desc_ring[status_desc->next]);
 
     if (status_desc == req_desc || (status_desc->flags & VIRTQ_DESC_F_WRITE) == 0) {
         LOG_SOUND_ERR("Message must contain writeable status descriptor\n");
@@ -834,8 +797,7 @@ void virtio_snd_notified(struct virtio_snd_device *state)
 
         uint32_t response = virtio_status_from_sddf(req->status);
 
-        bool responded = respond_to_request(req, dev, NULL, 0,
-                                            &response, sizeof(response));
+        bool responded = respond_to_request(req, dev, NULL, 0, &response, sizeof(response));
         if (responded) {
             ialloc_free(&state->free_requests, cmd.cookie);
             respond = true;
@@ -855,9 +817,7 @@ void virtio_snd_notified(struct virtio_snd_device *state)
         response.latency_bytes = pcm.latency_bytes;
 
         void *pcm_buffer = state->data_region + pcm.io_or_offset;
-        bool responded = respond_to_request(req, dev,
-                                            pcm_buffer, pcm.len,
-                                            &response, sizeof(response));
+        bool responded = respond_to_request(req, dev, pcm_buffer, pcm.len, &response, sizeof(response));
         if (responded) {
             ialloc_free(&state->free_requests, pcm.cookie);
             respond = true;

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -8,13 +8,51 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <libvmm/guest_ram.h>
 #include <libvmm/virtio/virtq.h>
 #include <libvmm/virtio/virtio.h>
+
+/* These are incorrect if VIRTIO_F_EVENT_IDX feature is negotitated, but we don't support that for now. */
+static inline size_t virtio_desc_ring_size_bytes(struct virtq *virtq)
+{
+    return virtq->num * sizeof(struct virtq_desc);
+}
+
+static inline size_t virtio_avail_ring_size_bytes(struct virtq *virtq)
+{
+    /* There are 2 u16 before the actual ring. */
+    return 4 + virtq->num * sizeof(uint16_t);
+}
+
+static inline size_t virtio_used_ring_size_bytes(struct virtq *virtq)
+{
+    /* There are 2 u16 before the actual ring. */
+    return 4 + virtq->num * sizeof(struct virtq_used_elem);
+}
+
+struct virtq_desc *virtio_get_desc_ring(struct virtq *virtq)
+{
+    uint64_t desc_ring_gpa = (uint64_t)virtq->desc_gpa;
+    return (struct virtq_desc *)gpa_to_hva(desc_ring_gpa, virtio_desc_ring_size_bytes(virtq));
+}
+
+struct virtq_avail *virtio_get_avail_ring(struct virtq *virtq)
+{
+    uint64_t avail_ring_gpa = (uint64_t)virtq->avail_gpa;
+    return (struct virtq_avail *)gpa_to_hva(avail_ring_gpa, virtio_avail_ring_size_bytes(virtq));
+}
+
+struct virtq_used *virtio_get_used_ring(struct virtq *virtq)
+{
+    uint64_t used_ring_gpa = (uint64_t)virtq->used_gpa;
+    return (struct virtq_used *)gpa_to_hva(used_ring_gpa, virtio_used_ring_size_bytes(virtq));
+}
 
 uint64_t virtio_desc_chain_payload_len(virtio_queue_handler_t *vq_handler, uint16_t desc_head)
 {
     assert(vq_handler->ready);
     struct virtq *virtq = &vq_handler->virtq;
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
 
     uint64_t loop_iter_count = 0;
     uint64_t payload_len = 0;
@@ -25,12 +63,12 @@ uint64_t virtio_desc_chain_payload_len(virtio_queue_handler_t *vq_handler, uint1
             return 0;
         }
 
-        payload_len += virtq->desc[curr_desc].len;
-        if (!(virtq->desc[curr_desc].flags & VIRTQ_DESC_F_NEXT)) {
+        payload_len += desc_ring[curr_desc].len;
+        if (!(desc_ring[curr_desc].flags & VIRTQ_DESC_F_NEXT)) {
             break;
         }
 
-        curr_desc = virtq->desc[curr_desc].next;
+        curr_desc = desc_ring[curr_desc].next;
         loop_iter_count++;
     };
     return payload_len;
@@ -41,6 +79,7 @@ bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16
 {
     assert(vq_handler->ready);
     struct virtq *virtq = &vq_handler->virtq;
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
 
     uint64_t current_list_byte = read_off;
     uint64_t end_list_byte = read_off + bytes_to_read;
@@ -54,16 +93,17 @@ bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16
             return false;
         }
 
-        struct virtq_desc *desc = &virtq->desc[curr_desc];
+        struct virtq_desc *desc = &desc_ring[curr_desc];
         uint64_t current_desc_end_byte = current_desc_start_byte + desc->len;
 
         if (current_list_byte >= current_desc_start_byte && current_list_byte < current_desc_end_byte) {
             /* This descriptor have what we need, copy it over to `data`. */
             uint64_t copy_size = MIN(current_desc_end_byte, end_list_byte) - current_list_byte;
             uint64_t src_gpa = desc->addr + (current_list_byte - current_desc_start_byte);
+            void *src_hva = gpa_to_hva(src_gpa, copy_size);
             char *dest = data + (current_list_byte - read_off);
 
-            memcpy(dest, (char *)src_gpa, copy_size);
+            memcpy(dest, src_hva, copy_size);
             current_list_byte += copy_size;
         }
 
@@ -73,7 +113,7 @@ bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16
         }
         loop_iter_count++;
         current_desc_start_byte += desc->len;
-        curr_desc = virtq->desc[curr_desc].next;
+        curr_desc = desc_ring[curr_desc].next;
     }
 
     return current_list_byte == end_list_byte;
@@ -84,6 +124,7 @@ bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_
 {
     assert(vq_handler->ready);
     struct virtq *virtq = &vq_handler->virtq;
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
 
     uint64_t current_list_byte = write_off;
     uint64_t end_list_byte = write_off + bytes_to_write;
@@ -97,7 +138,7 @@ bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_
             return false;
         }
 
-        struct virtq_desc *desc = &virtq->desc[curr_desc];
+        struct virtq_desc *desc = &desc_ring[curr_desc];
         uint64_t current_desc_end_byte = current_desc_start_byte + desc->len;
 
         if (current_list_byte >= current_desc_start_byte && current_list_byte < current_desc_end_byte) {
@@ -105,8 +146,9 @@ bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_
             uint64_t copy_size = MIN(current_desc_end_byte, end_list_byte) - current_list_byte;
             char *src = data + (current_list_byte - write_off);
             uint64_t dest_gpa = desc->addr + (current_list_byte - current_desc_start_byte);
+            void *dest_hva = gpa_to_hva(dest_gpa, copy_size);
 
-            memcpy((char *)dest_gpa, src, copy_size);
+            memcpy(dest_hva, src, copy_size);
             current_list_byte += copy_size;
         }
 
@@ -117,7 +159,7 @@ bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_
 
         loop_iter_count++;
         current_desc_start_byte += desc->len;
-        curr_desc = virtq->desc[curr_desc].next;
+        curr_desc = desc_ring[curr_desc].next;
     }
 
     return true;
@@ -127,9 +169,10 @@ bool virtio_virtq_peek_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret)
 {
     assert(vq_handler->ready);
     struct virtq *virtq = &vq_handler->virtq;
+    struct virtq_avail *avail_ring = virtio_get_avail_ring(virtq);
 
-    if (vq_handler->last_idx != virtq->avail->idx) {
-        *ret = virtq->avail->ring[vq_handler->last_idx % virtq->num];
+    if (vq_handler->last_idx != avail_ring->idx) {
+        *ret = avail_ring->ring[vq_handler->last_idx % virtq->num];
         return true;
     }
 
@@ -155,9 +198,10 @@ void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_hea
 {
     assert(vq_handler->ready);
     struct virtq *virtq = &vq_handler->virtq;
+    struct virtq_used *used_ring = virtio_get_used_ring(virtq);
 
-    struct virtq_used_elem *used_elem = &virtq->used->ring[virtq->used->idx % virtq->num];
+    struct virtq_used_elem *used_elem = &used_ring->ring[used_ring->idx % virtq->num];
     used_elem->id = desc_head;
     used_elem->len = len;
-    virtq->used->idx++;
+    used_ring->idx++;
 }


### PR DESCRIPTION
A follow up to https://github.com/au-ts/libvmm/pull/241.

Depends on https://github.com/au-ts/libvmm/pull/249.

Rather than treating GPA = HVA. Not sure
what to do about sound though since it has
bitrotted.