### PR TITLE
virtio/console: fixes

### DIFF
--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -231,12 +231,11 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
     uint16_t desc_head;
     while (!serial_queue_empty(console->rxq, console->rxq->queue->head) && virtio_virtq_pop_avail(vq, &desc_head)) {
         transferred = true;
-        struct virtq_desc desc = vq->virtq.desc[desc_head];
-        LOG_CONSOLE("processing descriptor (0x%lx) with buffer [0x%lx..0x%lx)\n", desc_head, desc.addr,
-                    desc.addr + desc.len);
+        uint64_t payload_len = virtio_desc_chain_payload_len(vq, desc_head);
+
         uint32_t bytes_written = 0;
         char c;
-        while (bytes_written < desc.len && serial_dequeue(console->rxq, &c) == 0) {
+        while (bytes_written < payload_len && serial_dequeue(console->rxq, &c) == 0) {
             assert(virtio_write_data_to_desc_chain(vq, desc_head, 1, bytes_written, &c));
             bytes_written++;
         }

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -127,7 +127,7 @@ static bool virtio_console_handle_tx(struct virtio_device *dev)
     LOG_CONSOLE("processing available buffers from index [0x%lx..0x%lx)\n", vq->last_idx, vq->virtq.avail->idx);
     bool transferred = false;
     uint16_t desc_head;
-    while (virtio_virtq_peek_avail(vq, &desc_head) && !serial_queue_full(console->txq, console->txq->queue->head)) {
+    while (virtio_virtq_peek_avail(vq, &desc_head)) {
         uint64_t payload_len = virtio_desc_chain_payload_len(vq, desc_head);
 
         if (payload_len > console->txq->capacity) {

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -223,7 +223,7 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
          * started, so just dequeue all data and early return.
          */
         char c;
-        while (serial_dequeue(console->rxq, &c));
+        while (serial_dequeue(console->rxq, &c) == 0);
         return true;
     }
 
@@ -236,7 +236,7 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
                     desc.addr + desc.len);
         uint32_t bytes_written = 0;
         char c;
-        while (bytes_written < desc.len && !serial_dequeue(console->rxq, &c)) {
+        while (bytes_written < desc.len && serial_dequeue(console->rxq, &c) == 0) {
             assert(virtio_write_data_to_desc_chain(vq, desc_head, 1, bytes_written, &c));
             bytes_written++;
         }

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -158,27 +158,25 @@ static bool virtio_console_handle_tx(struct virtio_device *dev)
         }
 
         uint32_t bytes_copied = 0;
+        uint32_t local_tail = console->txq->queue->tail;
 
         /* Copy data until no more to copy or until the queue wraps around */
-        char *serial_txq_dest = (char *)(console->txq->data_region
-                                         + (console->txq->queue->tail % console->txq->capacity));
+        char *serial_txq_dest = (char *)(console->txq->data_region + (local_tail % console->txq->capacity));
         uint32_t copy_len = MIN(payload_len, serial_txq_contiguous_free_len);
         assert(virtio_read_data_from_desc_chain(vq, desc_head, copy_len, bytes_copied, serial_txq_dest));
         bytes_copied += copy_len;
-        serial_update_shared_tail(console->txq, console->txq->queue->tail + copy_len);
 
         if (copy_twice) {
             /* Need to copy more data after the queue wraps around */
             serial_txq_dest = (char *)(console->txq->data_region
-                                       + (console->txq->queue->tail % console->txq->capacity));
+                                       + ((local_tail + bytes_copied) % console->txq->capacity));
             copy_len = payload_len - bytes_copied;
-            assert(copy_len <= serial_queue_contiguous_free(console->txq));
             assert(virtio_read_data_from_desc_chain(vq, desc_head, copy_len, bytes_copied, serial_txq_dest));
             bytes_copied += copy_len;
-            serial_update_shared_tail(console->txq, console->txq->queue->tail + copy_len);
         }
 
         assert(bytes_copied == payload_len);
+        serial_update_shared_tail(console->txq, local_tail + bytes_copied);
 
         LOG_CONSOLE("processed descriptor %u with content: %s\n", desc_head, serial_txq_dest);
 


### PR DESCRIPTION
virtio/console: fix TX deadlock

In virtio_console_handle_tx(), don't break the loop early if the TX
queue is full. Since we already have that check inside the loop to
request signal from the virtualiser.

virtio/console: fix incorrect serial dequeue check

`serial_dequeue()` returns zero on success rather than non zero.

virtio/console: use full descriptor chain for RX rather than using the first buffer then stopping.

virtio/console: just update serial tail once in TX.