### PR TITLE
examples/virtio: fix another deadlock

### DIFF
--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -633,22 +633,45 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
             if (reqbk->state == VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED
                 || reqbk->state == VIRTIO_BLK_REQ_STATE_RMW_WRITING) {
                 /* If we get here, we've just finished processing a normal or unaligned write. Now check
-                   which request is queueing on the same sDDF block we touched and process it. */
+                   which requests have been blocked on this request's completion and process them. */
+                int active_write_reqs[SDDF_MAX_QUEUE_CAPACITY];
+                int num_active_write_reqs = 0;
                 for (int i = 0; i < SDDF_MAX_QUEUE_CAPACITY; i++) {
-                    if (state->reqsbk[i].state == VIRTIO_BLK_REQ_STATE_RMW_QUEUEING
-                        && do_requests_overlap(&(state->reqsbk[i]), reqbk)) {
+                    if (i != sddf_ret_id
+                        && (state->reqsbk[i].state == VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED
+                            || state->reqsbk[i].state == VIRTIO_BLK_REQ_STATE_RMW_READING
+                            || state->reqsbk[i].state == VIRTIO_BLK_REQ_STATE_RMW_WRITING)) {
+                        active_write_reqs[num_active_write_reqs] = i;
+                        num_active_write_reqs++;
+                    }
+                }
 
-                        state->reqsbk[i].state = VIRTIO_BLK_REQ_STATE_RMW_READING;
-                        uintptr_t next_sddf_offset = state->reqsbk[i].sddf_data_cell_base
-                                                   - ((struct virtio_blk_device *)dev->device_data)->data_region;
+                for (int i = 0; i < SDDF_MAX_QUEUE_CAPACITY; i++) {
+                    if (state->reqsbk[i].state == VIRTIO_BLK_REQ_STATE_RMW_QUEUEING) {
+                        bool i_req_safe_to_dispatch = true;
+                        for (int j = 0; j < num_active_write_reqs; j++) {
+                            if (do_requests_overlap(&state->reqsbk[i], &state->reqsbk[active_write_reqs[j]])) {
 
-                        err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, next_sddf_offset,
-                                              state->reqsbk[i].sddf_block_number, state->reqsbk[i].sddf_count, i);
-                        assert(!err);
+                                i_req_safe_to_dispatch = false;
+                                break;
+                            }
+                        }
 
-                        virt_notify = true;
-                        read_write_modify_inflight = true;
-                        break;
+                        if (i_req_safe_to_dispatch) {
+                            state->reqsbk[i].state = VIRTIO_BLK_REQ_STATE_RMW_READING;
+                            uintptr_t next_sddf_offset = state->reqsbk[i].sddf_data_cell_base
+                                                       - ((struct virtio_blk_device *)dev->device_data)->data_region;
+
+                            err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, next_sddf_offset,
+                                                  state->reqsbk[i].sddf_block_number, state->reqsbk[i].sddf_count, i);
+                            assert(!err);
+
+                            virt_notify = true;
+                            read_write_modify_inflight = true;
+
+                            active_write_reqs[num_active_write_reqs] = i;
+                            num_active_write_reqs++;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
~~Using this PR for debugging why the Block test hangs for the `virtio` example but not for the `virtio_pci` example when I switched the QEMU CI Runner from GitHub to self hosted. I cannot replicate this issue even when I matched my local QEMU version with the runner's QEMU version.~~

Ah, I figured it out.

There is a deadlock bug in virtIO Block. This is the buggy code in `virtio_blk_handle_resp()`:
```c
if (reqbk->state == VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED
	|| reqbk->state == VIRTIO_BLK_REQ_STATE_RMW_WRITING) {
	/* If we get here, we've just finished processing a normal or unaligned write. Now check
		which request is queueing on the same sDDF block we touched and process it. */
	for (int i = 0; i < SDDF_MAX_QUEUE_CAPACITY; i++) {
		if (state->reqsbk[i].state == VIRTIO_BLK_REQ_STATE_RMW_QUEUEING
			&& do_requests_overlap(&(state->reqsbk[i]), reqbk)) {

			state->reqsbk[i].state = VIRTIO_BLK_REQ_STATE_RMW_READING;
			uintptr_t next_sddf_offset = state->reqsbk[i].sddf_data_cell_base
										- ((struct virtio_blk_device *)dev->device_data)->data_region;

			err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, next_sddf_offset,
									state->reqsbk[i].sddf_block_number, state->reqsbk[i].sddf_count, i);
			assert(!err);

			virt_notify = true;
			read_write_modify_inflight = true;
			break;
		}
	}
}
```

Consider a queue with 3 requests (with unaligned starting sectors which forces RMW):
1. Write sectors 10 and 11
2. Write sector 10
3. Write sector 11
Note how request 2 and 3 *does not overlap*.

This is the bug:
- Request 1 finishes, the code processes request 2 and break.
- Request 2 finishes, the code look for a request that overlaps with request 2.
- It checks Request 3. Request 3 wants Block 11, Request 2 wanted Block 10. They do not overlap.
- Request 2 does nothing.
- Request 3 is left in the queue forever. The device hangs.

To fix this, we need to ask a different question in the code. Instead of asking
"Does a queued request overlap with the one that just finished?". We need to ask
"For every request in the queue, is it blocked by ANY write that is currently running?"

This commit fixed this bug by processing all eligible queued requests, rather than
following a block chain like before.
