### PR TITLE
ci: temporarily disable rust example

### DIFF
--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -69,14 +69,14 @@ def generate_example_test_cases(
 
 
 EXAMPLES: dict[str, _ExampleMatrixType] = {
-    "rust": {
-        "configs": ["debug", "release"],
-        "build_systems": ["make"],
-        "boards": [
-            "qemu_virt_aarch64",
-        ],
-        "tests_exclude": [],
-    },
+    # "rust": {
+    #     "configs": ["debug", "release"],
+    #     "build_systems": ["make"],
+    #     "boards": [
+    #         "qemu_virt_aarch64",
+    #     ],
+    #     "tests_exclude": [],
+    # },
     "simple": {
         "configs": ["debug", "release"],
         "build_systems": ["make"],


### PR DESCRIPTION
Because it has bitrotted and I'm having issues updating rust-sel4 to the latest main branch. Disabling it for now to not block other works while I figure it out.