### PR TITLE
virtio/console: fixes many TX + RX deadlocks

### DIFF
--- a/examples/virtio-snd/client_vmm.c
+++ b/examples/virtio-snd/client_vmm.c
@@ -142,7 +142,7 @@ void notified(microkit_channel ch)
     case SERIAL_VIRT_RX_CH: {
         /* We have received an event from the serial virtualiser, so we
          * call the virtIO console handling */
-        virtio_console_handle_rx(&virtio_console);
+        virtio_console_queue_notify(&virtio_console);
         break;
     }
     case SOUND_DRIVER_CH: {

--- a/examples/virtio-snd/snd_driver_vmm.c
+++ b/examples/virtio-snd/snd_driver_vmm.c
@@ -173,7 +173,7 @@ void notified(microkit_channel ch)
     case SERIAL_RX_CH:
         /* We have received an event from the serial virtualiser, so we
             * call the virtIO console handling */
-        virtio_console_handle_rx(&virtio_console);
+        virtio_console_queue_notify(&virtio_console);
         break;
     case SND_CLIENT_CH:
         success = virq_inject(UIO_SND_IRQ);

--- a/examples/virtio/client_vmm.c
+++ b/examples/virtio/client_vmm.c
@@ -122,7 +122,7 @@ void init(void)
     success = virtio_mmio_console_init(&virtio_console, vmm_config.virtio_mmio_devices[console_vdev_idx].base,
                                        vmm_config.virtio_mmio_devices[console_vdev_idx].size,
                                        vmm_config.virtio_mmio_devices[console_vdev_idx].irq, &serial_rx_queue,
-                                       &serial_tx_queue, serial_config.tx.id);
+                                       &serial_tx_queue, serial_config.tx.id, serial_config.rx.id);
     assert(success);
 
     /* Initialise virtIO block device */
@@ -154,7 +154,7 @@ void init(void)
 void notified(microkit_channel ch)
 {
     if (ch == serial_config.rx.id) {
-        virtio_console_handle_rx(&virtio_console);
+        virtio_console_queue_notify(&virtio_console);
     } else if (ch == serial_config.tx.id || ch == net_config.tx.id) {
         /* Nothing to do */
     } else if (ch == blk_config.virt.id) {

--- a/examples/virtio_pci/client_vmm.c
+++ b/examples/virtio_pci/client_vmm.c
@@ -105,7 +105,8 @@ void init(void)
     serial_queue_init(&serial_tx_queue, serial_config.tx.queue.vaddr, serial_config.tx.data.size,
                       serial_config.tx.data.vaddr);
 
-    success = virtio_pci_console_init(&virtio_console, 0, 48, &serial_rx_queue, &serial_tx_queue, serial_config.tx.id);
+    success = virtio_pci_console_init(&virtio_console, 0, 48, &serial_rx_queue, &serial_tx_queue, serial_config.tx.id,
+                                      serial_config.rx.id);
     assert(success);
 
     success = virtio_pci_blk_init(&virtio_blk, 1, 49, (uintptr_t)blk_config.data.vaddr, blk_config.data.size,
@@ -132,7 +133,7 @@ void init(void)
 void notified(microkit_channel ch)
 {
     if (ch == serial_config.rx.id) {
-        virtio_console_handle_rx(&virtio_console);
+        virtio_console_queue_notify(&virtio_console);
     } else if (ch == serial_config.tx.id || ch == net_config.tx.id) {
         /* Nothing to do */
     } else if (ch == blk_config.virt.id) {

--- a/include/libvmm/virtio/console.h
+++ b/include/libvmm/virtio/console.h
@@ -95,17 +95,14 @@ struct virtio_console_device {
     serial_queue_handle_t *rxq;
     serial_queue_handle_t *txq;
     int tx_ch;
+    int rx_ch;
 };
 
-bool virtio_mmio_console_init(struct virtio_console_device *console,
-                              uintptr_t region_base,
-                              uintptr_t region_size,
-                              size_t virq,
-                              serial_queue_handle_t *rxq,
-                              serial_queue_handle_t *txq,
-                              int tx_ch);
-
-bool virtio_console_handle_rx(struct virtio_console_device *console);
+bool virtio_mmio_console_init(struct virtio_console_device *console, uintptr_t region_base, uintptr_t region_size,
+                              size_t virq, serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch,
+                              int rx_ch);
 
 bool virtio_pci_console_init(struct virtio_console_device *console, uint32_t dev_slot, size_t virq,
-                             serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch);
+                             serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch, int rx_ch);
+
+bool virtio_console_queue_notify(struct virtio_console_device *console);

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -200,16 +200,10 @@ static bool virtio_console_handle_tx(struct virtio_device *dev)
     return true;
 }
 
-bool virtio_console_handle_rx(struct virtio_console_device *console)
+static bool virtio_console_handle_rx(struct virtio_console_device *console)
 {
     LOG_CONSOLE("operation: handle rx\n");
     assert(console->virtio_device.num_vqs > RX_QUEUE);
-
-    /* Previously if a TX request have payload length:
-     * TX queue free length < payload length <= TX queue capacity
-     * We request the serial virtualiser to notify us once it has consumed data from the TX queue.
-     * So try to reprocess such requests. */
-    virtio_console_handle_tx(&(console->virtio_device));
 
     /* Used to know whether to set the IRQ status. */
     bool transferred = false;
@@ -222,6 +216,12 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
          */
         char c;
         while (serial_dequeue(console->rxq, &c) == 0);
+
+        if (serial_require_consumer_signal(console->rxq)) {
+            serial_cancel_consumer_signal(console->rxq);
+            microkit_notify(console->rx_ch);
+        }
+
         return true;
     }
 
@@ -241,6 +241,11 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
         virtio_virtq_add_used(vq, desc_head, bytes_written);
     }
 
+    if (serial_require_consumer_signal(console->rxq)) {
+        serial_cancel_consumer_signal(console->rxq);
+        microkit_notify(console->rx_ch);
+    }
+
     /* While unlikely, it is possible that we could not consume any of the
      * available data. In this case we do not set the IRQ status. */
     if (transferred) {
@@ -254,18 +259,32 @@ bool virtio_console_handle_rx(struct virtio_console_device *console)
     return true;
 }
 
+bool virtio_console_queue_notify(struct virtio_console_device *console)
+{
+    /* The guest kicked the queue or the serial virtualiser notified us, check if we can TX/RX any data. */
+    bool rx_success = virtio_console_handle_rx(console);
+    bool tx_success = virtio_console_handle_tx(&console->virtio_device);
+    return rx_success && tx_success;
+}
+
+/* @billn revisit type juggling */
+static bool virtio_console_queue_notify_guest(struct virtio_device *dev)
+{
+    return virtio_console_queue_notify((struct virtio_console_device *)dev->device_data);
+}
+
 virtio_device_funs_t functions = {
     .device_reset = virtio_console_reset,
     .get_device_features = virtio_console_get_device_features,
     .set_driver_features = virtio_console_set_driver_features,
     .get_device_config = virtio_console_get_device_config,
     .set_device_config = virtio_console_set_device_config,
-    .queue_notify = virtio_console_handle_tx,
+    .queue_notify = virtio_console_queue_notify_guest,
 };
 
 static struct virtio_device *virtio_console_init(struct virtio_console_device *console, virtio_transport_type_t type,
                                                  size_t virq, serial_queue_handle_t *rxq, serial_queue_handle_t *txq,
-                                                 int tx_ch)
+                                                 int tx_ch, int rx_ch)
 {
     struct virtio_device *dev = &console->virtio_device;
     dev->regs.DeviceID = VIRTIO_DEVICE_ID_CONSOLE;
@@ -280,22 +299,23 @@ static struct virtio_device *virtio_console_init(struct virtio_console_device *c
     console->rxq = rxq;
     console->txq = txq;
     console->tx_ch = tx_ch;
+    console->rx_ch = rx_ch;
 
     return dev;
 }
 
 bool virtio_mmio_console_init(struct virtio_console_device *console, uintptr_t region_base, uintptr_t region_size,
-                              size_t virq, serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch)
+                              size_t virq, serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch, int rx_ch)
 {
-    struct virtio_device *dev = virtio_console_init(console, VIRTIO_TRANSPORT_MMIO, virq, rxq, txq, tx_ch);
+    struct virtio_device *dev = virtio_console_init(console, VIRTIO_TRANSPORT_MMIO, virq, rxq, txq, tx_ch, rx_ch);
 
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
 
 bool virtio_pci_console_init(struct virtio_console_device *console, uint32_t dev_slot, size_t virq,
-                             serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch)
+                             serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch, int rx_ch)
 {
-    struct virtio_device *dev = virtio_console_init(console, VIRTIO_TRANSPORT_PCI, virq, rxq, txq, tx_ch);
+    struct virtio_device *dev = virtio_console_init(console, VIRTIO_TRANSPORT_PCI, virq, rxq, txq, tx_ch, rx_ch);
 
     dev->transport.pci.device_id = VIRTIO_PCI_CONSOLE_DEV_ID;
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;


### PR DESCRIPTION
1. In `virtio_console_handle_rx()`, we need to check if the serial virtualiser (producer) needs to be signalled.

2. Previously, a kick from the guest only process pending TX. But there might be a scenario where we previously ran out of RX descriptors while processing RX, and need to wait for additional descriptors to be made available by the guest. Thus we must also check for RX as well on a queue kick. Since the guest may be provided additional descriptors for the RX virt queue.