### PR TITLE
Reworked virtual PCI bus and virtIO devices

### DIFF
--- a/examples/rust/src/vmm.rs
+++ b/examples/rust/src/vmm.rs
@@ -67,10 +67,19 @@ pub struct guest_ram_region {
 }
 
 #[repr(C)]
+pub struct guest_pci_init {
+    pub ecam_gpa: usize,
+    pub ecam_size: usize,
+    pub mmio_aperature_gpa: usize,
+    pub mmio_aperature_size: usize,
+}
+
+#[repr(C)]
 pub struct arch_guest_init {
     pub num_vcpus: usize,
     pub num_guest_ram_regions: usize,
     pub guest_ram_regions: [guest_ram_region; GUEST_MAX_RAM_REGIONS],
+    pub pci_init: guest_pci_init,
 }
 
 #[protection_domain]
@@ -97,6 +106,12 @@ fn init() -> VmmHandler {
                 size: GUEST_RAM_SIZE,
                 vmm_vaddr: GUEST_RAM_VMM_VADDR as *mut _,
             }],
+            pci_init: guest_pci_init {
+                ecam_gpa: 0,
+                ecam_size: 0,
+                mmio_aperature_gpa: 0,
+                mmio_aperature_size: 0,
+            }
         });
         assert!(success);
 

--- a/examples/virtio_pci/client_vm/gic_v2_overlay.dts
+++ b/examples/virtio_pci/client_vm/gic_v2_overlay.dts
@@ -27,7 +27,7 @@
         bus-range = <0x00 0x00>;
 
         /* Register space for ECAM configuration */
-        reg = <0x0 0x10000000 0x0 0x100000>;  /* 256MB ECAM space */
+        reg = <0x0 0x10000000 0x0 0x100000>;  /* 1MB ECAM space */
 
         /* Memory and I/O ranges */
         ranges = <0x02000000 0x0 0x20100000  0x0 0x20100000  0x0 0x0ff00000>;  /* 32-bit memory */

--- a/examples/virtio_pci/client_vm/gic_v3_overlay.dts
+++ b/examples/virtio_pci/client_vm/gic_v3_overlay.dts
@@ -26,7 +26,7 @@
         bus-range = <0x00 0x00>;
 
         /* Register space for ECAM configuration */
-        reg = <0x0 0x10000000 0x0 0x100000>;  /* 256MB ECAM space */
+        reg = <0x0 0x10000000 0x0 0x100000>;  /* 1MB ECAM space */
 
         /* Memory and I/O ranges */
         ranges = <0x02000000 0x0 0x20100000  0x0 0x20100000  0x0 0x0ff00000>;  /* 32-bit memory */

--- a/examples/virtio_pci/client_vm/linux.dts
+++ b/examples/virtio_pci/client_vm/linux.dts
@@ -44,7 +44,7 @@
 	};
 
 	chosen {
-		bootargs = "console=hvc0 earlycon=hvc0 earlyprintk=serial debug loglevel=8";
+		bootargs = "console=hvc0 earlycon=hvc0 debug loglevel=8";
 		linux,initrd-start = <0x47000000>;
 		linux,initrd-end = <0x47f00000>;
 	};

--- a/examples/virtio_pci/client_vmm.c
+++ b/examples/virtio_pci/client_vmm.c
@@ -66,12 +66,18 @@ void init(void)
     assert(vmm_config_check_magic(&vmm_config));
     assert(net_config_check_magic(&net_config));
 
-    arch_guest_init_t args = {
-        .num_vcpus = 1,
-        .num_guest_ram_regions = 1,
-        .guest_ram_regions = { (struct guest_ram_region) {
-            .gpa_start = GUEST_RAM_START_GPA, .size = vmm_config.ram_size, .vmm_vaddr = (void *)vmm_config.ram } }
-    };
+    arch_guest_init_t args = { .num_vcpus = 1,
+                               .num_guest_ram_regions = 1,
+                               .guest_ram_regions = { (struct guest_ram_region) {
+                                   .gpa_start = GUEST_RAM_START_GPA,
+                                   .size = vmm_config.ram_size,
+                                   .vmm_vaddr = (void *)vmm_config.ram } },
+                               .pci_init = (struct guest_pci_init) {
+                                   .ecam_gpa = PCI_ECAM_GPA,
+                                   .ecam_size = PCI_ECAM_SIZE,
+                                   .mmio_aperature_gpa = PCI_MMIO_APERATURE_GPA,
+                                   .mmio_aperature_size = PCI_MMIO_APERATURE_SIZE,
+                               } };
     bool success = guest_init(args);
     if (!success) {
         LOG_VMM_ERR("Failed to initialise guest\n");
@@ -99,8 +105,6 @@ void init(void)
         LOG_VMM_ERR("Failed to initialise guest images\n");
         return;
     }
-
-    success = pci_bus_init(PCI_ECAM_GPA, PCI_ECAM_SIZE, PCI_MMIO_APERATURE_GPA, PCI_MMIO_APERATURE_SIZE);
 
     serial_queue_init(&serial_rx_queue, serial_config.rx.queue.vaddr, serial_config.rx.data.size,
                       serial_config.rx.data.vaddr);

--- a/examples/virtio_pci/client_vmm.c
+++ b/examples/virtio_pci/client_vmm.c
@@ -41,11 +41,11 @@ serial_queue_handle_t serial_tx_queue;
 
 static struct virtio_console_device virtio_console;
 
-/* /\* Virtio Block *\/ */
+/* Virtio Block */
 static blk_queue_handle_t blk_queue;
 static struct virtio_blk_device virtio_blk;
 
-/* /\* Virtio Net *\/ */
+/* Virtio Net */
 net_queue_handle_t net_rx_queue;
 net_queue_handle_t net_tx_queue;
 static struct virtio_net_device virtio_net;
@@ -53,6 +53,11 @@ static struct virtio_net_device virtio_net;
 /* PCI Configuration */
 uintptr_t pci_ecam;
 uintptr_t pci_memory_resource;
+
+#define PCI_ECAM_GPA 0x10000000
+#define PCI_ECAM_SIZE 0x100000
+#define PCI_MMIO_APERATURE_GPA 0x20100000
+#define PCI_MMIO_APERATURE_SIZE 0x0ff00000
 
 void init(void)
 {
@@ -95,21 +100,18 @@ void init(void)
         return;
     }
 
-    success = virtio_pci_ecam_init(0x10000000, 0x10000000, 0x100000);
-    assert(success);
-    success = virtio_pci_register_memory_resource(0x20100000, 0x20100000, 0xFF00000);
-    assert(success);
+    success = pci_bus_init(PCI_ECAM_GPA, PCI_ECAM_SIZE, PCI_MMIO_APERATURE_GPA, PCI_MMIO_APERATURE_SIZE);
 
     serial_queue_init(&serial_rx_queue, serial_config.rx.queue.vaddr, serial_config.rx.data.size,
                       serial_config.rx.data.vaddr);
     serial_queue_init(&serial_tx_queue, serial_config.tx.queue.vaddr, serial_config.tx.data.size,
                       serial_config.tx.data.vaddr);
 
-    success = virtio_pci_console_init(&virtio_console, 0, 48, &serial_rx_queue, &serial_tx_queue, serial_config.tx.id,
-                                      serial_config.rx.id);
+    success = virtio_pci_console_init(&virtio_console, 0, 0, 48, &serial_rx_queue, &serial_tx_queue,
+                                      serial_config.tx.id, serial_config.rx.id);
     assert(success);
 
-    success = virtio_pci_blk_init(&virtio_blk, 1, 49, (uintptr_t)blk_config.data.vaddr, blk_config.data.size,
+    success = virtio_pci_blk_init(&virtio_blk, 0, 1, 49, (uintptr_t)blk_config.data.vaddr, blk_config.data.size,
                                   storage_info, &blk_queue, blk_config.virt.num_buffers, blk_config.virt.id);
     assert(success);
 
@@ -120,9 +122,9 @@ void init(void)
                    net_config.tx.num_buffers);
     net_buffers_init(&net_tx_queue, 0);
 
-    success = virtio_pci_net_init(&virtio_net, 2, 50, &net_rx_queue, &net_tx_queue, (uintptr_t)net_config.rx_data.vaddr,
-                                  (uintptr_t)net_config.tx_data.vaddr, net_config.rx.id, net_config.tx.id,
-                                  net_config.mac_addr.addr);
+    success = virtio_pci_net_init(&virtio_net, 0, 2, 50, &net_rx_queue, &net_tx_queue,
+                                  (uintptr_t)net_config.rx_data.vaddr, (uintptr_t)net_config.tx_data.vaddr,
+                                  net_config.rx.id, net_config.tx.id, net_config.mac_addr.addr);
     assert(success);
 
     /* Finally start the guest */

--- a/include/libvmm/arch/aarch64/fault.h
+++ b/include/libvmm/arch/aarch64/fault.h
@@ -24,6 +24,7 @@ typedef bool (*vm_exception_handler_t)(size_t vcpu_id, size_t offset, size_t fsr
 bool fault_register_vm_exception_handler(uintptr_t base, size_t size, vm_exception_handler_t callback, void *data);
 
 /* Helpers for emulating the fault and getting fault details */
+int fault_get_width_bytes(uint64_t fsr);
 seL4_Word *decode_rt(size_t reg_idx, seL4_UserContext *regs);
 bool fault_advance_vcpu(size_t vcpu_id, seL4_UserContext *regs, size_t regs_size);
 bool fault_advance(size_t vcpu_id, seL4_UserContext *regs, uint64_t addr, uint64_t fsr, uint64_t reg_val);

--- a/include/libvmm/arch/aarch64/vgic/virq.h
+++ b/include/libvmm/arch/aarch64/vgic/virq.h
@@ -48,12 +48,11 @@ struct virq_handle {
     void *ack_data;
 };
 
-// @ivanv: revisit
 static inline void virq_ack(size_t vcpu_id, struct virq_handle *irq)
 {
-    // printf("VGIC|INFO: Acking for vIRQ %d\n", irq->virq);
-    assert(irq->ack_fn);
-    irq->ack_fn(vcpu_id, irq->virq, irq->ack_data);
+    if (irq->ack_fn) {
+        irq->ack_fn(vcpu_id, irq->virq, irq->ack_data);
+    }
 }
 
 /* TODO: A typical number of list registers supported by GIC is four, but not

--- a/include/libvmm/guest.h
+++ b/include/libvmm/guest.h
@@ -24,6 +24,13 @@
 #define GUEST_MAX_NUM_VCPUS 4UL
 #endif
 
+struct guest_pci_init {
+    uint64_t ecam_gpa;
+    uint64_t ecam_size;
+    uint64_t mmio_aperature_gpa;
+    uint64_t mmio_aperature_size;
+};
+
 #if defined(CONFIG_ARCH_X86_64)
 typedef struct guest {
     uint64_t tsc_hz;
@@ -56,6 +63,8 @@ typedef struct arch_guest_init {
 
     size_t num_guest_ram_regions;
     struct guest_ram_region guest_ram_regions[GUEST_MAX_RAM_REGIONS];
+
+    struct guest_pci_init pci_init;
 } arch_guest_init_t;
 #endif
 

--- a/include/libvmm/libvmm.h
+++ b/include/libvmm/libvmm.h
@@ -13,12 +13,12 @@
 #include <libvmm/tcb.h>
 #include <libvmm/vcpu.h>
 #include <libvmm/virq.h>
+#include <libvmm/pci.h>
 
-#include <libvmm/virtio/virtio.h>
 #include <libvmm/virtio/block.h>
 #include <libvmm/virtio/console.h>
 #include <libvmm/virtio/net.h>
-#include <libvmm/virtio/sound.h>
+// #include <libvmm/virtio/sound.h>
 
 #if defined(CONFIG_ARCH_ARM)
 #include <libvmm/arch/aarch64/linux.h>

--- a/include/libvmm/pci.h
+++ b/include/libvmm/pci.h
@@ -74,6 +74,12 @@ struct pci_capability {
 }
  * The caller must provide the cap id, payload and its length.
  */
+
+struct pci_capability_header {
+    uint8_t cap_id;
+    uint8_t next_ptr;
+} __attribute__((packed));
+
 bool pci_register_device_capability(pci_dev_handle_t pci_dev_handle, uint8_t cap_id, void *payload,
                                     uint8_t payload_size);
 

--- a/include/libvmm/pci.h
+++ b/include/libvmm/pci.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <libvmm/virq.h>
+#include <stdint.h>
+
+/* Implements a guest-side virtual PCI bus and an interface that virtual PCI devices
+ * must implements to expose itself to the guest. */
+
+// PCI Command Register
+#define PCI_COMMAND_MEMORY             0x2    /* Enable response in Memory space */
+#define PCI_COMMAND_MASTER             0x4    /* Enable bus mastering */
+
+// PCI Status Register
+#define PCI_STATUS_CAP_LIST             0x10    /* Support Capability List */
+
+// PCI Class
+#define PCI_CLASS_STORAGE_SCSI           0x0100
+#define PCI_CLASS_NETWORK_ETHERNET       0x0200
+#define PCI_CLASS_COMMUNICATION_OTHER    0x0780
+
+#define PCI_CLASS_CODE(x) ((x >> 8) & 0xFF)
+#define PCI_SUB_CLASS(x) (x & 0xFF)
+
+// PCI Capability IDs
+#define PCI_CAP_ID_VNDR     0x09    // Vendor Specific
+
+/* Initialise the guest visible virtual PCI bus. The MMIO aperature must be the same as what you told the guest
+ * via the DTS on ARM or DSDT on x86. */
+bool pci_bus_init(uint64_t ecam_gpa, uint32_t ecam_size, uint64_t mmio_aperature_gpa, uint64_t mmio_aperature_size);
+
+/* Information about the device during the initial registration process. */
+typedef struct pci_device_register_data {
+    uint16_t vendor_id;
+    uint16_t device_id;
+    uint16_t command;
+    uint16_t status;
+    uint8_t revision_id;
+    uint8_t subclass;
+    uint8_t class_code;
+    uint16_t subsystem_vendor_id;
+    uint16_t subsystem_device_id;
+
+    // @billn todo, add callbacks for reading status registers etc?
+} pci_device_register_data_t;
+
+#define INVALID_PCI_DEVICE_HANDLE -1
+typedef int pci_dev_handle_t;
+
+/* Create a virtual PCI device on the virtual PCI bus. */
+pci_dev_handle_t pci_register_device(uint8_t bus, uint8_t dev, uint8_t func, pci_device_register_data_t *device_data);
+
+/* Register the virtual PCI device IRQ with the virtual IRQ controller. */
+bool pci_register_device_irq(pci_dev_handle_t pci_dev_handle, int virq, virq_ack_fn_t ack_fn, void *ack_data);
+
+/* Inject an IRQ into the guest from the given virtual PCI device. The IRQ must be registered first. */
+bool pci_inject_device_irq(pci_dev_handle_t pci_dev_handle);
+
+/* Add a capability to a virtual PCI device capability linked list. A PCI device capability
+ * looks like this and is tightly packed:
+struct pci_capability {
+    struct pci_capability_header {
+        uint8_t cap_id;
+        uint8_t next_ptr;
+    }
+    struct payload {
+        ...
+    }
+}
+ * The caller must provide the cap id, payload and its length.
+ */
+bool pci_register_device_capability(pci_dev_handle_t pci_dev_handle, uint8_t cap_id, void *payload,
+                                    uint8_t payload_size);
+
+/* Callback for virtual PCI device's BAR access. If the guest is reading, the callee is expected to write the result to `data`.
+ * If the guest is writing, `data` contain the value. */
+typedef bool (*pci_bar_mmio_fault_handler_t)(pci_dev_handle_t pci_dev_handle, uint64_t bar_offset, bool is_read,
+                                             int access_width_bytes, uint64_t *data, void *cookie);
+
+/* Allocate a memory BAR in the virtual PCI bus' MMIO aperature for the given PCI device. */
+bool pci_register_device_mmio_bar(pci_dev_handle_t pci_dev_handle, uint8_t bar_index, uint64_t size,
+                                  pci_bar_mmio_fault_handler_t callback, void *cookie);

--- a/include/libvmm/util/util.h
+++ b/include/libvmm/util/util.h
@@ -48,6 +48,8 @@ static void assert_fail(const char *assertion, const char *file, unsigned int li
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
+#define REG_RANGE(r0, r1)   r0 ... (r1 - 1)
+
 #ifndef assert
 #ifndef CONFIG_DEBUG_BUILD
 

--- a/include/libvmm/virq.h
+++ b/include/libvmm/virq.h
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 #include <stdbool.h>
 #include <microkit.h>
 

--- a/include/libvmm/virtio/block.h
+++ b/include/libvmm/virtio/block.h
@@ -209,8 +209,8 @@ bool virtio_mmio_blk_init(struct virtio_blk_device *blk_dev, uintptr_t region_ba
                           uintptr_t data_region, size_t data_region_size, blk_storage_info_t *storage_info,
                           blk_queue_handle_t *queue_h, uint32_t queue_capacity, int server_ch);
 
-bool virtio_blk_handle_resp(struct virtio_blk_device *blk_dev);
+bool virtio_pci_blk_init(struct virtio_blk_device *blk_dev, uint16_t pci_bus, uint16_t pci_dev, size_t virq,
+                         uintptr_t data_region, size_t data_region_size, blk_storage_info_t *storage_info,
+                         blk_queue_handle_t *queue_h, uint32_t queue_capacity, int server_ch);
 
-bool virtio_pci_blk_init(struct virtio_blk_device *blk_dev, uint32_t dev_slot, size_t virq, uintptr_t data_region,
-                         size_t data_region_size, blk_storage_info_t *storage_info, blk_queue_handle_t *queue_h,
-                         uint32_t queue_capacity, int server_ch);
+bool virtio_blk_handle_resp(struct virtio_blk_device *blk_dev);

--- a/include/libvmm/virtio/console.h
+++ b/include/libvmm/virtio/console.h
@@ -102,7 +102,7 @@ bool virtio_mmio_console_init(struct virtio_console_device *console, uintptr_t r
                               size_t virq, serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch,
                               int rx_ch);
 
-bool virtio_pci_console_init(struct virtio_console_device *console, uint32_t dev_slot, size_t virq,
+bool virtio_pci_console_init(struct virtio_console_device *console, uint16_t pci_bus, uint16_t pci_dev, size_t virq,
                              serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch, int rx_ch);
 
 bool virtio_console_queue_notify(struct virtio_console_device *console);

--- a/include/libvmm/virtio/mmio.h
+++ b/include/libvmm/virtio/mmio.h
@@ -48,32 +48,6 @@
 #define VIRTIO_DEVICE_ID_CONSOLE      3
 #define VIRTIO_DEVICE_ID_SOUND        25
 
-/* handler of a virtqueue */
-// @ivanv: we can pack/bitfield this struct
-typedef struct virtio_queue_handler {
-    struct virtq virtq;
-    /* is this virtq fully initialised? */
-    bool ready;
-    /* the last index that the virtIO device processed */
-    uint16_t last_idx;
-} virtio_queue_handler_t;
-
-struct virtio_device;
-
-// functions provided by the emul (device) layer for the emul (mmio) layer
-typedef struct virtio_emul_funs {
-    void (*device_reset)(struct virtio_device *dev);
-
-    // REG_VIRTIO_MMIO_DEVICE_FEATURES related operations
-    bool (*get_device_features)(struct virtio_device *dev, uint32_t *features);
-    bool (*set_driver_features)(struct virtio_device *dev, uint32_t features);
-
-    // REG_VIRTIO_MMIO_CONFIG related operations
-    bool (*get_device_config)(struct virtio_device *dev, uint32_t offset, uint32_t *ret_val);
-    bool (*set_device_config)(struct virtio_device *dev, uint32_t offset, uint32_t val);
-    bool (*queue_notify)(struct virtio_device *dev);
-} virtio_device_funs_t;
-
 /* Emulated MMIO registers for the virtIO device */
 typedef struct virtio_device_regs {
     uint32_t DeviceID;

--- a/include/libvmm/virtio/net.h
+++ b/include/libvmm/virtio/net.h
@@ -32,7 +32,6 @@
 #include <stdint.h>
 #include <sddf/network/queue.h>
 #include <libvmm/virtio/virtio.h>
-#include <libvmm/virtio/pci.h>
 
 /* The feature bitmap for virtio net */
 #define VIRTIO_NET_F_CSUM               0   /* Host handles pkts w/ partial csum */
@@ -226,17 +225,9 @@ struct virtio_net_device {
     microkit_channel rx_ch;
 };
 
-bool virtio_mmio_net_init(struct virtio_net_device *dev,
-                          uintptr_t region_base,
-                          uintptr_t region_size,
-                          size_t virq,
-                          net_queue_handle_t *rx,
-                          net_queue_handle_t *tx,
-                          uintptr_t rx_data,
-                          uintptr_t tx_data,
-                          microkit_channel rx_ch,
-                          microkit_channel tx_ch,
-                          uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ]);
+bool virtio_mmio_net_init(struct virtio_net_device *dev, uintptr_t region_base, uintptr_t region_size, size_t virq,
+                          net_queue_handle_t *rx, net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data,
+                          microkit_channel rx_ch, microkit_channel tx_ch, uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ]);
 
 /**
  * Handles the incoming sDDF net traffic and queues the data into the virtio queues.
@@ -247,6 +238,6 @@ bool virtio_mmio_net_init(struct virtio_net_device *dev,
  */
 void virtio_net_handle_rx(struct virtio_net_device *dev);
 
-bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint32_t pci_dev_slot, size_t virq, net_queue_handle_t *rx,
-                         net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data, microkit_channel rx_ch,
-                         microkit_channel tx_ch, uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ]);
+bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint16_t pci_bus, uint16_t pci_dev, size_t virq,
+                         net_queue_handle_t *rx, net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data,
+                         microkit_channel rx_ch, microkit_channel tx_ch, uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ]);

--- a/include/libvmm/virtio/pci.h
+++ b/include/libvmm/virtio/pci.h
@@ -59,7 +59,6 @@
 #define VIRTIO_PCI_NET_DEV_ID           0x1000
 #define VIRTIO_PCI_BLK_DEV_ID           0x1001
 #define VIRTIO_PCI_CONSOLE_DEV_ID       0x1003
-#define VIRTIO_PCI_NOTIF_OFF_MULTIPLIER 0x2
 #define VIRTIO_PCI_QUEUE_NUM_MAX        0x2
 
 typedef struct virtio_pci_data {

--- a/include/libvmm/virtio/pci.h
+++ b/include/libvmm/virtio/pci.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <libvmm/pci.h>
 #include <libvmm/util/util.h>
 
 /* PCI REVISION */
@@ -27,83 +28,6 @@
 #define VIRTIO_PCI_CAP_SHARED_MEMORY_CFG 8
 /* Vendor-specific data */
 #define VIRTIO_PCI_CAP_VENDOR_CFG 9
-
-#define REG_RANGE(r0, r1)   r0 ... (r1 - 1)
-
-/* This is the default for PCI devices as it allows enough space
- * for all the PCI capabilities */
-#define VIRTIO_PCI_DEFAULT_BAR_SIZE 0x10000
-
-#define PCI_CFG_OFFSET_COMMAND       0x04
-#define PCI_CFG_OFFSET_STATUS        0x06
-#define PCI_CFG_OFFSET_BAR1          0x10
-#define PCI_CFG_OFFSET_BAR2          0x14
-#define PCI_CFG_OFFSET_BAR3          0x18
-#define PCI_CFG_OFFSET_BAR4          0x1C
-#define PCI_CFG_OFFSET_BAR5          0x20
-#define PCI_CFG_OFFSET_BAR6          0x24
-#define PCI_CFG_OFFSET_CARDBUS       0x28
-
-// PCI Capability IDs
-#define PCI_CAP_ID_PM       0x01    // Power Management
-#define PCI_CAP_ID_AGP      0x02    // AGP
-#define PCI_CAP_ID_VPD      0x03    // Vital Product Data
-#define PCI_CAP_ID_SLOTID   0x04    // Slot Identification
-#define PCI_CAP_ID_MSI      0x05    // Message Signaled Interrupts
-#define PCI_CAP_ID_CHSWP    0x06    // CompactPCI HotSwap
-#define PCI_CAP_ID_PCIX     0x07    // PCI-X
-#define PCI_CAP_ID_HT       0x08    // HyperTransport
-#define PCI_CAP_ID_VNDR     0x09    // Vendor Specific
-#define PCI_CAP_ID_DBG      0x0A    // Debug port
-#define PCI_CAP_ID_CCRC     0x0B    // CompactPCI Central Resource Control
-#define PCI_CAP_ID_SHPC     0x0C    // PCI Standard Hot-Plug Controller
-#define PCI_CAP_ID_SSVID    0x0D    // Bridge subsystem vendor/device ID
-#define PCI_CAP_ID_AGP3     0x0E    // AGP Target PCI-PCI bridge
-#define PCI_CAP_ID_SECDEV   0x0F    // Secure Device
-#define PCI_CAP_ID_EXP      0x10    // PCI Express
-#define PCI_CAP_ID_MSIX     0x11    // MSI-X
-#define PCI_CAP_ID_SATA     0x12    // SATA Data/Index Conf.
-#define PCI_CAP_ID_AF       0x13    // PCI Advanced Features
-#define PCI_CAP_ID_EA       0x14    // PCI Enhanced Allocation
-
-// PCI Class
-#define PCI_CLASS_STORAGE_SCSI           0x0100
-#define PCI_CLASS_NETWORK_ETHERNET       0x0200
-#define PCI_CLASS_COMMUNICATION_OTHER    0x0780
-
-#define PCI_CLASS_CODE(x) ((x >> 8) & 0xFF)
-#define PCI_SUB_CLASS(x) (x & 0xFF)
-
-// PCI Status Register
-#define PCI_STATUS_IMM_READY            0x01    /* Immediate Readiness */
-#define PCI_STATUS_INTERRUPT            0x08    /* Interrupt status */
-#define PCI_STATUS_CAP_LIST             0x10    /* Support Capability List */
-#define PCI_STATUS_66MHZ                0x20    /* Support 66 MHz PCI 2.1 bus */
-#define PCI_STATUS_UDF                  0x40    /* Support User Definable Features [obsolete] */
-#define PCI_STATUS_FAST_BACK            0x80    /* Accept fast-back to back */
-#define PCI_STATUS_PARITY               0x100   /* Detected parity error */
-#define PCI_STATUS_DEVSEL_MASK          0x600   /* DEVSEL timing */
-#define PCI_STATUS_DEVSEL_FAST          0x000
-#define PCI_STATUS_DEVSEL_MEDIUM        0x200
-#define PCI_STATUS_DEVSEL_SLOW          0x400
-#define PCI_STATUS_SIG_TARGET_ABORT     0x800   /* Set on target abort */
-#define PCI_STATUS_REC_TARGET_ABORT     0x1000  /* Master ack of " */
-#define PCI_STATUS_REC_MASTER_ABORT     0x2000  /* Set on master abort */
-#define PCI_STATUS_SIG_SYSTEM_ERROR     0x4000  /* Set when we drive SERR */
-#define PCI_STATUS_DETECTED_PARITY      0x8000  /* Set on parity error */
-
-// PCI Command Register
-#define PCI_COMMAND_IO                 0x1    /* Enable response in I/O space */
-#define PCI_COMMAND_MEMORY             0x2    /* Enable response in Memory space */
-#define PCI_COMMAND_MASTER             0x4    /* Enable bus mastering */
-#define PCI_COMMAND_SPECIAL            0x8    /* Enable response to special cycles */
-#define PCI_COMMAND_INVALIDATE         0x10   /* Use memory write and invalidate */
-#define PCI_COMMAND_VGA_PALETTE        0x20   /* Enable palette snooping */
-#define PCI_COMMAND_PARITY             0x40   /* Enable parity checking */
-#define PCI_COMMAND_WAIT               0x80   /* Enable address/data stepping */
-#define PCI_COMMAND_SERR               0x100  /* Enable SERR */
-#define PCI_COMMAND_FAST_BACK          0x200  /* Enable back-to-back writes */
-#define PCI_COMMAND_INTX_DISABLE       0x400  /* INTx Emulation Disable */
 
 // PCI Common configuration
 #define VIRTIO_PCI_COMMON_DEV_FEATURE_SEL       0x0
@@ -131,13 +55,6 @@
 #define VIRTIO_PCI_COMMON_ADM_Q_NUM             0x3e
 #define VIRTIO_PCI_COMMON_END                   0x40
 
-#define VIRTIO_PCI_BUS_NUM                      0x1
-#define VIRTIO_PCI_DEVS_PER_BUS                 (1 << 5)
-#define VIRTIO_PCI_FUNCS_PER_DEV                1         // (1 << 3)
-#define VIRTIO_PCI_DEV_FUNC_MAX                 (VIRTIO_PCI_BUS_NUM * VIRTIO_PCI_DEVS_PER_BUS * VIRTIO_PCI_FUNCS_PER_DEV)
-#define VIRTIO_PCI_FUNC_CFG_SPACE_SIZE          0x100
-#define VIRTIO_PCI_MAX_MEM_BARS                 0x10
-
 #define VIRTIO_PCI_VENDOR_ID            0x1AF4
 #define VIRTIO_PCI_NET_DEV_ID           0x1000
 #define VIRTIO_PCI_BLK_DEV_ID           0x1001
@@ -145,135 +62,35 @@
 #define VIRTIO_PCI_NOTIF_OFF_MULTIPLIER 0x2
 #define VIRTIO_PCI_QUEUE_NUM_MAX        0x2
 
-// Type 0 headers for endpoints
-struct pci_config_space {
-    // Device Identification
-    uint16_t vendor_id;           // 0x00: Vendor ID
-    uint16_t device_id;           // 0x02: Device ID
-    uint16_t command;             // 0x04: Command Register
-    uint16_t status;              // 0x06: Status Register
-    uint8_t revision_id;         // 0x08: Revision ID
-    uint8_t prog_if;             // 0x09: Programming Interface
-    uint8_t subclass;            // 0x0A: Sub Class Code
-    uint8_t class_code;          // 0x0B: Base Class Code
-    uint8_t cache_line_size;     // 0x0C: Cache Line Size
-    uint8_t latency_timer;       // 0x0D: Latency Timer
-    uint8_t header_type;         // 0x0E: Header Type
-    uint8_t bist;                // 0x0F: Built-in Self Test
-
-    // Base Address Registers (BARs)
-    uint32_t bar[6];              // 0x10-0x27: Base Address Registers
-
-    // Subsystem Information
-    uint32_t cardbus_cis_ptr;     // 0x28: CardBus CIS Pointer
-    uint16_t subsystem_vendor_id; // 0x2C: Subsystem Vendor ID
-    uint16_t subsystem_device_id; // 0x2E: Subsystem Device ID
-    uint32_t expansion_rom_addr;  // 0x30: Expansion ROM Base Address
-
-    // Capabilities and Interrupts
-    uint8_t cap_ptr;             // 0x34: Capabilities Pointer
-    uint8_t reserved1[3];        // 0x35-0x37: Reserved
-    uint32_t reserved2;           // 0x38-0x3B: Reserved
-    uint8_t interrupt_line;      // 0x3C: Interrupt Line
-    uint8_t interrupt_pin;       // 0x3D: Interrupt Pin
-    uint8_t min_gnt;             // 0x3E: Min_Gnt
-    uint8_t max_lat;             // 0x3F: Max_Lat
-
-    // Capability list
-    uint8_t cap_data[192];
-};
-
-struct pci_memory_resource {
-    uintptr_t vm_addr;
-    uintptr_t vmm_addr;
-    uint32_t size;
-    uint32_t free_offset;
-};
-
-struct virtio_pci_ecam {
-    uintptr_t vm_base;
-    uintptr_t vmm_base;
-    uint32_t size;
-};
-
 typedef struct virtio_pci_data {
     uint32_t device_id;
     uint32_t vendor_id;
     uint32_t device_class;
-    // Index to get dev's data structure:
-    //   dev_table_idx = ((bus_id * #dev_per_bus) + dev_slot) * #funcs_per_dev + func_id
-    uint32_t dev_table_idx;
-    // Indices to the bar in global_memory_bars
-    uint32_t mem_bar_ids[6];
-    // Leave this so multiple memory regions can be supported in the future
-    struct pci_memory_resource *mem_resources;
+    pci_dev_handle_t pci_handle;
 } virtio_pci_data_t;
-
-typedef struct virtio_device virtio_device_t;
-
-struct pci_memory_bar {
-    uintptr_t vaddr;
-    uintptr_t size;
-    uintptr_t free_offset;
-    virtio_device_t *dev;
-    uint8_t idx;                  // bar index in the device
-};
-
-struct pci_bar_memory_bits {
-    uint32_t memory_type : 1;    // Bit 0: 0 = Memory space
-    uint32_t mem_type : 2;    // Bits 2-1: Memory type
-    uint32_t prefetchable : 1;    // Bit 3: Prefetchable
-    uint32_t base_address : 28;   // Bits 31-4: Base address
-} __attribute__((packed));
-
-struct pci_bar_io_bits {
-    uint32_t io_type : 1;    // Bit 0: 1 = I/O space
-    uint32_t reserved : 1;    // Bit 1: Reserved (must be 0)
-    uint32_t base_address : 30;   // Bits 31-2: I/O base address
-} __attribute__((packed));
 
 // Vendor-specific Capability (ID 0x09)
 struct virtio_pci_cap {
-    uint8_t cap_id;               /* Generic PCI field: PCI_CAP_ID_VNDR */
-    uint8_t next_ptr;             /* Generic PCI field: next ptr. */
-    uint8_t cap_len;              /* Generic PCI field: capability length */
+    uint8_t cap_len;              /* capability length. */
     uint8_t cfg_type;             /* Identifies the structure. */
     uint8_t bar;                  /* Where to find it. */
     uint8_t id;                   /* Multiple capabilities of the same type */
     uint8_t padding[2];           /* Pad to full dword. */
     uint32_t offset;              /* Offset within bar. */
     uint32_t length;              /* Length of the structure, in bytes. */
-};
-
-// MSI-X Capability (ID 0x11)
-struct msix_capability {
-    uint8_t cap_id;              // 0x11 (MSI-X capability ID)
-    uint8_t next_ptr;            // Pointer to next capability
-    uint16_t message_control;     // Control register
-    uint32_t table_offset_bir;    // Table offset and BAR indicator
-    uint32_t pba_offset_bir;      // Pending bit array offset and BAR
-};
-
-/* PCI vendor config capability */
-struct virtio_pci_vendor_cap {
-    uint8_t cap_vndr;             /* Generic PCI field: PCI_CAP_ID_VNDR */
-    uint8_t cap_next;             /* Generic PCI field: next ptr. */
-    uint8_t cap_len;              /* Generic PCI field: capability length */
-    uint8_t cfg_type;             /* Identifies the structure. */
-    uint16_t vendor_id;           /* Identifies the vendor-specific format. */
-};
+} __attribute__((packed));
 
 /* PCI Notify capability */
 struct virtio_pci_notify_cap {
     struct virtio_pci_cap cap;
     uint32_t notify_off_multiplier; /* Multiplier for queue_notify_off. */
-};
+} __attribute__((packed));
 
 /* PCI CFG capability: provides indirect access */
 struct virtio_pci_cfg_cap {
     struct virtio_pci_cap cap;
     uint32_t pci_cfg_data;
-};
+} __attribute__((packed));
 
 struct virtio_pci_common_cfg {
     /* About the whole device. */
@@ -303,18 +120,12 @@ struct virtio_pci_common_cfg {
     uint16_t admin_queue_num;           /* read-only for driver */
 };
 
-typedef bool (*virtio_pci_cfg_exception_handler_t)(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                                   seL4_UserContext *regs);
+typedef struct virtio_device virtio_device_t;
 
-bool virtio_pci_ecam_init(uintptr_t ecam_base_vm, uintptr_t ecam_base_vmm, uint32_t ecam_size);
 /*
  * Registers a new virtIO device at a given guest-physical region.
  *
  * Assumes the virtio_device_t *dev struct passed has been populated
  * and virtual IRQ associated with the device has been registered.
  */
-bool virtio_pci_register_device(virtio_device_t *dev, int virq);
-
-bool virtio_pci_alloc_dev_cfg_space(virtio_device_t *dev, uint8_t dev_slot);
-bool virtio_pci_register_memory_resource(uintptr_t vm_addr, uintptr_t vmm_addr, uint32_t size);
-bool virtio_pci_alloc_memory_bar(virtio_device_t *dev, uint8_t bar_id, uint32_t size);
+bool virtio_pci_register_device(virtio_device_t *dev, uint16_t pci_bus, uint16_t pci_dev, int virq);

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <libvmm/virtio/mmio.h>
 #include <libvmm/virtio/pci.h>
+#include <libvmm/virtio/virtq.h>
 
 /*
  * Default maximum capacity of each virtIO queue. Currently applies to all
@@ -32,6 +34,32 @@ typedef union virtio_transport_data {
     virtio_pci_data_t pci;
     virtio_mmio_data_t mmio;
 } virtio_transport_data_t;
+
+/* handler of a virtqueue */
+// @ivanv: we can pack/bitfield this struct
+typedef struct virtio_queue_handler {
+    struct virtq virtq;
+    /* is this virtq fully initialised? */
+    bool ready;
+    /* the last index that the virtIO device processed */
+    uint16_t last_idx;
+} virtio_queue_handler_t;
+
+typedef struct virtio_device virtio_device_t;
+
+/* functions provided by the virtio device emulation for the transport layer (MMIO/PCI) */
+typedef struct virtio_emul_funs {
+    void (*device_reset)(virtio_device_t *dev);
+
+    // REG_VIRTIO_MMIO_DEVICE_FEATURES related operations
+    bool (*get_device_features)(virtio_device_t *dev, uint32_t *features);
+    bool (*set_driver_features)(virtio_device_t *dev, uint32_t features);
+
+    // REG_VIRTIO_MMIO_CONFIG related operations
+    bool (*get_device_config)(virtio_device_t *dev, uint32_t offset, uint32_t *ret_val);
+    bool (*set_device_config)(virtio_device_t *dev, uint32_t offset, uint32_t val);
+    bool (*queue_notify)(virtio_device_t *dev);
+} virtio_device_funs_t;
 
 /* Everything needed at runtime for a virtIO device to function. */
 typedef struct virtio_device {

--- a/src/arch/aarch64/fault.c
+++ b/src/arch/aarch64/fault.c
@@ -70,10 +70,22 @@ enum fault_width {
     WIDTH_DOUBLEWORD = 0b11,
 };
 
-static enum fault_width fault_get_width(uint64_t fsr)
+int fault_get_width_bytes(uint64_t fsr)
 {
     if (HSR_IS_SYNDROME_VALID(fsr) && HSR_SYNDROME_WIDTH(fsr) <= WIDTH_DOUBLEWORD) {
-        return (enum fault_width)(HSR_SYNDROME_WIDTH(fsr));
+        switch ((enum fault_width)(HSR_SYNDROME_WIDTH(fsr))) {
+        case WIDTH_BYTE:
+            return 1;
+        case WIDTH_HALFWORD:
+            return 2;
+        case WIDTH_WORD:
+            return 4;
+        case WIDTH_DOUBLEWORD:
+            return 8;
+        default:
+                /* unreachable */
+            assert(false);
+        }
     } else {
         LOG_VMM_ERR("Received invalid FSR: 0x%lx\n", fsr);
         // @ivanv: reviist
@@ -87,24 +99,23 @@ static enum fault_width fault_get_width(uint64_t fsr)
 uint64_t fault_get_data_mask(uint64_t addr, uint64_t fsr)
 {
     uint64_t mask = 0;
-    switch (fault_get_width(fsr)) {
-    case WIDTH_BYTE:
+    switch (fault_get_width_bytes(fsr)) {
+    case 1:
         mask = 0x000000ff;
         assert(!(addr & 0x0));
         break;
-    case WIDTH_HALFWORD:
+    case 2:
         mask = 0x0000ffff;
         assert(!(addr & 0x1));
         break;
-    case WIDTH_WORD:
+    case 4:
         mask = 0xffffffff;
         assert(!(addr & 0x3));
         break;
-    case WIDTH_DOUBLEWORD:
+    case 8:
         mask = ~mask;
         break;
     default:
-        LOG_VMM_ERR("unknown width: 0x%x, from FSR: 0x%lx, addr: 0x%lx\n", fault_get_width(fsr), fsr, addr);
         assert(0);
         return 0;
     }
@@ -380,8 +391,8 @@ bool fault_register_vm_exception_handler(uintptr_t base, size_t size, vm_excepti
     for (int i = 0; i < vm_exception_handler_index; i++) {
         struct vm_exception_handler *curr = &registered_vm_exception_handlers[i];
         if (!(base >= curr->end || base + size <= curr->base)) {
-            LOG_VMM_ERR("VM exception handler [0x%lx..0x%lx), overlaps with another handler [0x%lx..0x%lx)\n",
-                        base, base + size, curr->base, curr->end);
+            LOG_VMM_ERR("VM exception handler [0x%lx..0x%lx), overlaps with another handler [0x%lx..0x%lx)\n", base,
+                        base + size, curr->base, curr->end);
             return false;
         }
     }
@@ -407,8 +418,9 @@ static bool fault_handle_registered_vm_exceptions(size_t vcpu_id, uintptr_t addr
         if (addr >= base && addr < end) {
             bool success = callback(vcpu_id, addr - base, fsr, regs, data);
             if (!success) {
-                LOG_VMM_ERR("registered virtual memory exception handler for region [0x%lx..0x%lx) at address 0x%lx failed\n", base,
-                            end, addr);
+                LOG_VMM_ERR(
+                    "registered virtual memory exception handler for region [0x%lx..0x%lx) at address 0x%lx failed\n",
+                    base, end, addr);
             }
 
             return success;

--- a/src/arch/aarch64/guest.c
+++ b/src/arch/aarch64/guest.c
@@ -57,7 +57,15 @@ bool guest_init(arch_guest_init_t init_args)
     /* Initialise the virtual GIC driver */
     bool success = virq_controller_init();
     if (!success) {
-        LOG_VMM_ERR("Failed to initialise emulated interrupt controller\n");
+        LOG_VMM_ERR("Failed to initialise virtual interrupt controller\n");
+    }
+
+    if (init_args.pci_init.ecam_size && init_args.pci_init.mmio_aperature_size) {
+        success = pci_bus_init(init_args.pci_init.ecam_gpa, init_args.pci_init.ecam_size,
+                               init_args.pci_init.mmio_aperature_gpa, init_args.pci_init.mmio_aperature_size);
+        if (!success) {
+            LOG_VMM_ERR("Failed to initialise virtual PCII bus\n");
+        }
     }
 
     return success;

--- a/src/pci.c
+++ b/src/pci.c
@@ -170,6 +170,14 @@ static inline bool pci_device_exist_check(pci_dev_handle_t pci_dev_handle)
     return true;
 }
 
+static inline bool pci_bus_initialised_check(void)
+{
+    if (!pci_bus.initialised) {
+        LOG_PCI_ERR("PCI bus not initialised!\n");
+    }
+    return pci_bus.initialised;
+}
+
 static bool pci_bar_fault_handler(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *cookie)
 {
     pci_dev_handle_t handle = (pci_dev_handle_t)(((uint64_t)(cookie)) << 3) >> 3;
@@ -315,6 +323,10 @@ static bool pci_ecam_fault_handle(size_t vcpu_id, size_t ecam_offset, size_t fsr
 
 pci_dev_handle_t pci_register_device(uint8_t bus, uint8_t dev, uint8_t func, pci_device_register_data_t *device_data)
 {
+    if (!pci_bus_initialised_check()) {
+        return false;
+    }
+
     if (bus >= PCI_NUM_BUS) {
         LOG_PCI_ERR("PCI bus %u is out of bound\n", bus);
         return INVALID_PCI_DEVICE_HANDLE;
@@ -368,6 +380,10 @@ pci_dev_handle_t pci_register_device(uint8_t bus, uint8_t dev, uint8_t func, pci
 
 bool pci_register_device_irq(pci_dev_handle_t pci_dev_handle, int virq, virq_ack_fn_t ack_fn, void *ack_data)
 {
+    if (!pci_bus_initialised_check()) {
+        return false;
+    }
+
     if (!pci_device_exist_check(pci_dev_handle)) {
         return false;
     }
@@ -395,6 +411,10 @@ bool pci_register_device_irq(pci_dev_handle_t pci_dev_handle, int virq, virq_ack
 bool pci_register_device_capability(pci_dev_handle_t pci_dev_handle, uint8_t cap_id, void *payload,
                                     uint8_t payload_size)
 {
+    if (!pci_bus_initialised_check()) {
+        return false;
+    }
+
     if (!pci_device_exist_check(pci_dev_handle)) {
         return false;
     }
@@ -439,6 +459,10 @@ bool pci_register_device_capability(pci_dev_handle_t pci_dev_handle, uint8_t cap
 bool pci_register_device_mmio_bar(pci_dev_handle_t pci_dev_handle, uint8_t bar_index, uint64_t size,
                                   pci_bar_mmio_fault_handler_t callback, void *cookie)
 {
+    if (!pci_bus_initialised_check()) {
+        return false;
+    }
+
     if (!pci_device_exist_check(pci_dev_handle)) {
         return false;
     }

--- a/src/pci.c
+++ b/src/pci.c
@@ -45,11 +45,6 @@
 #define PCI_CFG_OFFSET_BAR5          0x20
 #define PCI_CFG_OFFSET_BAR6          0x24
 
-struct pci_capability_header {
-    uint8_t cap_id;
-    uint8_t next_ptr;
-} __attribute__((packed));
-
 struct pci_bar_memory_bits {
     uint32_t memory_type : 1;    // Bit 0: 0 = Memory space
     uint32_t mem_type : 2;    // Bits 2-1: Memory type

--- a/src/pci.c
+++ b/src/pci.c
@@ -1,0 +1,507 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <microkit.h>
+#include <libvmm/libvmm.h>
+
+#define LOG_PCI_INFO(...) do{ printf("%s|%s INFO: ", microkit_name, __func__); printf(__VA_ARGS__); }while(0)
+#define LOG_PCI_ERR(...) do{ printf("%s|%s ERROR: ", microkit_name, __func__); printf(__VA_ARGS__); }while(0)
+
+/* Document referenced: https://wiki.osdev.org/PCI */
+
+#define PCI_INVALID_VENDOR_ID 0xffff
+
+/* Should be plenty for now. */
+#define PCI_NUM_BUS 1
+/* These are based on the x86 Configuration Space Access Mechanism #1.
+ * Where there are 5 bits for the device number and 3 bits for the function number. */
+#define PCI_DEV_PER_BUS 32
+#define PCI_FUNC_PER_DEV 8
+
+#define PCI_NUM_CONFIG_SPACES (PCI_NUM_BUS * PCI_DEV_PER_BUS * PCI_FUNC_PER_DEV)
+/* Under the modern ECAM regime each configuration space is 4K large. */
+#define PCI_CONFIG_SPACE_SIZE 0x1000
+#define PCI_EXPECTED_ECAM_SIZE (PCI_NUM_CONFIG_SPACES * PCI_CONFIG_SPACE_SIZE)
+
+/* This is hard define in the PCI config space */
+#define PCI_NUM_BARS_PER_CONFIG_SPACE 6
+
+/* PCI Status Register */
+#define PCI_STATUS_IMM_READY            0x01    /* Immediate Readiness */
+#define PCI_STATUS_INTERRUPT            0x08    /* Interrupt status */
+#define PCI_STATUS_CAP_LIST             0x10    /* Support Capability List */
+
+#define PCI_CFG_OFFSET_COMMAND       0x04
+#define PCI_CFG_OFFSET_STATUS        0x06
+#define PCI_CFG_OFFSET_BAR1          0x10
+#define PCI_CFG_OFFSET_BAR2          0x14
+#define PCI_CFG_OFFSET_BAR3          0x18
+#define PCI_CFG_OFFSET_BAR4          0x1C
+#define PCI_CFG_OFFSET_BAR5          0x20
+#define PCI_CFG_OFFSET_BAR6          0x24
+
+struct pci_capability_header {
+    uint8_t cap_id;
+    uint8_t next_ptr;
+} __attribute__((packed));
+
+struct pci_bar_memory_bits {
+    uint32_t memory_type : 1;    // Bit 0: 0 = Memory space
+    uint32_t mem_type : 2;    // Bits 2-1: Memory type
+    uint32_t prefetchable : 1;    // Bit 3: Prefetchable
+    uint32_t base_address : 28;   // Bits 31-4: Base address
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct pci_bar_memory_bits) == 4, "struct pci_bar_memory_bits size != 32 bits");
+
+// Type 0 headers for endpoints
+struct pci_config_space {
+    // Device Identification
+    uint16_t vendor_id;           // 0x00: Vendor ID
+    uint16_t device_id;           // 0x02: Device ID
+    uint16_t command;             // 0x04: Command Register
+    uint16_t status;              // 0x06: Status Register
+    uint8_t revision_id;         // 0x08: Revision ID
+    uint8_t prog_if;             // 0x09: Programming Interface
+    uint8_t subclass;            // 0x0A: Sub Class Code
+    uint8_t class_code;          // 0x0B: Base Class Code
+    uint8_t cache_line_size;     // 0x0C: Cache Line Size
+    uint8_t latency_timer;       // 0x0D: Latency Timer
+    uint8_t header_type;         // 0x0E: Header Type
+    uint8_t bist;                // 0x0F: Built-in Self Test
+
+    // Base Address Registers (BARs)
+    struct pci_bar_memory_bits bars[PCI_NUM_BARS_PER_CONFIG_SPACE]; // 0x10-0x27: Base Address Registers
+
+    // Subsystem Information
+    uint32_t cardbus_cis_ptr;     // 0x28: CardBus CIS Pointer
+    uint16_t subsystem_vendor_id; // 0x2C: Subsystem Vendor ID
+    uint16_t subsystem_device_id; // 0x2E: Subsystem Device ID
+    uint32_t expansion_rom_addr;  // 0x30: Expansion ROM Base Address
+
+    // Capabilities and Interrupts
+    uint8_t cap_ptr;             // 0x34: Capabilities Pointer
+    uint8_t reserved1[3];        // 0x35-0x37: Reserved
+    uint32_t reserved2;           // 0x38-0x3B: Reserved
+    uint8_t interrupt_line;      // 0x3C: Interrupt Line
+    uint8_t interrupt_pin;       // 0x3D: Interrupt Pin
+    uint8_t min_gnt;             // 0x3E: Min_Gnt
+    uint8_t max_lat;             // 0x3F: Max_Lat
+
+    // Capability list
+    uint8_t cap_data[192];       // 0x40
+} __attribute((packed));
+
+_Static_assert(sizeof(struct pci_config_space) == 256, "PCI Config Space size");
+
+struct pci_device_bar {
+    bool valid;
+    uint64_t gpa;
+    uint64_t size;
+    pci_bar_mmio_fault_handler_t callback;
+    void *cookie;
+};
+
+struct pci_device {
+    uint32_t sticky_cmd_bits;
+    struct pci_config_space config_space;
+    bool virq_registered;
+    /* NOTE that 64 bit BARs consume 2 slots! */
+    struct pci_device_bar bars[PCI_NUM_BARS_PER_CONFIG_SPACE];
+    /* A simple bump allocator for the capabilities linked list. */
+    uint8_t next_available_cap_ptr;
+};
+
+struct pci_ecam {
+    uint64_t gpa;
+    uint32_t size;
+
+    /* Storage for the PCI devices' virtual configuration spaces and associated metadata.
+     * Note that this is a flattened array.*/
+    struct pci_device devices[PCI_NUM_CONFIG_SPACES];
+};
+
+struct pci_mmio_aperature {
+    uint64_t gpa;
+    uint64_t size;
+};
+
+struct pci_bus {
+    bool initialised;
+    struct pci_ecam ecam;
+    struct pci_mmio_aperature mmio_aperature;
+};
+
+static struct pci_bus pci_bus;
+
+// Translate PCI Geographic Address, represented as Bus:Device.Function, to an index to `config_spaces`.
+static uint32_t pci_geo_addr_to_internal_index(uint8_t bus, uint8_t dev, uint8_t func)
+{
+    return (bus * PCI_DEV_PER_BUS) + (dev * PCI_FUNC_PER_DEV) + func;
+}
+
+static struct pci_device *pci_get_device(pci_dev_handle_t pci_dev_handle)
+{
+    return &pci_bus.ecam.devices[pci_dev_handle];
+}
+
+static inline bool pci_device_exist_check(pci_dev_handle_t pci_dev_handle)
+{
+    if (pci_dev_handle < 0) {
+        LOG_PCI_ERR("PCI handle %d is invalid\n", pci_dev_handle);
+        return false;
+    }
+
+    if (pci_dev_handle >= PCI_NUM_CONFIG_SPACES) {
+        LOG_PCI_ERR("PCI handle %d is out of bound.\n", pci_dev_handle);
+        return false;
+    }
+
+    struct pci_config_space *config_space = &pci_get_device(pci_dev_handle)->config_space;
+    if (config_space->vendor_id == PCI_INVALID_VENDOR_ID) {
+        LOG_PCI_ERR("PCI handle %d is invalid.\n", pci_dev_handle);
+        return false;
+    }
+    return true;
+}
+
+static bool pci_bar_fault_handler(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *cookie)
+{
+    pci_dev_handle_t handle = (pci_dev_handle_t)(((uint64_t)(cookie)) << 3) >> 3;
+    if (!pci_device_exist_check(handle)) {
+        return false;
+    }
+
+    struct pci_device *pci_device = pci_get_device(handle);
+    uint8_t bar_idx = ((uint64_t)cookie) >> 61;
+    assert(bar_idx < PCI_NUM_BARS_PER_CONFIG_SPACE);
+
+    seL4_Word data = 0;
+
+#if defined(CONFIG_ARCH_ARM)
+    bool is_read = fault_is_read(fsr);
+    int width_bytes = fault_get_width_bytes(fsr);
+    if (!is_read) {
+        data = fault_get_data(regs, fsr);
+    }
+#else
+    bool is_read = false; //@billn fix
+    int width_bytes = 0;
+#endif
+
+    bool success = pci_device->bars[bar_idx].callback(handle, offset, is_read, width_bytes, &data,
+                                                      pci_device->bars[bar_idx].cookie);
+
+#if defined(CONFIG_ARCH_ARM)
+    if (success && is_read) {
+        fault_emulate_write(regs, offset, fsr, data);
+    }
+#endif
+
+    return success;
+}
+
+static bool pci_ecam_fault_handle(size_t vcpu_id, size_t ecam_offset, size_t fsr, seL4_UserContext *regs, void *cookie)
+{
+    uint16_t bus = ecam_offset >> 20;
+    uint16_t dev = (ecam_offset >> 15) & 0x1F;
+    uint16_t func = (ecam_offset >> 12) & 0x7;
+    uint16_t offset = ecam_offset & 0xFF; /* The mask needs to be updated if we support the extended config space. */
+
+    if (bus >= PCI_NUM_BUS) {
+        return false;
+    }
+    if (dev >= PCI_DEV_PER_BUS) {
+        return false;
+    }
+    if (func >= PCI_FUNC_PER_DEV) {
+        return false;
+    }
+
+    pci_dev_handle_t handle = pci_geo_addr_to_internal_index(bus, dev, func);
+
+    /* We don't need to check if the device is registered, because in that case we already initialised
+     * vendor ID to PCI_INVALID_VENDOR_ID. */
+    struct pci_device *pci_device = pci_get_device(handle);
+    struct pci_config_space *config_space = &pci_device->config_space;
+
+#if defined(CONFIG_ARCH_ARM)
+    bool is_read = fault_is_read(fsr);
+#else
+    bool is_read = false; // @Billn fix
+#endif
+
+    if (is_read) {
+        uint32_t data = 0;
+        uint32_t *reg = (uint32_t *)config_space;
+        data = reg[offset / 4];
+
+#if defined(CONFIG_ARCH_ARM)
+        fault_emulate_write(regs, offset, fsr, data);
+#else
+        (void)data;
+        (void)reg;
+#endif
+    } else {
+#if defined(CONFIG_ARCH_ARM)
+        uint32_t data = fault_get_data(regs, fsr);
+#else
+        uint32_t data = 0;
+#endif
+
+        switch (offset) {
+        case REG_RANGE(PCI_CFG_OFFSET_COMMAND, PCI_CFG_OFFSET_STATUS): {
+            config_space->command = data & pci_device->sticky_cmd_bits;
+            break;
+        }
+        case REG_RANGE(PCI_CFG_OFFSET_STATUS, PCI_CFG_OFFSET_BAR1): {
+            config_space->status = data;
+            break;
+        }
+        case REG_RANGE(PCI_CFG_OFFSET_BAR1, PCI_CFG_OFFSET_BAR2): {
+            uint8_t dev_bar_id = (offset - PCI_CFG_OFFSET_BAR1) / 0x4;
+            assert(dev_bar_id < PCI_NUM_BARS_PER_CONFIG_SPACE);
+
+            // @billn handle 64-bit BARs
+            // Memory negotiation process:
+            //     1. The driver writes all 1s to the BAR register.
+            //     2. The device writes the size mask ~(size - 1) to the BAR register.
+            //     3. The driver writes the original value (all 0s in our code) back
+            //         to the BAR register. (no action from the device)
+            //     4. The driver allocates memory from the memory resources, and writes
+            //         the allocated address to the BAR register.
+            //     5. The device parse the memory address and bookkeep it.
+            if (pci_device->bars[dev_bar_id].size) {
+                if (data == 0xFFFFFFFF) {
+                    struct pci_bar_memory_bits *bar = &config_space->bars[dev_bar_id];
+                    bar->base_address = (~(pci_device->bars[dev_bar_id].size - 1)) >> 4;
+                } else if (data != 0x0) {
+                    struct pci_bar_memory_bits *bar = &config_space->bars[dev_bar_id];
+                    uint32_t guest_allocated_addr = data & 0xFFFFFFF0;   // Ignore control bits
+                    bar->base_address = guest_allocated_addr >> 4;       // 16-byte aligned
+                    pci_device->bars[dev_bar_id].gpa = guest_allocated_addr;
+
+                    /* We just need 3 bits to represent the BAR index (0-5), so we can stuff it
+                     * to the top bits of the handle. */
+                    uint64_t cookie = handle;
+                    /* Make sure the top 3 bits aren't used. */
+                    assert((cookie & (BIT(63) | BIT(62) | BIT(61))) == 0);
+                    uint64_t bar_idx_mask = (uint64_t)dev_bar_id << 61;
+                    cookie |= bar_idx_mask;
+
+#if defined(CONFIG_ARCH_ARM)
+                    if (!fault_register_vm_exception_handler(guest_allocated_addr, pci_device->bars[dev_bar_id].size,
+                                                             &pci_bar_fault_handler, (void *)cookie)) {
+                        LOG_VMM_ERR("Could not register MMIO fault handler for BAR %d of PCI device %d:%d.%d\n",
+                                    dev_bar_id, bus, dev, func);
+                        return false;
+                    }
+#else
+
+#endif
+                }
+            }
+            break;
+        }
+        }
+    }
+    return true;
+}
+
+pci_dev_handle_t pci_register_device(uint8_t bus, uint8_t dev, uint8_t func, pci_device_register_data_t *device_data)
+{
+    if (bus >= PCI_NUM_BUS) {
+        LOG_PCI_ERR("PCI bus %u is out of bound\n", bus);
+        return INVALID_PCI_DEVICE_HANDLE;
+    }
+
+    if (dev >= PCI_DEV_PER_BUS) {
+        LOG_PCI_ERR("PCI dev %u is out of bound\n", bus);
+        return INVALID_PCI_DEVICE_HANDLE;
+    }
+
+    if (func >= PCI_FUNC_PER_DEV) {
+        LOG_PCI_ERR("PCI func %u is out of bound\n", bus);
+        return INVALID_PCI_DEVICE_HANDLE;
+    }
+
+    pci_dev_handle_t handle = pci_geo_addr_to_internal_index(bus, dev, func);
+    struct pci_device *pci_device = pci_get_device(handle);
+    struct pci_config_space *config_space = &pci_device->config_space;
+    if (config_space->vendor_id != PCI_INVALID_VENDOR_ID) {
+        LOG_PCI_ERR(
+            "Geo addr %u:%u.%u has already been occupied by PCI device vendor id 0x%x, device id 0x%x, handle %d\n",
+            bus, dev, func, config_space->vendor_id, config_space->device_id, handle);
+        return INVALID_PCI_DEVICE_HANDLE;
+    }
+
+    if (device_data->vendor_id == PCI_INVALID_VENDOR_ID) {
+        LOG_PCI_ERR("Vendor ID cannot be an invalid value\n");
+        return INVALID_PCI_DEVICE_HANDLE;
+    }
+
+    /* Let be safe even though we don't support deregistering a PCI device. */
+    memset(pci_device, 0, sizeof(struct pci_device));
+
+    config_space->vendor_id = device_data->vendor_id;
+    config_space->device_id = device_data->device_id;
+    config_space->command = device_data->command;
+    config_space->status = device_data->status;
+    config_space->revision_id = device_data->revision_id;
+    config_space->subclass = device_data->subclass;
+    config_space->class_code = device_data->class_code;
+    config_space->subsystem_vendor_id = device_data->subsystem_vendor_id;
+    config_space->subsystem_device_id = device_data->subsystem_device_id;
+
+    pci_device->next_available_cap_ptr = offsetof(struct pci_config_space, cap_data);
+    pci_device->virq_registered = false;
+
+    pci_device->sticky_cmd_bits = device_data->command;
+
+    return handle;
+}
+
+bool pci_register_device_irq(pci_dev_handle_t pci_dev_handle, int virq, virq_ack_fn_t ack_fn, void *ack_data)
+{
+    if (!pci_device_exist_check(pci_dev_handle)) {
+        return false;
+    }
+
+    struct pci_device *pci_device = pci_get_device(pci_dev_handle);
+    if (pci_device->virq_registered) {
+        LOG_PCI_ERR("IRQ already registered for PCI dev handle %d\n", pci_dev_handle);
+        return false;
+    }
+
+    bool success = virq_register(GUEST_BOOT_VCPU_ID, virq, ack_fn, ack_data);
+    if (!success) {
+        LOG_PCI_ERR("Cannot register IRQ for PCI dev handle %d\n", pci_dev_handle);
+        return false;
+    }
+
+    /* Always use dev's first interrupt pin specified in interrupt-map */
+    pci_device->config_space.interrupt_pin = 0x1;
+    pci_device->config_space.interrupt_line = virq;
+
+    pci_device->virq_registered = success;
+    return success;
+}
+
+bool pci_register_device_capability(pci_dev_handle_t pci_dev_handle, uint8_t cap_id, void *payload,
+                                    uint8_t payload_size)
+{
+    if (!pci_device_exist_check(pci_dev_handle)) {
+        return false;
+    }
+
+    struct pci_device *pci_device = pci_get_device(pci_dev_handle);
+    struct pci_config_space *config_space = &pci_device->config_space;
+
+    uint16_t cap_size = payload_size + sizeof(struct pci_capability_header);
+    if ((uint16_t)pci_device->next_available_cap_ptr + cap_size > sizeof(struct pci_config_space)) {
+        LOG_PCI_ERR("Out of space for registering cap id %u, size %u, for PCI dev handle %d\n", cap_id, cap_size,
+                    pci_dev_handle);
+        return false;
+    }
+
+    if (config_space->cap_ptr == 0) {
+        /* First cap */
+        config_space->cap_ptr = pci_device->next_available_cap_ptr;
+        config_space->status |= PCI_STATUS_CAP_LIST;
+    } else {
+        /* Walk to the last cap and update the next ptr. */
+        struct pci_capability_header *curr_cap = (struct pci_capability_header *)((uintptr_t)config_space
+                                                                                  + config_space->cap_ptr);
+        while (curr_cap->next_ptr) {
+            curr_cap = (struct pci_capability_header *)((uintptr_t)config_space + curr_cap->next_ptr);
+        }
+        curr_cap->next_ptr = pci_device->next_available_cap_ptr;
+    }
+
+    struct pci_capability_header *dest = (struct pci_capability_header *)(((char *)config_space)
+                                                                          + pci_device->next_available_cap_ptr);
+    assert(((uint16_t)pci_device->next_available_cap_ptr) + cap_size <= sizeof(struct pci_config_space));
+
+    dest->cap_id = cap_id;
+    dest->next_ptr = 0;
+    memcpy((void *)(((char *)dest) + sizeof(struct pci_capability_header)), payload, payload_size);
+
+    pci_device->next_available_cap_ptr = ROUND_UP(pci_device->next_available_cap_ptr + cap_size, 4);
+
+    return true;
+}
+
+bool pci_register_device_mmio_bar(pci_dev_handle_t pci_dev_handle, uint8_t bar_index, uint64_t size,
+                                  pci_bar_mmio_fault_handler_t callback, void *cookie)
+{
+    if (!pci_device_exist_check(pci_dev_handle)) {
+        return false;
+    }
+
+    if (!size) {
+        LOG_PCI_ERR("bar size is zero\n");
+        return false;
+    }
+
+    if (bar_index >= PCI_NUM_BARS_PER_CONFIG_SPACE) {
+        LOG_PCI_ERR("bar index %u is out of bound\n", bar_index);
+        return false;
+    }
+
+    struct pci_device *pci_device = pci_get_device(pci_dev_handle);
+    if (pci_device->bars[bar_index].valid) {
+        LOG_PCI_ERR("bar index %u is is already registered for PCI device handle %d\n", bar_index, pci_dev_handle);
+        return false;
+    }
+
+    pci_device->bars[bar_index].valid = true;
+    pci_device->bars[bar_index].size = size;
+    pci_device->bars[bar_index].callback = callback;
+    pci_device->bars[bar_index].cookie = cookie;
+
+    return true;
+}
+
+bool pci_bus_init(uint64_t ecam_gpa, uint32_t ecam_size, uint64_t mmio_aperature_gpa, uint64_t mmio_aperature_size)
+{
+    if (ecam_size != PCI_EXPECTED_ECAM_SIZE) {
+        LOG_PCI_ERR("`ecam_size` = 0x%x does not equal expected 0x%x!\n", ecam_size, PCI_EXPECTED_ECAM_SIZE);
+        return false;
+    }
+
+    if (mmio_aperature_size == 0) {
+        LOG_PCI_ERR("mmio_aperature_size cannot be zero.\n");
+        return false;
+    }
+
+    memset(&pci_bus, 0, sizeof(struct pci_bus));
+
+    pci_bus.ecam.gpa = ecam_gpa;
+    pci_bus.ecam.size = ecam_size;
+    pci_bus.mmio_aperature.gpa = mmio_aperature_gpa;
+    pci_bus.mmio_aperature.size = mmio_aperature_size;
+
+    for (int i = 0; i < PCI_NUM_CONFIG_SPACES; i++) {
+        pci_bus.ecam.devices[i].config_space.vendor_id = PCI_INVALID_VENDOR_ID;
+    }
+
+#if defined(CONFIG_ARCH_ARM)
+    if (!fault_register_vm_exception_handler(ecam_gpa, ecam_size, &pci_ecam_fault_handle, NULL)) {
+        LOG_PCI_ERR("Could not register virtual memory fault handler for PCI ECAM area!\n");
+        return false;
+    }
+#else
+
+#endif
+
+    /* We don't register fault handlers for the MMIO aperature yet as they will be individually handled later. */
+
+    pci_bus.initialised = true;
+
+    return true;
+}

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -808,9 +808,9 @@ bool virtio_mmio_blk_init(struct virtio_blk_device *blk_dev, uintptr_t region_ba
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
 
-bool virtio_pci_blk_init(struct virtio_blk_device *blk_dev, uint32_t dev_slot, size_t virq, uintptr_t data_region,
-                         size_t data_region_size, blk_storage_info_t *storage_info, blk_queue_handle_t *queue_h,
-                         uint32_t queue_capacity, int server_ch)
+bool virtio_pci_blk_init(struct virtio_blk_device *blk_dev, uint16_t pci_bus, uint16_t pci_dev, size_t virq,
+                         uintptr_t data_region, size_t data_region_size, blk_storage_info_t *storage_info,
+                         blk_queue_handle_t *queue_h, uint32_t queue_capacity, int server_ch)
 {
     struct virtio_device *dev = virtio_blk_init(blk_dev, VIRTIO_TRANSPORT_PCI, virq, data_region, data_region_size,
                                                 storage_info, queue_h, queue_capacity, server_ch);
@@ -819,10 +819,5 @@ bool virtio_pci_blk_init(struct virtio_blk_device *blk_dev, uint32_t dev_slot, s
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_STORAGE_SCSI;
 
-    bool success = virtio_pci_alloc_dev_cfg_space(dev, dev_slot);
-    assert(success);
-
-    virtio_pci_alloc_memory_bar(dev, 0, VIRTIO_PCI_DEFAULT_BAR_SIZE);
-
-    return virtio_pci_register_device(dev, virq);
+    return virtio_pci_register_device(dev, pci_bus, pci_dev, virq);
 }

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -312,7 +312,7 @@ bool virtio_mmio_console_init(struct virtio_console_device *console, uintptr_t r
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
 
-bool virtio_pci_console_init(struct virtio_console_device *console, uint32_t dev_slot, size_t virq,
+bool virtio_pci_console_init(struct virtio_console_device *console, uint16_t pci_bus, uint16_t pci_dev, size_t virq,
                              serial_queue_handle_t *rxq, serial_queue_handle_t *txq, int tx_ch, int rx_ch)
 {
     struct virtio_device *dev = virtio_console_init(console, VIRTIO_TRANSPORT_PCI, virq, rxq, txq, tx_ch, rx_ch);
@@ -321,10 +321,5 @@ bool virtio_pci_console_init(struct virtio_console_device *console, uint32_t dev
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_COMMUNICATION_OTHER;
 
-    bool success = virtio_pci_alloc_dev_cfg_space(dev, dev_slot);
-    assert(success);
-
-    virtio_pci_alloc_memory_bar(dev, 0, VIRTIO_PCI_DEFAULT_BAR_SIZE);
-
-    return virtio_pci_register_device(dev, virq);
+    return virtio_pci_register_device(dev, pci_bus, pci_dev, virq);
 }

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -372,9 +372,9 @@ bool virtio_mmio_net_init(struct virtio_net_device *net_dev, uintptr_t region_ba
     return virtio_mmio_register_device(dev, region_base, region_size, virq);
 }
 
-bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint32_t dev_slot, size_t virq, net_queue_handle_t *rx,
-                         net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data, microkit_channel rx_ch,
-                         microkit_channel tx_ch, uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ])
+bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint16_t pci_bus, uint16_t pci_dev, size_t virq,
+                         net_queue_handle_t *rx, net_queue_handle_t *tx, uintptr_t rx_data, uintptr_t tx_data,
+                         microkit_channel rx_ch, microkit_channel tx_ch, uint8_t mac[VIRTIO_NET_CONFIG_MAC_SZ])
 {
     struct virtio_device *dev = virtio_net_init(net_dev, VIRTIO_TRANSPORT_PCI, virq, rx, tx, rx_data, tx_data, rx_ch,
                                                 tx_ch, mac);
@@ -383,10 +383,5 @@ bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint32_t dev_slot, s
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_NETWORK_ETHERNET;
 
-    bool success = virtio_pci_alloc_dev_cfg_space(dev, dev_slot);
-    assert(success);
-
-    virtio_pci_alloc_memory_bar(dev, 0, VIRTIO_PCI_DEFAULT_BAR_SIZE);
-
-    return virtio_pci_register_device(dev, virq);
+    return virtio_pci_register_device(dev, pci_bus, pci_dev, virq);
 }

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -196,7 +196,8 @@ static void handle_tx_msg(struct virtio_device *dev, uint16_t desc_head, bool *n
      * read_off = sizeof(struct virtio_net_hdr_mrg_rxbuf)
      * to strip virtio header before copying to sDDF
      */
-    assert(virtio_read_data_from_desc_chain(vq, desc_head, packet_len, sizeof(struct virtio_net_hdr_mrg_rxbuf), dest_buf));
+    assert(
+        virtio_read_data_from_desc_chain(vq, desc_head, packet_len, sizeof(struct virtio_net_hdr_mrg_rxbuf), dest_buf));
     sddf_buffer.len = packet_len;
 
 #ifdef NETWORK_HW_HAS_CHECKSUM
@@ -231,11 +232,15 @@ static bool virtio_net_queue_notify(struct virtio_device *dev)
         LOG_NET_ERR("Driver not ready\n");
         return false;
     }
-    if (dev->regs.QueueSel != VIRTIO_NET_TX_VIRTQ) {
-        LOG_NET_ERR("Invalid queue\n");
-        return false;
+    if (dev->regs.QueueSel == VIRTIO_NET_RX_VIRTQ) {
+        if (!dev->vqs[VIRTIO_NET_RX_VIRTQ].ready) {
+            LOG_NET_ERR("RX virtq not ready\n");
+            return false;
+        }
+        virtio_net_handle_rx(device_state(dev));
+        return true;
     }
-    if (!dev->vqs[VIRTIO_NET_TX_VIRTQ].ready) {
+    if (dev->regs.QueueSel == VIRTIO_NET_TX_VIRTQ && !dev->vqs[VIRTIO_NET_TX_VIRTQ].ready) {
         LOG_NET_ERR("TX virtq not ready\n");
         return false;
     }

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -14,8 +14,6 @@
 #define LOG_VIRTIO_PCI_INFO(...) do{ printf("%s|VIRTIO(PCI) INFO: ", microkit_name); printf(__VA_ARGS__); }while(0)
 #define LOG_VIRTIO_PCI_ERR(...) do{ printf("%s|VIRTIO(PCI) ERROR: ", microkit_name); printf(__VA_ARGS__); }while(0)
 
-// @billn pull in bug fixes from windows branch https://github.com/au-ts/libvmm/compare/main...windows
-
 /* This is the default for virtio PCI devices as it allows plenty of space
  * for all the capabilities */
 #define VIRTIO_PCI_DEFAULT_BAR_SIZE 0x4000
@@ -108,8 +106,9 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t offset, uint
         *data = dev->vqs[dev->regs.QueueSel].ready;
         break;
     case VIRTIO_PCI_COMMON_Q_NOTIF_OFF:
-        // proper way?
-        *data = 1 << 16;
+        /* virtIO spec 1.2:
+         * "Note: For example, if notifier_off_multiplier is 0, the device uses the same Queue Notify address for all queues." */
+        *data = 0;
         break;
     default:
         LOG_VIRTIO_PCI_ERR("read operation is invalid or not implemented at offset 0x%lx of common_cfg\n", offset);
@@ -262,7 +261,7 @@ static bool virtio_pci_device_reg_write(virtio_device_t *dev, size_t offset, uin
 static bool virtio_pci_notify_reg_write(virtio_device_t *dev, size_t offset, uint32_t data)
 {
     dev->regs.QueueNotify = data;
-    dev->regs.QueueSel = offset / VIRTIO_PCI_NOTIF_OFF_MULTIPLIER;
+    dev->regs.QueueSel = data;
     return dev->funs->queue_notify(dev);
 }
 
@@ -391,7 +390,7 @@ bool virtio_pci_register_device(virtio_device_t *dev, uint16_t pci_bus, uint16_t
                 .offset = VIRTIO_PCI_NOTIFY_CFG_BAR_OFF,
                 .length = 0x1000,
             },
-        .notify_off_multiplier = VIRTIO_PCI_NOTIF_OFF_MULTIPLIER,
+        .notify_off_multiplier = 0,
     };
     if (!pci_register_device_capability(handle, PCI_CAP_ID_VNDR, &ntfn_cap, sizeof(struct virtio_pci_notify_cap))) {
         return false;

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -345,7 +345,7 @@ bool virtio_pci_register_device(virtio_device_t *dev, uint16_t pci_bus, uint16_t
 
     /* Create all the virtIO specific capabilities */
     struct virtio_pci_cap common_cfg_cap = (struct virtio_pci_cap) {
-        .cap_len = sizeof(struct virtio_pci_cap) + 2, // @billn sort out, include header legnth
+        .cap_len = sizeof(struct pci_capability_header) + sizeof(struct virtio_pci_cap),
         .cfg_type = VIRTIO_PCI_CAP_COMMON_CFG,
         .bar = 0,
         .id = 0,
@@ -357,7 +357,7 @@ bool virtio_pci_register_device(virtio_device_t *dev, uint16_t pci_bus, uint16_t
     }
 
     struct virtio_pci_cap isr_cap = (struct virtio_pci_cap) {
-        .cap_len = sizeof(struct virtio_pci_cap) + 2,
+        .cap_len = sizeof(struct pci_capability_header) + sizeof(struct virtio_pci_cap),
         .cfg_type = VIRTIO_PCI_CAP_ISR_CFG,
         .bar = 0,
         .id = 0,
@@ -369,7 +369,7 @@ bool virtio_pci_register_device(virtio_device_t *dev, uint16_t pci_bus, uint16_t
     }
 
     struct virtio_pci_cap device_cfg_cap = (struct virtio_pci_cap) {
-        .cap_len = sizeof(struct virtio_pci_cap) + 2,
+        .cap_len = sizeof(struct pci_capability_header) + sizeof(struct virtio_pci_cap),
         .cfg_type = VIRTIO_PCI_CAP_DEVICE_CFG,
         .bar = 0,
         .id = 0,
@@ -383,7 +383,7 @@ bool virtio_pci_register_device(virtio_device_t *dev, uint16_t pci_bus, uint16_t
     struct virtio_pci_notify_cap ntfn_cap = (struct virtio_pci_notify_cap) {
         .cap =
             (struct virtio_pci_cap) {
-                .cap_len = sizeof(struct virtio_pci_notify_cap) + 2,
+                .cap_len = sizeof(struct pci_capability_header) + sizeof(struct virtio_pci_notify_cap),
                 .cfg_type = VIRTIO_PCI_CAP_NOTIFY_CFG,
                 .bar = 0,
                 .id = 0,

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -86,6 +86,9 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t offset, uint
     bool success = true;
 
     switch (offset) {
+    case VIRTIO_PCI_COMMON_DEV_FEATURE_SEL:
+        *data = dev->regs.DeviceFeaturesSel;
+        break;
     case VIRTIO_PCI_COMMON_DEV_FEATURE:
         success = dev->funs->get_device_features(dev, data);
         break;
@@ -110,6 +113,7 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t offset, uint
         break;
     default:
         LOG_VIRTIO_PCI_ERR("read operation is invalid or not implemented at offset 0x%lx of common_cfg\n", offset);
+        success = false;
     }
 
     return success;

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -4,185 +4,28 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <libvmm/guest.h>
+#include <libvmm/pci.h>
 #include <libvmm/virq.h>
 #include <libvmm/virtio/virtio.h>
 #include <libvmm/virtio/config.h>
 #include <libvmm/virtio/virtq.h>
 #include <libvmm/arch/aarch64/fault.h>
 
-#define LOG_PCI_INFO(...) do{ printf("%s|VIRTIO(PCI) INFO: ", microkit_name); printf(__VA_ARGS__); }while(0)
-#define LOG_PCI_ERR(...) do{ printf("%s|VIRTIO(PCI) ERROR: ", microkit_name); printf(__VA_ARGS__); }while(0)
+#define LOG_VIRTIO_PCI_INFO(...) do{ printf("%s|VIRTIO(PCI) INFO: ", microkit_name); printf(__VA_ARGS__); }while(0)
+#define LOG_VIRTIO_PCI_ERR(...) do{ printf("%s|VIRTIO(PCI) ERROR: ", microkit_name); printf(__VA_ARGS__); }while(0)
 
-/* We assume that there is only one PCI node */
-static struct virtio_pci_ecam global_pci_ecam;
-static struct pci_memory_resource registered_pci_memory_resource;
-static struct pci_memory_bar global_memory_bars[VIRTIO_PCI_MAX_MEM_BARS];
+// @billn pull in bug fixes from windows branch https://github.com/au-ts/libvmm/compare/main...windows
 
-static virtio_device_t *virtio_pci_dev_table[VIRTIO_PCI_DEV_FUNC_MAX];
+/* This is the default for virtio PCI devices as it allows plenty of space
+ * for all the capabilities */
+#define VIRTIO_PCI_DEFAULT_BAR_SIZE 0x4000
 
-static struct pci_config_space *virtio_pci_find_dev_cfg_space(virtio_device_t *dev)
-{
-    uint32_t dev_table_idx = dev->transport.pci.dev_table_idx;
-    assert(dev_table_idx < VIRTIO_PCI_DEV_FUNC_MAX);
-
-    if (virtio_pci_dev_table[dev_table_idx] == NULL) {
-        return NULL;
-    }
-
-    uint16_t bus_id = dev_table_idx / VIRTIO_PCI_DEVS_PER_BUS / VIRTIO_PCI_FUNCS_PER_DEV;
-    uint8_t dev_slot = (dev_table_idx % VIRTIO_PCI_DEVS_PER_BUS) / VIRTIO_PCI_FUNCS_PER_DEV;
-    uint8_t func_id = dev_table_idx % VIRTIO_PCI_FUNCS_PER_DEV;
-
-    uint32_t offset = (bus_id << 20) + (dev_slot << 15) + (func_id << 12);
-    if ((offset + (1 << 15)) > global_pci_ecam.size) {
-        LOG_PCI_ERR("ECAM area for 0x%4x:0x%2x:0x%2x,0x%x is invalid \n", 0, bus_id, dev_slot, func_id);
-    }
-
-    return (struct pci_config_space *)(global_pci_ecam.vmm_base + offset);
-}
-
-/**
- * Allocate a memory region from a memory bar for a capability.
- */
-static uintptr_t pci_allocate_bar_memory(virtio_device_t *dev, uint8_t dev_bar_id, uint32_t size)
-{
-    // indice of the bar in global_memory_bars
-    uint32_t idx = dev->transport.pci.mem_bar_ids[dev_bar_id];
-
-    assert(global_memory_bars[idx].free_offset + size <= global_memory_bars[idx].size);
-
-    uintptr_t allocated_offset = global_memory_bars[idx].free_offset;
-    global_memory_bars[idx].free_offset = global_memory_bars[idx].free_offset + size;
-
-    return allocated_offset;
-}
-
-static bool pci_add_virtio_capability(virtio_device_t *dev, uint8_t offset, uint8_t cfg_type, uint8_t bar,
-                                      uint8_t next_ptr)
-{
-    uintptr_t new_cap_addr = (uintptr_t)virtio_pci_find_dev_cfg_space(dev) + offset;
-    uint8_t len;            // length of the new cap
-    uint32_t size = 0;      // size of the structure on the BAR, in bytes
-
-    // Add the capability to the config space
-    switch (cfg_type) {
-    case VIRTIO_PCI_CAP_COMMON_CFG:
-    case VIRTIO_PCI_CAP_ISR_CFG:
-    case VIRTIO_PCI_CAP_DEVICE_CFG:
-        len = sizeof(struct virtio_pci_cap);
-        assert(offset + len < VIRTIO_PCI_FUNC_CFG_SPACE_SIZE);
-        size = 0x1000;
-        break;
-    case VIRTIO_PCI_CAP_NOTIFY_CFG:
-        len = sizeof(struct virtio_pci_notify_cap);
-        assert(offset + len < VIRTIO_PCI_FUNC_CFG_SPACE_SIZE);
-        size = 0x1000;
-        struct virtio_pci_notify_cap *notify = (struct virtio_pci_notify_cap *)new_cap_addr;
-        notify->notify_off_multiplier = VIRTIO_PCI_NOTIF_OFF_MULTIPLIER;
-        break;
-    case VIRTIO_PCI_CAP_PCI_CFG:
-        len = sizeof(struct virtio_pci_cfg_cap);
-        break;
-    /* case VIRTIO_PCI_CAP_SHARED_MEMORY_CFG: */
-    /* case VIRTIO_PCI_CAP_VENDOR_CFG: */
-    default:
-        LOG_PCI_ERR("Unimplemented capability type: 0x%x\n", cfg_type);
-        return false;
-    }
-
-    uint32_t bar_offset = pci_allocate_bar_memory(dev, bar, size);
-
-    struct virtio_pci_cap *new_cap = (struct virtio_pci_cap *)new_cap_addr;
-    new_cap->cap_id = PCI_CAP_ID_VNDR;
-    new_cap->next_ptr = next_ptr;
-    new_cap->cap_len = len;
-    new_cap->cfg_type = cfg_type;
-    new_cap->bar = bar;
-    new_cap->offset = bar_offset;
-    new_cap->length = size;
-
-    return true;
-}
-
-static bool pci_add_capability(virtio_device_t *dev, uint8_t cap_id, uint8_t cfg_type, uint8_t bar)
-{
-    // Make sure the byte "cap_len" is within the region
-    struct pci_config_space *config_space = virtio_pci_find_dev_cfg_space(dev);
-    assert(config_space->cap_ptr + 2 < VIRTIO_PCI_FUNC_CFG_SPACE_SIZE);
-
-    uint8_t *last_cap = (uint8_t *)config_space + config_space->cap_ptr;
-    uint8_t offset = config_space->cap_ptr + last_cap[2];
-    bool success = true;
-
-    switch (cap_id) {
-    case PCI_CAP_ID_VNDR:
-        success = pci_add_virtio_capability(dev, offset, cfg_type, bar, config_space->cap_ptr);
-        break;
-    default:
-        success = false;
-        LOG_PCI_ERR("Unimplementeed capability ID: 0x%x\n", cap_id);
-    }
-
-    if (!success) {
-        LOG_PCI_ERR("Failed to add capability: ID (0x%x), type (0x%x), bar (0x%x)\n", cap_id, cfg_type, bar);
-        return false;
-    }
-
-    // Update cap_ptr in config space
-    config_space->cap_ptr = offset;
-    return true;
-}
-
-bool virtio_pci_alloc_memory_bar(virtio_device_t *dev, uint8_t bar_id, uint32_t size)
-{
-    assert(dev->transport_type == VIRTIO_TRANSPORT_PCI);
-    // Assume there are only memory bars, and bar size needs to be 16-byte aligned
-    assert((size & 0xFFFFFFF0) == size);
-
-    uint32_t idx = 0;
-    while (idx < VIRTIO_PCI_MAX_MEM_BARS && global_memory_bars[idx].dev) idx++;
-    if (idx == VIRTIO_PCI_MAX_MEM_BARS) {
-        LOG_PCI_ERR("No more available memory bar slots. Please increase VIRTIO_PCI_MAX_MEM_BARS\n");
-        return false;
-    }
-
-    if (registered_pci_memory_resource.free_offset + size > registered_pci_memory_resource.size) {
-        LOG_PCI_ERR("Could not allocate 0x%x bytes for new memory bar. 0x%x bytes left.\n", size,
-                    registered_pci_memory_resource.size - registered_pci_memory_resource.free_offset);
-        return false;
-    }
-
-    global_memory_bars[idx].size = size;
-    global_memory_bars[idx].free_offset = 0;
-    global_memory_bars[idx].dev = dev;
-    global_memory_bars[idx].idx = bar_id;
-
-    dev->transport.pci.mem_bar_ids[bar_id] = idx;
-
-    struct pci_config_space *config_space = virtio_pci_find_dev_cfg_space(dev);
-    struct pci_bar_memory_bits *new_mem_bar = (struct pci_bar_memory_bits *)&config_space->bar[bar_id];
-    new_mem_bar->base_address = 0;
-
-    return true;
-}
-
-/**
- * Look for the capability of a device by the offset on the memory resource
- * */
-static struct virtio_pci_cap *find_pci_cap_by_offset(virtio_device_t *dev, uint8_t bar, uint32_t offset)
-{
-    struct pci_config_space *config_space = virtio_pci_find_dev_cfg_space(dev);
-    struct virtio_pci_cap *cap = (struct virtio_pci_cap *)((uintptr_t)config_space + config_space->cap_ptr);
-    while (cap != (struct virtio_pci_cap *)config_space) {
-        if (cap->cap_id == PCI_CAP_ID_VNDR && cap->bar == bar
-            && (cap->offset <= offset && offset < cap->offset + cap->length)) {
-            return cap;
-        }
-        cap = (struct virtio_pci_cap *)((uintptr_t)config_space + cap->next_ptr);
-    }
-    return NULL;
-}
+/* Since we place all the virtIO PCI registers into one BAR, we need to
+ * differentiate them. */
+#define VIRTIO_PCI_COMMON_CFG_BAR_OFF 0x0
+#define VIRTIO_PCI_ISR_BAR_OFF        0x1000
+#define VIRTIO_PCI_DEVICE_CFG_BAR_OFF 0x2000
+#define VIRTIO_PCI_NOTIFY_CFG_BAR_OFF 0x3000
 
 static bool handle_virtio_pci_set_status_flag(virtio_device_t *dev, uint32_t reg)
 {
@@ -228,63 +71,53 @@ static bool handle_virtio_pci_set_status_flag(virtio_device_t *dev, uint32_t reg
         break;
 
     case VIRTIO_CONFIG_S_FAILED:
-        LOG_PCI_INFO("received FAILED status from driver, giving up this device.\n");
+        LOG_VIRTIO_PCI_ERR("received FAILED status from driver, giving up this device.\n");
         break;
 
     default:
-        LOG_PCI_INFO("unknown device status 0x%x.\n", reg);
+        LOG_VIRTIO_PCI_ERR("unknown device status 0x%x.\n", reg);
         success = false;
     }
     return success;
 }
 
-static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                       seL4_UserContext *regs)
+static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t offset, uint32_t *data)
 {
-    uint32_t reg = 0;
     bool success = true;
 
     switch (offset) {
     case REG_RANGE(VIRTIO_PCI_COMMON_DEV_FEATURE, VIRTIO_PCI_COMMON_DRI_FEATURE_SEL):
-        success = dev->funs->get_device_features(dev, &reg);
+        success = dev->funs->get_device_features(dev, data);
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_NUM_QUEUES, VIRTIO_PCI_COMMON_DEV_STATUS):
-        reg = dev->num_vqs << 16;
+        *data = dev->num_vqs << 16;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_DEV_STATUS, VIRTIO_PCI_COMMON_CFG_GENERATION):
-        reg = dev->regs.Status;
+        *data = dev->regs.Status;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_CFG_GENERATION, VIRTIO_PCI_COMMON_Q_SIZE):
-        reg = dev->regs.ConfigGeneration;
+        *data = dev->regs.ConfigGeneration;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_SIZE, VIRTIO_PCI_COMMON_Q_ENABLE):
-        reg = VIRTIO_DEFAULT_QUEUE_SIZE;
+        *data = VIRTIO_DEFAULT_QUEUE_SIZE;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_ENABLE, VIRTIO_PCI_COMMON_Q_NOTIF_OFF):
-        reg = dev->vqs[dev->regs.QueueSel].ready;
+        *data = dev->vqs[dev->regs.QueueSel].ready;
         break;
     case REG_RANGE(VIRTIO_PCI_COMMON_Q_NOTIF_OFF, VIRTIO_PCI_COMMON_Q_DESC_LO):
         // proper way?
-        reg = 1 << 16;
+        *data = 1 << 16;
         break;
     default:
-        LOG_PCI_ERR("read operation is invalid or not implemented at offset 0x%lx of common_cfg\n", offset);
+        LOG_VIRTIO_PCI_ERR("read operation is invalid or not implemented at offset 0x%lx of common_cfg\n", offset);
     }
 
-    uint32_t mask = fault_get_data_mask(offset, fsr);
-    fault_emulate_write(regs, offset, fsr, reg & mask);
     return success;
 }
 
-static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                        seL4_UserContext *regs)
+static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uint32_t data)
 {
     bool success = true;
-    uint32_t data = fault_get_data(regs, fsr);
-    /* Mask the data to write */
-    /* Why commented out? Given queue_sel is not the case */
-    // uint32_t mask = fault_get_data_mask(offset, fsr);
-    /* data &= mask; */
 
     switch (offset) {
     case REG_RANGE(VIRTIO_PCI_COMMON_DEV_FEATURE_SEL, VIRTIO_PCI_COMMON_DEV_FEATURE):
@@ -307,9 +140,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
             struct virtq *virtq = get_current_virtq_by_handler(dev);
             virtq->num = (unsigned int)data;
         } else {
-            LOG_VMM_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                        "given when accessing REG_VIRTIO_MMIO_QUEUE_NUM\n",
-                        dev->regs.QueueSel, dev->num_vqs);
+            LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
+                               "given when accessing REG_VIRTIO_MMIO_QUEUE_NUM\n",
+                               dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
@@ -326,9 +159,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
             ptr |= data;
             virtq->desc_gpa = (struct virtq_desc *)ptr;
         } else {
-            LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                        "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
-                        dev->regs.QueueSel, dev->num_vqs);
+            LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
+                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
@@ -339,9 +172,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
             ptr |= (uintptr_t)data << 32;
             virtq->desc_gpa = (struct virtq_desc *)ptr;
         } else {
-            LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                        "given when accessing REG_VIRTIO_MMIO_QUEUE_DESC_HIGH\n",
-                        dev->regs.QueueSel, dev->num_vqs);
+            LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
+                               "given when accessing REG_VIRTIO_MMIO_QUEUE_DESC_HIGH\n",
+                               dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
@@ -352,9 +185,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
             ptr |= data;
             virtq->avail_gpa = (struct virtq_avail *)ptr;
         } else {
-            LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                        "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
-                        dev->regs.QueueSel, dev->num_vqs);
+            LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
+                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
@@ -365,9 +198,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
             ptr |= (uintptr_t)data << 32;
             virtq->avail_gpa = (struct virtq_avail *)ptr;
         } else {
-            LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                        "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
-                        dev->regs.QueueSel, dev->num_vqs);
+            LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
+                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
@@ -378,9 +211,9 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
             ptr |= data;
             virtq->used_gpa = (struct virtq_used *)ptr;
         } else {
-            LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                        "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
-                        dev->regs.QueueSel, dev->num_vqs);
+            LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
+                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
@@ -391,286 +224,174 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t vcpu_id, si
             ptr |= (uintptr_t)data << 32;
             virtq->used_gpa = (struct virtq_used *)ptr;
         } else {
-            LOG_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                        "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
-                        dev->regs.QueueSel, dev->num_vqs);
+            LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
+                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
     default:
-        LOG_PCI_ERR("write operation is invalid or not implemented at offset 0x%lx of common_cfg\n", offset);
+        LOG_VIRTIO_PCI_ERR("write operation is invalid or not implemented at offset 0x%lx of common_cfg\n", offset);
+        success = false;
     }
 
     return success;
 }
 
-static bool virtio_pci_device_reg_read(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                       seL4_UserContext *regs)
+static bool virtio_pci_isr_read(virtio_device_t *dev, size_t offset, uint32_t *data)
 {
-    uint32_t reg = 0;
-    bool success = true;
-    success = dev->funs->get_device_config(dev, offset, &reg);
-
-    uint32_t mask = fault_get_data_mask(offset, fsr);
-    fault_emulate_write(regs, offset, fsr, reg & mask);
-    return success;
-}
-
-static bool virtio_pci_device_reg_write(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                        seL4_UserContext *regs)
-{
-    bool success = true;
-    uint32_t data = fault_get_data(regs, fsr);
-    uint32_t mask = fault_get_data_mask(offset, fsr);
-    /* Mask the data to write */
-    data &= mask;
-    success = dev->funs->set_device_config(dev, offset, data);
-
-    return success;
-}
-
-static bool virtio_pci_notify_reg_read(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                       seL4_UserContext *regs)
-{
-    LOG_PCI_ERR("notfiy_cfg should not be read\n");
-    return false;
-}
-
-static bool virtio_pci_notify_reg_write(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                        seL4_UserContext *regs)
-{
-    bool success = true;
-    uint32_t data = fault_get_data(regs, fsr);
-    dev->regs.QueueNotify = data;
-
-    dev->regs.QueueSel = offset / VIRTIO_PCI_NOTIF_OFF_MULTIPLIER;
-    success = dev->funs->queue_notify(dev);
-    return success;
-}
-
-static bool virtio_pci_isr_reg_read(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                    seL4_UserContext *regs)
-{
-    uint32_t reg = dev->regs.InterruptStatus;
-    uint32_t mask = fault_get_data_mask(offset, fsr);
-    fault_emulate_write(regs, offset, fsr, reg & mask);
+    *data = dev->regs.InterruptStatus;
     dev->regs.InterruptStatus = 0;
     return true;
 }
 
-static bool virtio_pci_isr_reg_write(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                     seL4_UserContext *regs)
+static bool virtio_pci_device_reg_read(virtio_device_t *dev, size_t offset, uint32_t *data)
 {
-    LOG_PCI_ERR("isr should not be written by the driver\n");
-    return false;
+    return dev->funs->get_device_config(dev, offset, data);
 }
 
-static bool virtio_pci_bar_fault_handle(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data)
+static bool virtio_pci_device_reg_write(virtio_device_t *dev, size_t offset, uint32_t data)
 {
-    uintptr_t vmm_addr = offset + registered_pci_memory_resource.vmm_addr;
+    return dev->funs->set_device_config(dev, offset, data);
+}
 
-    // Search for dev from global_memory_bars
-    uint32_t i = 0;
-    for (i = 0; i < VIRTIO_PCI_MAX_MEM_BARS; i++) {
-        if (global_memory_bars[i].vaddr <= vmm_addr
-            && vmm_addr < global_memory_bars[i].vaddr + global_memory_bars[i].size) {
-            break;
+static bool virtio_pci_notify_reg_write(virtio_device_t *dev, size_t offset, uint32_t data)
+{
+    dev->regs.QueueNotify = data;
+    dev->regs.QueueSel = offset / VIRTIO_PCI_NOTIF_OFF_MULTIPLIER;
+    return dev->funs->queue_notify(dev);
+}
+
+bool virtio_pci_bar_fault_handle(pci_dev_handle_t pci_dev_handle, uint64_t bar_offset, bool is_read,
+                                 int access_width_bytes, uint64_t *data, void *cookie)
+{
+    virtio_device_t *dev = (virtio_device_t *)cookie;
+    assert(dev);
+
+    bool success = false;
+
+    switch (bar_offset) {
+    case REG_RANGE(VIRTIO_PCI_COMMON_CFG_BAR_OFF, VIRTIO_PCI_ISR_BAR_OFF):
+        if (is_read) {
+            success = virtio_pci_common_reg_read(dev, bar_offset - VIRTIO_PCI_COMMON_CFG_BAR_OFF, (uint32_t *)data);
+        } else {
+            success = virtio_pci_common_reg_write(dev, bar_offset - VIRTIO_PCI_COMMON_CFG_BAR_OFF, (uint32_t)*data);
         }
-    }
-    if (i == VIRTIO_PCI_MAX_MEM_BARS) {
-        LOG_PCI_ERR("Fault address 0x%lx is not located within any registered memory bars\n",
-                    registered_pci_memory_resource.vm_addr + offset);
-        return false;
-    }
-
-    // Search for the capability
-    uint32_t bar_offset = vmm_addr - global_memory_bars[i].vaddr;
-    virtio_device_t *dev = global_memory_bars[i].dev;
-    struct virtio_pci_cap *cap = find_pci_cap_by_offset(dev, global_memory_bars[i].idx, bar_offset);
-
-    virtio_pci_cfg_exception_handler_t cfg_handler = NULL;
-    switch (cap->cfg_type) {
-    case VIRTIO_PCI_CAP_COMMON_CFG:
-        cfg_handler = fault_is_read(fsr) ? virtio_pci_common_reg_read : virtio_pci_common_reg_write;
         break;
-    case VIRTIO_PCI_CAP_DEVICE_CFG:
-        cfg_handler = fault_is_read(fsr) ? virtio_pci_device_reg_read : virtio_pci_device_reg_write;
+    case REG_RANGE(VIRTIO_PCI_ISR_BAR_OFF, VIRTIO_PCI_DEVICE_CFG_BAR_OFF):
+        if (is_read) {
+            success = virtio_pci_isr_read(dev, bar_offset - VIRTIO_PCI_ISR_BAR_OFF, (uint32_t *)data);
+        } else {
+            LOG_VIRTIO_PCI_ERR("driver must not write to ISR\n");
+            success = false;
+        }
         break;
-    case VIRTIO_PCI_CAP_NOTIFY_CFG:
-        cfg_handler = fault_is_read(fsr) ? virtio_pci_notify_reg_read : virtio_pci_notify_reg_write;
+    case REG_RANGE(VIRTIO_PCI_DEVICE_CFG_BAR_OFF, VIRTIO_PCI_NOTIFY_CFG_BAR_OFF):
+        if (is_read) {
+            success = virtio_pci_device_reg_read(dev, bar_offset - VIRTIO_PCI_DEVICE_CFG_BAR_OFF, (uint32_t *)data);
+        } else {
+            success = virtio_pci_device_reg_write(dev, bar_offset - VIRTIO_PCI_DEVICE_CFG_BAR_OFF, (uint32_t)*data);
+        }
         break;
-    case VIRTIO_PCI_CAP_ISR_CFG:
-        cfg_handler = fault_is_read(fsr) ? virtio_pci_isr_reg_read : virtio_pci_isr_reg_write;
+    case REG_RANGE(VIRTIO_PCI_NOTIFY_CFG_BAR_OFF, VIRTIO_PCI_DEFAULT_BAR_SIZE):
+        if (is_read) {
+            LOG_VIRTIO_PCI_ERR("driver must not read from notify\n");
+            success = false;
+        } else {
+            success = virtio_pci_notify_reg_write(dev, bar_offset - VIRTIO_PCI_NOTIFY_CFG_BAR_OFF, (uint32_t)*data);
+        }
         break;
     default:
-        LOG_PCI_INFO("Unimplemented bar fault handler for type: 0x%x\n", cap->cfg_type);
-        break;
+        /* Unreachable. */
+        assert(0);
     }
 
-    if (cfg_handler) {
-        return cfg_handler(dev, vcpu_id, bar_offset - cap->offset, fsr, regs);
-    }
-    return false;
-}
-
-bool virtio_pci_register_memory_resource(uintptr_t vm_addr, uintptr_t vmm_addr, uint32_t size)
-{
-    // We assume that there is only one memory resource for each VM.
-    registered_pci_memory_resource.vm_addr = vm_addr;
-    registered_pci_memory_resource.vmm_addr = vmm_addr;
-    registered_pci_memory_resource.size = size;
-    registered_pci_memory_resource.free_offset = 0;
-
-    bool success = fault_register_vm_exception_handler(vm_addr, size, &virtio_pci_bar_fault_handle, NULL);
-
-    if (!success) {
-        LOG_PCI_ERR("Could not register virtual memory fault handler for pci device");
-    }
     return success;
 }
 
-static bool handle_virtio_ecam_reg_write(virtio_device_t *dev, size_t vcpu_id, size_t offset, size_t fsr,
-                                         seL4_UserContext *regs)
-{
-    uint32_t data = fault_get_data(regs, fsr);
-    struct pci_config_space *config_space = virtio_pci_find_dev_cfg_space(dev);
-
-    switch (offset) {
-    case REG_RANGE(PCI_CFG_OFFSET_COMMAND, PCI_CFG_OFFSET_STATUS): {
-        config_space->command = data & (PCI_COMMAND_MEMORY | PCI_COMMAND_MASTER);
-        break;
-    }
-    case REG_RANGE(PCI_CFG_OFFSET_STATUS, PCI_CFG_OFFSET_BAR1): {
-        config_space->status = data;
-        break;
-    }
-    case REG_RANGE(PCI_CFG_OFFSET_BAR1, PCI_CFG_OFFSET_BAR2): {
-        uint8_t dev_bar_id = (offset - PCI_CFG_OFFSET_BAR1) % 0x4;
-        uint32_t global_bar_id = dev->transport.pci.mem_bar_ids[dev_bar_id];
-
-        // Memory negotiation process:
-        //     1. The driver writes all 1s to the BAR register.
-        //     2. The device writes the size mask ~(size - 1) to the BAR register.
-        //     3. The driver writes the original value (all 0s in our code) back
-        //         to the BAR register. (no action from the device)
-        //     4. The driver allocates memory from the memory resources, and writes
-        //         the allocated address to the BAR register.
-        //     5. The device parse the memory address and bookkeep it.
-        if (global_memory_bars[global_bar_id].size) {
-            if (data == 0xFFFFFFFF) {
-                struct pci_bar_memory_bits *bar = (struct pci_bar_memory_bits *)&(config_space->bar[dev_bar_id]);
-                bar->base_address = (~(global_memory_bars[global_bar_id].size - 1)) >> 4;
-            } else if (data != 0x0) {
-                struct pci_bar_memory_bits *bar = (struct pci_bar_memory_bits *)&config_space->bar[dev_bar_id];
-                uintptr_t allocated_addr = data & 0xFFFFFFF0;   // Ignore control bits
-                bar->base_address = allocated_addr >> 4;        // 16-byte aligned
-                global_memory_bars[global_bar_id].vaddr = allocated_addr - registered_pci_memory_resource.vm_addr
-                                                        + registered_pci_memory_resource.vmm_addr;
-            }
-        }
-        break;
-    }
-    }
-    return true;
-}
-
-static bool virtio_ecam_fault_handle(size_t vcpu_id, size_t offset, size_t fsr, seL4_UserContext *regs, void *data)
-{
-    uint32_t dev_table_idx = (((offset >> 20) * VIRTIO_PCI_DEVS_PER_BUS) + (offset >> 15) & 0x1F)
-                               * VIRTIO_PCI_FUNCS_PER_DEV
-                           + ((offset >> 12) & 7);
-    virtio_device_t *dev = virtio_pci_dev_table[dev_table_idx];
-
-    if (fault_is_read(fsr)) {
-        uint32_t mask = fault_get_data_mask(offset, fsr);
-        uint32_t data = 0;
-        if (dev) {
-            uint32_t *reg = (uint32_t *)virtio_pci_find_dev_cfg_space(dev);
-            data = reg[(offset & 0xFF) / 4];
-        }
-        fault_emulate_write(regs, offset, fsr, data & mask);
-        return true;
-    } else {
-        return handle_virtio_ecam_reg_write(dev, vcpu_id, offset & 0xFF, fsr, regs);
-    }
-}
-
-/*
- * If the guest acknowledges the virtual IRQ associated with the virtIO
- * device, there is nothing that we need to do.
- */
-static void virtio_virq_default_ack(size_t vcpu_id, int irq, void *cookie)
-{
-}
-
-bool virtio_pci_alloc_dev_cfg_space(virtio_device_t *dev, uint8_t dev_slot)
-{
-    // Always use the only bus and func for each device.
-    uint16_t bus_id = 0;
-    uint8_t func_id = 0;
-
-    uint32_t dev_table_idx = ((bus_id * VIRTIO_PCI_DEVS_PER_BUS) + dev_slot) * VIRTIO_PCI_FUNCS_PER_DEV + func_id;
-
-    if (virtio_pci_dev_table[dev_table_idx]) {
-        LOG_PCI_ERR("The config space for 0x%4x:0x%2x:0x%2x,0x%x has been taken.\n", 0, bus_id, dev_slot, func_id);
-        return false;
-    }
-
-    dev->transport.pci.dev_table_idx = dev_table_idx;
-    virtio_pci_dev_table[dev_table_idx] = dev;
-    return true;
-}
-
-bool virtio_pci_ecam_init(uintptr_t ecam_base_vm, uintptr_t ecam_base_vmm, uint32_t ecam_size)
-{
-    global_pci_ecam.vm_base = ecam_base_vm;
-    global_pci_ecam.vmm_base = ecam_base_vmm;
-    global_pci_ecam.size = ecam_size;
-
-    bool success = fault_register_vm_exception_handler(ecam_base_vm, ecam_size, &virtio_ecam_fault_handle, NULL);
-
-    if (!success) {
-        LOG_PCI_ERR("Could not register virtual memory fault handler for PCI ECAM area!\n");
-    }
-    return success;
-}
-
-bool virtio_pci_register_device(virtio_device_t *dev, int virq)
+bool virtio_pci_register_device(virtio_device_t *dev, uint16_t pci_bus, uint16_t pci_dev, int virq)
 {
     assert(dev->transport_type == VIRTIO_TRANSPORT_PCI);
 
-    struct pci_config_space *config_space = virtio_pci_find_dev_cfg_space(dev);
+    pci_device_register_data_t device_data = (pci_device_register_data_t) {
+        .vendor_id = dev->transport.pci.vendor_id,
+        .device_id = dev->transport.pci.device_id,
+        .command = (PCI_COMMAND_MEMORY | PCI_COMMAND_MASTER),
+        .status = PCI_STATUS_CAP_LIST,
+        .revision_id = VIRTIO_PCI_REVISION,
+        .subclass = PCI_SUB_CLASS(dev->transport.pci.device_class),
+        .class_code = PCI_CLASS_CODE(dev->transport.pci.device_class),
+        .subsystem_vendor_id = dev->regs.VendorID,
+        .subsystem_device_id = dev->regs.DeviceID,
+    };
 
-    config_space->vendor_id = dev->transport.pci.vendor_id;
-    config_space->device_id = dev->transport.pci.device_id;
-    config_space->command = (PCI_COMMAND_MEMORY | PCI_COMMAND_MASTER);
-    config_space->status = PCI_STATUS_CAP_LIST;
-    config_space->revision_id = VIRTIO_PCI_REVISION;
-    config_space->subclass = PCI_SUB_CLASS(dev->transport.pci.device_class);
-    config_space->class_code = PCI_CLASS_CODE(dev->transport.pci.device_class);
-    config_space->subsystem_vendor_id = dev->regs.VendorID;
-    config_space->subsystem_device_id = dev->regs.DeviceID;
+    pci_dev_handle_t handle = pci_register_device(pci_bus, pci_dev, 0, &device_data);
+    if (handle == INVALID_PCI_DEVICE_HANDLE) {
+        return false;
+    }
 
-    // Always use dev's first interrupt pin specified in interrupt-map
-    config_space->interrupt_pin = 0x1;
+    /* When the guest ACKs the IRQ there is nothing to do */
+    if (!pci_register_device_irq(handle, virq, NULL, NULL)) {
+        return false;
+    }
 
-    bool success = true;
-    config_space->cap_ptr = 0x40;
-    success = pci_add_capability(dev, PCI_CAP_ID_VNDR, VIRTIO_PCI_CAP_COMMON_CFG, 0);
-    assert(success);
-    success = pci_add_capability(dev, PCI_CAP_ID_VNDR, VIRTIO_PCI_CAP_ISR_CFG, 0);
-    assert(success);
-    success = pci_add_capability(dev, PCI_CAP_ID_VNDR, VIRTIO_PCI_CAP_DEVICE_CFG, 0);
-    assert(success);
-    success = pci_add_capability(dev, PCI_CAP_ID_VNDR, VIRTIO_PCI_CAP_NOTIFY_CFG, 0);
-    assert(success);
-    success = pci_add_capability(dev, PCI_CAP_ID_VNDR, VIRTIO_PCI_CAP_PCI_CFG, 0);
-    assert(success);
+    if (!pci_register_device_mmio_bar(handle, 0, VIRTIO_PCI_DEFAULT_BAR_SIZE, virtio_pci_bar_fault_handle,
+                                      (void *)dev)) {
+        return false;
+    }
 
-    /* Register the virtual IRQ that will be used to communicate from the device
-     * to the guest. This assumes that the interrupt controller is already setup. */
-    success = virq_register(GUEST_BOOT_VCPU_ID, virq, &virtio_virq_default_ack, NULL);
-    assert(success);
+    /* Create all the virtIO specific capabilities */
+    struct virtio_pci_cap common_cfg_cap = (struct virtio_pci_cap) {
+        .cap_len = sizeof(struct virtio_pci_cap) + 2, // @billn sort out, include header legnth
+        .cfg_type = VIRTIO_PCI_CAP_COMMON_CFG,
+        .bar = 0,
+        .id = 0,
+        .offset = VIRTIO_PCI_COMMON_CFG_BAR_OFF,
+        .length = 0x1000,
+    };
+    if (!pci_register_device_capability(handle, PCI_CAP_ID_VNDR, &common_cfg_cap, sizeof(struct virtio_pci_cap))) {
+        return false;
+    }
 
-    return success;
+    struct virtio_pci_cap isr_cap = (struct virtio_pci_cap) {
+        .cap_len = sizeof(struct virtio_pci_cap) + 2,
+        .cfg_type = VIRTIO_PCI_CAP_ISR_CFG,
+        .bar = 0,
+        .id = 0,
+        .offset = VIRTIO_PCI_ISR_BAR_OFF,
+        .length = 0x1000,
+    };
+    if (!pci_register_device_capability(handle, PCI_CAP_ID_VNDR, &isr_cap, sizeof(struct virtio_pci_cap))) {
+        return false;
+    }
+
+    struct virtio_pci_cap device_cfg_cap = (struct virtio_pci_cap) {
+        .cap_len = sizeof(struct virtio_pci_cap) + 2,
+        .cfg_type = VIRTIO_PCI_CAP_DEVICE_CFG,
+        .bar = 0,
+        .id = 0,
+        .offset = VIRTIO_PCI_DEVICE_CFG_BAR_OFF,
+        .length = 0x1000,
+    };
+    if (!pci_register_device_capability(handle, PCI_CAP_ID_VNDR, &device_cfg_cap, sizeof(struct virtio_pci_cap))) {
+        return false;
+    }
+
+    struct virtio_pci_notify_cap ntfn_cap = (struct virtio_pci_notify_cap) {
+        .cap =
+            (struct virtio_pci_cap) {
+                .cap_len = sizeof(struct virtio_pci_notify_cap) + 2,
+                .cfg_type = VIRTIO_PCI_CAP_NOTIFY_CFG,
+                .bar = 0,
+                .id = 0,
+                .offset = VIRTIO_PCI_NOTIFY_CFG_BAR_OFF,
+                .length = 0x1000,
+            },
+        .notify_off_multiplier = VIRTIO_PCI_NOTIF_OFF_MULTIPLIER,
+    };
+    if (!pci_register_device_capability(handle, PCI_CAP_ID_VNDR, &ntfn_cap, sizeof(struct virtio_pci_notify_cap))) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -86,25 +86,25 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t offset, uint
     bool success = true;
 
     switch (offset) {
-    case REG_RANGE(VIRTIO_PCI_COMMON_DEV_FEATURE, VIRTIO_PCI_COMMON_DRI_FEATURE_SEL):
+    case VIRTIO_PCI_COMMON_DEV_FEATURE:
         success = dev->funs->get_device_features(dev, data);
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_NUM_QUEUES, VIRTIO_PCI_COMMON_DEV_STATUS):
-        *data = dev->num_vqs << 16;
+    case VIRTIO_PCI_COMMON_NUM_QUEUES:
+        *data = dev->num_vqs << 16; // @billn why << 16?
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_DEV_STATUS, VIRTIO_PCI_COMMON_CFG_GENERATION):
+    case VIRTIO_PCI_COMMON_DEV_STATUS:
         *data = dev->regs.Status;
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_CFG_GENERATION, VIRTIO_PCI_COMMON_Q_SIZE):
+    case VIRTIO_PCI_COMMON_CFG_GENERATION:
         *data = dev->regs.ConfigGeneration;
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_SIZE, VIRTIO_PCI_COMMON_Q_ENABLE):
+    case VIRTIO_PCI_COMMON_Q_SIZE:
         *data = VIRTIO_DEFAULT_QUEUE_SIZE;
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_ENABLE, VIRTIO_PCI_COMMON_Q_NOTIF_OFF):
+    case VIRTIO_PCI_COMMON_Q_ENABLE:
         *data = dev->vqs[dev->regs.QueueSel].ready;
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_NOTIF_OFF, VIRTIO_PCI_COMMON_Q_DESC_LO):
+    case VIRTIO_PCI_COMMON_Q_NOTIF_OFF:
         // proper way?
         *data = 1 << 16;
         break;
@@ -120,39 +120,39 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uin
     bool success = true;
 
     switch (offset) {
-    case REG_RANGE(VIRTIO_PCI_COMMON_DEV_FEATURE_SEL, VIRTIO_PCI_COMMON_DEV_FEATURE):
+    case VIRTIO_PCI_COMMON_DEV_FEATURE_SEL:
         dev->regs.DeviceFeaturesSel = data;
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_DRI_FEATURE_SEL, VIRTIO_PCI_COMMON_DRI_FEATURE):
+    case VIRTIO_PCI_COMMON_DRI_FEATURE_SEL:
         dev->regs.DriverFeaturesSel = data;
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_DRI_FEATURE, VIRTIO_PCI_COMMON_MSIX):
+    case VIRTIO_PCI_COMMON_DRI_FEATURE:
         success = dev->funs->set_driver_features(dev, data);
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_DEV_STATUS, VIRTIO_PCI_COMMON_CFG_GENERATION):
+    case VIRTIO_PCI_COMMON_DEV_STATUS:
         success = handle_virtio_pci_set_status_flag(dev, data);
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_SELECT, VIRTIO_PCI_COMMON_Q_SIZE):
+    case VIRTIO_PCI_COMMON_Q_SELECT:
         dev->regs.QueueSel = data;
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_SIZE, VIRTIO_PCI_COMMON_Q_ENABLE):
+    case VIRTIO_PCI_COMMON_Q_SIZE:
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = get_current_virtq_by_handler(dev);
             virtq->num = (unsigned int)data;
         } else {
             LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                               "given when accessing REG_VIRTIO_MMIO_QUEUE_NUM\n",
+                               "given when accessing VIRTIO_PCI_COMMON_Q_SIZE\n",
                                dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_ENABLE, VIRTIO_PCI_COMMON_Q_NOTIF_OFF):
+    case VIRTIO_PCI_COMMON_Q_ENABLE:
         if (data == 0x1) {
             dev->vqs[dev->regs.QueueSel].ready = true;
             // the virtq is already in ram so we don't need to do any initiation
         }
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_DESC_LO, VIRTIO_PCI_COMMON_Q_DESC_HI):
+    case VIRTIO_PCI_COMMON_Q_DESC_LO:
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
             uintptr_t ptr = (uintptr_t)virtq->desc_gpa;
@@ -160,12 +160,12 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uin
             virtq->desc_gpa = (struct virtq_desc *)ptr;
         } else {
             LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               "given when accessing VIRTIO_PCI_COMMON_Q_DESC_LO\n",
                                dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_DESC_HI, VIRTIO_PCI_COMMON_Q_AVAIL_LO):
+    case VIRTIO_PCI_COMMON_Q_DESC_HI:
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
             uintptr_t ptr = (uintptr_t)virtq->desc_gpa;
@@ -173,12 +173,12 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uin
             virtq->desc_gpa = (struct virtq_desc *)ptr;
         } else {
             LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                               "given when accessing REG_VIRTIO_MMIO_QUEUE_DESC_HIGH\n",
+                               "given when accessing VIRTIO_PCI_COMMON_Q_DESC_HI\n",
                                dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_AVAIL_LO, VIRTIO_PCI_COMMON_Q_AVAIL_HI):
+    case VIRTIO_PCI_COMMON_Q_AVAIL_LO:
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
             uintptr_t ptr = (uintptr_t)virtq->avail_gpa;
@@ -186,12 +186,12 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uin
             virtq->avail_gpa = (struct virtq_avail *)ptr;
         } else {
             LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               "given when accessing VIRTIO_PCI_COMMON_Q_AVAIL_LO\n",
                                dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_AVAIL_HI, VIRTIO_PCI_COMMON_Q_USED_LO):
+    case VIRTIO_PCI_COMMON_Q_AVAIL_HI:
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
             uintptr_t ptr = (uintptr_t)virtq->avail_gpa;
@@ -199,12 +199,12 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uin
             virtq->avail_gpa = (struct virtq_avail *)ptr;
         } else {
             LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               "given when accessing VIRTIO_PCI_COMMON_Q_AVAIL_HI\n",
                                dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_USED_LO, VIRTIO_PCI_COMMON_Q_USED_HI):
+    case VIRTIO_PCI_COMMON_Q_USED_LO:
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
             uintptr_t ptr = (uintptr_t)virtq->used_gpa;
@@ -212,12 +212,12 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uin
             virtq->used_gpa = (struct virtq_used *)ptr;
         } else {
             LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               "given when accessing VIRTIO_PCI_COMMON_Q_USED_LO\n",
                                dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }
         break;
-    case REG_RANGE(VIRTIO_PCI_COMMON_Q_USED_HI, VIRTIO_PCI_COMMON_Q_NOTIF_DATA):
+    case VIRTIO_PCI_COMMON_Q_USED_HI:
         if (dev->regs.QueueSel < dev->num_vqs) {
             struct virtq *virtq = &dev->vqs[dev->regs.QueueSel].virtq;
             uintptr_t ptr = (uintptr_t)virtq->used_gpa;
@@ -225,7 +225,7 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uin
             virtq->used_gpa = (struct virtq_used *)ptr;
         } else {
             LOG_VIRTIO_PCI_ERR("invalid virtq index 0x%x (number of virtqs is 0x%lx) "
-                               "given when accessing REG_VIRTIO_PCI_COMMAND_Q_DESC_LO\n",
+                               "given when accessing VIRTIO_PCI_COMMON_Q_USED_HI\n",
                                dev->regs.QueueSel, dev->num_vqs);
             success = false;
         }

--- a/vmm.mk
+++ b/vmm.mk
@@ -56,13 +56,13 @@ CFLAGS += -I${LIBVMM_DIR}/include
 endif
 
 ARCH_INDEP_FILES := \
-		    src/virtio/block.c \
 		    src/virtio/console.c \
-		    src/virtio/pci.c \
-		    src/virtio/net.c \
-		    src/virtio/sound.c \
+			src/virtio/block.c \
+			src/virtio/net.c \
 		    src/virtio/virtio.c \
+			src/virtio/pci.c \
 		    src/util/util.c \
+			src/pci.c \
 			src/guest_ram.c
 
 ifeq ($(ARCH),aarch64)


### PR DESCRIPTION
- Reworked virtual PCI bus from the ground up.
- Decoupled virtIO PCI devices emulation code from the transport layer.
- Previously the virtIO PCI code pulled in stuff from the virtIO MMIO code which made no sense, this PR cleaned this up amongst other misc issues with the virtIO code.
- Prepared virtIO console, block and network for integration on x86_64.

Closes https://github.com/au-ts/libvmm/issues/272

~~This is far from ready but opening a PR so I don't forget about it if I context switch.~~

Edit: this is ready now