### PR TITLE
ci: add x86_64 examples to HW CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,13 @@ jobs:
         with:
           submodules: true
       - name: Setup systems-ci
-        uses: au-ts/systems-ci@main
+        uses: actions/checkout@v4
+        with:
+          repository: au-ts/systems-ci
+          ref: x86
+          path: systems-ci
+      - name: Run TS CI setup script
+        run: ./systems-ci/setup.sh
 
       # GitHub seems to limit download speed of artifacts from their runners to self hosted runners.
       # So applying a workaround from https://github.com/actions/download-artifact/issues/362#issuecomment-3060841829
@@ -171,7 +177,13 @@ jobs:
           name: loader-images
           path: ci_build
       - name: Setup systems-ci
-        uses: au-ts/systems-ci@main
+        uses: actions/checkout@v4
+        with:
+          repository: au-ts/systems-ci
+          ref: x86
+          path: systems-ci
+      - name: Run TS CI setup script
+        run: ./systems-ci/setup.sh
       - name: Setup machine queue SSH key
         run: .github/setup_ssh_key.sh
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,7 @@ jobs:
           path: |
             ci_build/**/loader.img
             ci_build/**/sel4_32.elf
+            ci_build/**/sel4.elf
           if-no-files-found: error
 
   run_qemu:

--- a/ci/build.py
+++ b/ci/build.py
@@ -25,6 +25,10 @@ def build_make(args: argparse.Namespace, test_config: common.TestConfig):
     build_dir = common.example_build_path(test_config)
     example_dir = get_example_dir(test_config.example)
 
+    microkit_board = test_config.board
+    if common.is_x86_board(microkit_board):
+        microkit_board = "x86_64_generic_vtx"
+
     subprocess.run(
         [
             "make",
@@ -32,7 +36,7 @@ def build_make(args: argparse.Namespace, test_config: common.TestConfig):
             f"--directory={example_dir}",
             f"BUILD_DIR={build_dir}",
             f"MICROKIT_SDK={args.microkit_sdk}",
-            f"MICROKIT_BOARD={test_config.board}",
+            f"MICROKIT_BOARD={microkit_board}",
             f"MICROKIT_CONFIG={test_config.config}",
         ],
         check=True,

--- a/ci/common.py
+++ b/ci/common.py
@@ -46,6 +46,17 @@ def example_build_path(test_config: TestConfig):
     )
 
 
+def is_x86_board(board: str):
+    if "x86" in board:
+        return True
+    elif "skylake" in board:
+        return True
+    elif board == "vb_105":
+        return True
+    else:
+        return False
+
+
 def backend_fn(
     test_config: TestCase,
     loader_img: Path,
@@ -72,7 +83,7 @@ def backend_fn(
                 # fmt: on
                 *QEMU_COMMON_FLAGS,
             )
-        elif test_config.board == "x86_64_generic_vtx":
+        elif test_config.board == "qemu_virt_x86_64":
             return QemuBackend(
                 "qemu-system-x86_64",
                 # fmt: off
@@ -110,7 +121,7 @@ def virtio_backend_fn(test_config: TestConfig, loader_img: Path) -> HardwareBack
             capture_output=True,
         )
 
-        if "x86_64_generic" in test_config.board:
+        if "x86" in test_config.board:
             virtio_blk_device = "virtio-blk-pci,drive=hd,addr=0x3.0"
             virtio_net_device = "virtio-net-pci,netdev=netdev0,addr=0x2.0"
         else:
@@ -158,8 +169,7 @@ class TestConfig(TestCase):
     no_output_timeout_s: int
 
     def is_qemu(self):
-        # TODO: x86_64_generic assumes QEMU for the moment.
-        return self.board.startswith("qemu") or self.board.startswith("x86_64_generic")
+        return "qemu" in self.board
 
     def pretty_name(self) -> str:
         return f"{self.test} for {self.example} on {self.board} ({self.config}, built with {self.build_system})"

--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -88,7 +88,8 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "qemu_virt_aarch64",
             "odroidc4",
             "maaxboard",
-            "x86_64_generic_vtx",
+            "qemu_virt_x86_64",
+            "skylake",
         ],
         "tests_exclude": [],
     },
@@ -121,7 +122,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
         "boards": [
             "qemu_virt_aarch64",
             "maaxboard",
-            "x86_64_generic_vtx",
+            "qemu_virt_x86_64",
         ],
         "tests_exclude": [],
     },
@@ -141,14 +142,20 @@ _BoardNames = Literal[
     "maaxboard",
     "odroidc4",
     "qemu_virt_aarch64",
-    "x86_64_generic_vtx",
+    # Note that these are not valid Microkit boards but
+    # rather the testing targets, which maps to x86_64_generic_vtx
+    "qemu_virt_x86_64",
+    "vb_105",
+    "skylake",
 ]
 
 known_board_names = set(MACHINE_QUEUE_BOARDS.keys()) | {
     # simulation boards
     "qemu_virt_aarch64",
     "qemu_virt_riscv64",
-    "x86_64_generic_vtx",
+    "qemu_virt_x86_64",
+    "vb_105",
+    "skylake",
 }
 assert (
     set(_BoardNames.__args__) <= known_board_names  # type: ignore

--- a/ci/tests/arch_timers.py
+++ b/ci/tests/arch_timers.py
@@ -21,7 +21,7 @@ from ci import common, matrix
 # check that Linux is happy with our virtualisation job.
 async def test(backend: HardwareBackend, test_config: common.TestConfig):
     async with asyncio.timeout(30):
-        if "x86" in test_config.board:
+        if common.is_x86_board(test_config.board):
             # HPET detected?
             await wait_for_output(backend, b"clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff")
             # TSC-early detected?


### PR DESCRIPTION
This is not ready yet as I need to update the mq.sh command in the systems-ci Python package to also specify the kernel file alongside the image file.

Closes  https://github.com/au-ts/libvmm/issues/277