### PR TITLE
Many fixes to virtio devices

### DIFF
--- a/include/libvmm/pci.h
+++ b/include/libvmm/pci.h
@@ -58,8 +58,8 @@ pci_dev_handle_t pci_register_device(uint8_t bus, uint8_t dev, uint8_t func, pci
 /* Register the virtual PCI device IRQ with the virtual IRQ controller. */
 bool pci_register_device_irq(pci_dev_handle_t pci_dev_handle, int virq, virq_ack_fn_t ack_fn, void *ack_data);
 
-/* Inject an IRQ into the guest from the given virtual PCI device. The IRQ must be registered first. */
-bool pci_inject_device_irq(pci_dev_handle_t pci_dev_handle);
+/* Set the device's IRQ status register in its configuration space. */
+bool pci_device_set_irq_status(pci_dev_handle_t pci_dev_handle, bool new_status);
 
 /* Add a capability to a virtual PCI device capability linked list. A PCI device capability
  * looks like this and is tightly packed:

--- a/include/libvmm/virtio/mmio.h
+++ b/include/libvmm/virtio/mmio.h
@@ -48,24 +48,6 @@
 #define VIRTIO_DEVICE_ID_CONSOLE      3
 #define VIRTIO_DEVICE_ID_SOUND        25
 
-/* Emulated MMIO registers for the virtIO device */
-typedef struct virtio_device_regs {
-    uint32_t DeviceID;
-    uint32_t VendorID;
-
-    uint32_t DeviceFeaturesSel;
-    uint32_t DriverFeaturesSel;
-
-    uint32_t QueueSel;
-    uint32_t QueueNotify;
-
-    uint32_t InterruptStatus;
-
-    uint32_t Status;
-
-    uint32_t ConfigGeneration;
-} virtio_device_regs_t;
-
 typedef struct virtio_mmio_data {
     uint32_t revision;
     uint32_t vendor_id;

--- a/include/libvmm/virtio/pci.h
+++ b/include/libvmm/virtio/pci.h
@@ -12,7 +12,7 @@
 #include <libvmm/util/util.h>
 
 /* PCI REVISION */
-#define VIRTIO_PCI_REVISION 0
+#define VIRTIO_PCI_REVISION 1
 
 /* Common configuration */
 #define VIRTIO_PCI_CAP_COMMON_CFG 1
@@ -55,11 +55,9 @@
 #define VIRTIO_PCI_COMMON_ADM_Q_NUM             0x3e
 #define VIRTIO_PCI_COMMON_END                   0x40
 
-#define VIRTIO_PCI_VENDOR_ID            0x1AF4
-#define VIRTIO_PCI_NET_DEV_ID           0x1000
-#define VIRTIO_PCI_BLK_DEV_ID           0x1001
-#define VIRTIO_PCI_CONSOLE_DEV_ID       0x1003
-#define VIRTIO_PCI_QUEUE_NUM_MAX        0x2
+#define VIRTIO_PCI_VENDOR_ID             0x1AF4
+#define VIRTIO_PCI_MODERN_BASE_DEVICE_ID 0x1040 // "non-transitional"
+#define VIRTIO_PCI_QUEUE_NUM_MAX         0x2
 
 typedef struct virtio_pci_data {
     uint32_t device_id;

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -67,6 +67,7 @@ typedef struct virtio_device_regs {
     uint32_t VendorID;
 
     uint32_t DeviceFeaturesSel;
+    uint32_t DriverFeatures;
     uint32_t DriverFeaturesSel;
 
     uint32_t QueueSel;

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -149,3 +149,5 @@ bool virtio_virtq_pop_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret);
  * place it in the used queue
  */
 void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint32_t bytes_written);
+
+void virtio_set_interrupt_status(struct virtio_device *dev, bool used_buffer, bool config_change);

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -61,6 +61,24 @@ typedef struct virtio_emul_funs {
     bool (*queue_notify)(virtio_device_t *dev);
 } virtio_device_funs_t;
 
+/* Emulated common registers for the virtIO device */
+typedef struct virtio_device_regs {
+    uint32_t DeviceID;
+    uint32_t VendorID;
+
+    uint32_t DeviceFeaturesSel;
+    uint32_t DriverFeaturesSel;
+
+    uint32_t QueueSel;
+    uint32_t QueueNotify;
+
+    uint32_t InterruptStatus;
+
+    uint32_t Status;
+
+    uint32_t ConfigGeneration;
+} virtio_device_regs_t;
+
 /* Everything needed at runtime for a virtIO device to function. */
 typedef struct virtio_device {
     virtio_transport_type_t transport_type;

--- a/src/pci.c
+++ b/src/pci.c
@@ -403,6 +403,31 @@ bool pci_register_device_irq(pci_dev_handle_t pci_dev_handle, int virq, virq_ack
     return success;
 }
 
+bool pci_device_set_irq_status(pci_dev_handle_t pci_dev_handle, bool new_status)
+{
+    if (!pci_bus_initialised_check()) {
+        return false;
+    }
+
+    if (!pci_device_exist_check(pci_dev_handle)) {
+        return false;
+    }
+
+    struct pci_device *pci_device = pci_get_device(pci_dev_handle);
+    if (!pci_device->virq_registered) {
+        LOG_PCI_ERR("IRQ not registered PCI dev handle %d\n", pci_dev_handle);
+        return false;
+    }
+
+    if (new_status) {
+        pci_device->config_space.status |= PCI_STATUS_INTERRUPT;
+    } else {
+        pci_device->config_space.status &= ~PCI_STATUS_INTERRUPT;
+    }
+
+    return true;
+}
+
 bool pci_register_device_capability(pci_dev_handle_t pci_dev_handle, uint8_t cap_id, void *payload,
                                     uint8_t payload_size)
 {

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -815,7 +815,7 @@ bool virtio_pci_blk_init(struct virtio_blk_device *blk_dev, uint16_t pci_bus, ui
     struct virtio_device *dev = virtio_blk_init(blk_dev, VIRTIO_TRANSPORT_PCI, virq, data_region, data_region_size,
                                                 storage_info, queue_h, queue_capacity, server_ch);
 
-    dev->transport.pci.device_id = VIRTIO_PCI_BLK_DEV_ID;
+    dev->transport.pci.device_id = VIRTIO_PCI_MODERN_BASE_DEVICE_ID + VIRTIO_DEVICE_ID_BLOCK;
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_STORAGE_SCSI;
 

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -157,10 +157,27 @@ static inline struct virtio_blk_device *device_state(struct virtio_device *dev)
     return (struct virtio_blk_device *)dev->device_data;
 }
 
+static void virtio_blk_regs_init(struct virtio_device *dev)
+{
+    dev->regs.DeviceID = VIRTIO_DEVICE_ID_BLOCK;
+    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
+}
+
 static inline void virtio_blk_reset(struct virtio_device *dev)
 {
-    dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].ready = false;
-    dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ].last_idx = 0;
+    for (int i = 0; i < dev->num_vqs; i++) {
+        dev->vqs[i].virtq.avail_gpa = 0;
+        dev->vqs[i].virtq.used_gpa = 0;
+        dev->vqs[i].virtq.desc_gpa = 0;
+        dev->vqs[i].last_idx = 0;
+        dev->vqs[i].ready = false;
+    }
+    assert(blk_queue_empty_req(&device_state(dev)->queue_h));
+    assert(blk_queue_empty_resp(&device_state(dev)->queue_h));
+    memset(&dev->regs, 0, sizeof(virtio_device_regs_t));
+    memset(device_state(dev)->reqsbk, 0, sizeof((device_state(dev)->reqsbk)));
+
+    virtio_blk_regs_init(dev);
 }
 
 static inline bool virtio_blk_get_device_features(struct virtio_device *dev, uint32_t *features)
@@ -759,8 +776,8 @@ static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, 
                                              uint32_t queue_capacity, int server_ch)
 {
     struct virtio_device *dev = &blk_dev->virtio_device;
-    dev->regs.DeviceID = VIRTIO_DEVICE_ID_BLOCK;
-    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
+
+    virtio_blk_regs_init(dev);
     dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = blk_dev->vqs;

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -236,6 +236,7 @@ static inline bool virtio_blk_set_driver_features(struct virtio_device *dev, uin
     }
 
     if (success) {
+        dev->regs.DriverFeatures = features;
         dev->features_happy = 1;
     }
 

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -256,14 +256,6 @@ static inline bool virtio_blk_virq_inject(struct virtio_device *dev)
     return virq_inject(dev->virq);
 }
 
-static inline void virtio_blk_set_interrupt_status(struct virtio_device *dev, bool used_buffer, bool config_change)
-{
-    /* Set the reason of the irq.
-       bit 0: used buffer
-       bit 1: configuration change */
-    dev->regs.InterruptStatus = used_buffer | (config_change << 1);
-}
-
 /* Check if ialloc and req queue are full.
  * If these all pass then a request without a payload (e.g. flush) can be handled successfully */
 static inline bool sddf_make_req_check(struct virtio_blk_device *state, uint16_t sddf_count)
@@ -549,7 +541,7 @@ static bool virtio_blk_queue_notify(struct virtio_device *dev)
     bool virq_inject_success = true;
     if (!consumption_status) {
         LOG_BLOCK("virtio_blk_queue_notify dropped requests\n");
-        virtio_blk_set_interrupt_status(dev, true, false);
+        virtio_set_interrupt_status(dev, true, false);
         virq_inject_success = virtio_blk_virq_inject(dev);
     }
 
@@ -719,7 +711,7 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
      */
     bool virq_inject_success = true;
     if (resp_handled && !read_write_modify_inflight && !virt_notify) {
-        virtio_blk_set_interrupt_status(dev, true, false);
+        virtio_set_interrupt_status(dev, true, false);
         virq_inject_success = virtio_blk_virq_inject(dev);
     }
 

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -317,7 +317,7 @@ bool virtio_pci_console_init(struct virtio_console_device *console, uint16_t pci
 {
     struct virtio_device *dev = virtio_console_init(console, VIRTIO_TRANSPORT_PCI, virq, rxq, txq, tx_ch, rx_ch);
 
-    dev->transport.pci.device_id = VIRTIO_PCI_CONSOLE_DEV_ID;
+    dev->transport.pci.device_id = VIRTIO_PCI_MODERN_BASE_DEVICE_ID + VIRTIO_DEVICE_ID_CONSOLE;
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_COMMUNICATION_OTHER;
 

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -130,10 +130,17 @@ static bool virtio_console_set_device_config(struct virtio_device *dev, uint32_t
 static bool virtio_console_handle_tx(struct virtio_device *dev)
 {
     LOG_CONSOLE("operation: handle transmit\n");
-    // @ivanv: we need to check the pre-conditions before doing anything. e.g check
-    // TX_QUEUE is ready?
-    assert(dev->num_vqs > TX_QUEUE);
+
+    if (dev->regs.QueueSel != TX_QUEUE) {
+        return true;
+    }
+
     struct virtio_queue_handler *vq = &dev->vqs[TX_QUEUE];
+    if (!vq->ready) {
+        LOG_VMM_ERR("virtio console TX vq not ready!\n");
+        return true;
+    }
+
     struct virtio_console_device *console = device_state(dev);
 
     /* Transmit all available descriptors possible */

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -108,6 +108,7 @@ static bool virtio_console_set_driver_features(struct virtio_device *dev, uint32
     }
 
     if (success) {
+        dev->regs.DriverFeatures = features;
         dev->features_happy = 1;
         LOG_CONSOLE("device is feature happy\n");
     }

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -41,6 +41,12 @@ static void virtio_console_features_print(uint32_t features)
                 BIT_LOW(VIRTIO_CONSOLE_F_EMERG_WRITE) & features ? "true" : "false");
 }
 
+static void virtio_console_regs_init(struct virtio_device *dev)
+{
+    dev->regs.DeviceID = VIRTIO_DEVICE_ID_CONSOLE;
+    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
+}
+
 static void virtio_console_reset(struct virtio_device *dev)
 {
     LOG_CONSOLE("operation: reset device\n");
@@ -48,7 +54,14 @@ static void virtio_console_reset(struct virtio_device *dev)
     for (int i = 0; i < dev->num_vqs; i++) {
         dev->vqs[i].ready = false;
         dev->vqs[i].last_idx = 0;
+        dev->vqs[i].virtq.avail_gpa = 0;
+        dev->vqs[i].virtq.used_gpa = 0;
+        dev->vqs[i].virtq.desc_gpa = 0;
+        dev->vqs[i].virtq.num = 0;
     }
+
+    memset(&dev->regs, 0, sizeof(virtio_device_regs_t));
+    virtio_console_regs_init(dev);
 }
 
 static bool virtio_console_get_device_features(struct virtio_device *dev, uint32_t *features)
@@ -287,14 +300,14 @@ static struct virtio_device *virtio_console_init(struct virtio_console_device *c
                                                  int tx_ch, int rx_ch)
 {
     struct virtio_device *dev = &console->virtio_device;
-    dev->regs.DeviceID = VIRTIO_DEVICE_ID_CONSOLE;
-    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
+
     dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = console->vqs;
     dev->num_vqs = VIRTIO_CONSOLE_NUM_VIRTQ;
     dev->virq = virq;
     dev->device_data = console;
+    virtio_console_regs_init(dev);
 
     console->rxq = rxq;
     console->txq = txq;

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -76,8 +76,8 @@ static bool virtio_net_get_device_features(struct virtio_device *dev, uint32_t *
         *features = BIT_HIGH(VIRTIO_F_VERSION_1);
         break;
     default:
-        LOG_NET_ERR("Bad DeviceFeaturesSel 0x%x\n", dev->regs.DeviceFeaturesSel);
-        return false;
+        *features = 0;
+        LOG_NET_ERR("Unimplemented DeviceFeaturesSel 0x%x\n", dev->regs.DeviceFeaturesSel);
     }
     return true;
 }
@@ -100,10 +100,12 @@ static bool virtio_net_set_driver_features(struct virtio_device *dev, uint32_t f
 
     default:
         LOG_NET_ERR("Bad DriverFeaturesSel 0x%x\n", dev->regs.DriverFeaturesSel);
-        success = false;
     }
     if (success) {
         dev->features_happy = 1;
+    } else {
+        LOG_NET_ERR("failed to set driver features with DriverFeaturesSel 0x%x, features: 0x%x\n",
+                    dev->regs.DriverFeaturesSel, features);
     }
     return success;
 }

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -384,7 +384,7 @@ bool virtio_pci_net_init(struct virtio_net_device *net_dev, uint16_t pci_bus, ui
     struct virtio_device *dev = virtio_net_init(net_dev, VIRTIO_TRANSPORT_PCI, virq, rx, tx, rx_data, tx_data, rx_ch,
                                                 tx_ch, mac);
 
-    dev->transport.pci.device_id = VIRTIO_PCI_NET_DEV_ID;
+    dev->transport.pci.device_id = VIRTIO_PCI_MODERN_BASE_DEVICE_ID + VIRTIO_DEVICE_ID_NET;
     dev->transport.pci.vendor_id = VIRTIO_PCI_VENDOR_ID;
     dev->transport.pci.device_class = PCI_CLASS_NETWORK_ETHERNET;
 

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -102,6 +102,7 @@ static bool virtio_net_set_driver_features(struct virtio_device *dev, uint32_t f
         LOG_NET_ERR("Bad DriverFeaturesSel 0x%x\n", dev->regs.DriverFeaturesSel);
     }
     if (success) {
+        dev->regs.DriverFeatures = features;
         dev->features_happy = 1;
     } else {
         LOG_NET_ERR("failed to set driver features with DriverFeaturesSel 0x%x, features: 0x%x\n",

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -31,13 +31,26 @@ static inline struct virtio_net_device *device_state(struct virtio_device *dev)
     return (struct virtio_net_device *)dev->device_data;
 }
 
+static void virtio_net_regs_init(struct virtio_device *dev)
+{
+    dev->regs.DeviceID = VIRTIO_DEVICE_ID_NET;
+    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
+}
+
 static void virtio_net_reset(struct virtio_device *dev)
 {
     LOG_NET("operation: reset\n");
     for (int i = 0; i < dev->num_vqs; i++) {
         dev->vqs[i].ready = false;
         dev->vqs[i].last_idx = 0;
+        dev->vqs[i].virtq.avail_gpa = 0;
+        dev->vqs[i].virtq.used_gpa = 0;
+        dev->vqs[i].virtq.desc_gpa = 0;
+        dev->vqs[i].virtq.num = 0;
     }
+
+    memset(&dev->regs, 0, sizeof(virtio_device_regs_t));
+    virtio_net_regs_init(dev);
 }
 
 static bool driver_ok(struct virtio_device *dev)
@@ -346,8 +359,7 @@ static struct virtio_device *virtio_net_init(struct virtio_net_device *net_dev, 
 {
     struct virtio_device *dev = &net_dev->virtio_device;
 
-    dev->regs.DeviceID = VIRTIO_DEVICE_ID_NET;
-    dev->regs.VendorID = VIRTIO_DEV_VENDOR_ID;
+    virtio_net_regs_init(dev);
     dev->transport_type = type;
     dev->funs = &functions;
     dev->vqs = net_dev->vqs;

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -244,7 +244,11 @@ static bool virtio_pci_common_reg_write(virtio_device_t *dev, size_t offset, uin
 static bool virtio_pci_isr_read(virtio_device_t *dev, size_t offset, uint32_t *data)
 {
     *data = dev->regs.InterruptStatus;
-    dev->regs.InterruptStatus = 0;
+    /*
+     * virtIO spec section 4.1.4.5.1 Device Requirements: ISR status capability
+     * "The device MUST reset ISR status to 0 on driver read."
+     */
+    virtio_set_interrupt_status(dev, false, false);
     return true;
 }
 

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -87,6 +87,9 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t offset, uint
     case VIRTIO_PCI_COMMON_DEV_FEATURE_SEL:
         *data = dev->regs.DeviceFeaturesSel;
         break;
+    case VIRTIO_PCI_COMMON_DRI_FEATURE:
+        *data = dev->regs.DriverFeatures;
+        break;
     case VIRTIO_PCI_COMMON_DEV_FEATURE:
         success = dev->funs->get_device_features(dev, data);
         break;

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <libvmm/guest_ram.h>
+#include <libvmm/pci.h>
 #include <libvmm/virtio/virtq.h>
 #include <libvmm/virtio/virtio.h>
 
@@ -204,4 +205,25 @@ void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_hea
     used_elem->id = desc_head;
     used_elem->len = len;
     used_ring->idx++;
+}
+
+void virtio_set_interrupt_status(struct virtio_device *dev, bool used_buffer, bool config_change)
+{
+    /* Set the reason of the irq.
+       bit 0: used buffer
+       bit 1: configuration change */
+    dev->regs.InterruptStatus = 0;
+    if (used_buffer) {
+        dev->regs.InterruptStatus |= 0x1;
+    }
+    if (config_change) {
+        dev->regs.InterruptStatus |= 0x2;
+    }
+
+    if (dev->transport_type == VIRTIO_TRANSPORT_PCI) {
+        /*
+         * virtIO spec 4.1.4.5.1 Device Requirements: ISR status capability
+         */
+        assert(pci_device_set_irq_status(dev->transport.pci.pci_handle, dev->regs.InterruptStatus != 0));
+    }
 }


### PR DESCRIPTION
Most of these fixes were backported from the `windows` branch, in preparation for upstreaming other things from that branch such as UEFI firmware and Windows VM booting.