### PR TITLE
virtio: refactor IRQ handling, made PCI IRQ level triggered 

### DIFF
--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -143,4 +143,8 @@ bool virtio_virtq_pop_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret);
  */
 void virtio_virtq_add_used(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint32_t bytes_written);
 
+/* Set the device's interrupt status, then deassert the virtual interrupt line if needed. */
 void virtio_set_interrupt_status(struct virtio_device *dev, bool used_buffer, bool config_change);
+
+/* Inject an interrupt into the guest according to the device's transport type. */
+bool virtio_inject_interrupt(struct virtio_device *dev);

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -555,7 +555,7 @@ static bool virtio_blk_queue_notify(struct virtio_device *dev)
     if (!consumption_status) {
         LOG_BLOCK("virtio_blk_queue_notify dropped requests\n");
         virtio_set_interrupt_status(dev, true, false);
-        virq_inject_success = virq_inject(dev->irq_routing_info);
+        virq_inject_success = virtio_inject_interrupt(dev);
     }
 
     struct virtio_blk_device *state = device_state(dev);
@@ -725,7 +725,7 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
     bool virq_inject_success = true;
     if (resp_handled && !read_write_modify_inflight && !virt_notify) {
         virtio_set_interrupt_status(dev, true, false);
-        virq_inject_success = virq_inject(dev->irq_routing_info);
+        virq_inject_success = virtio_inject_interrupt(dev);
     }
 
     if (virt_notify) {

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -207,7 +207,7 @@ static bool virtio_console_handle_tx(struct virtio_device *dev)
      * available data. In this case we do not set the IRQ status. */
     if (transferred) {
         virtio_set_interrupt_status(dev, true, false);
-        bool success = virq_inject(dev->irq_routing_info);
+        bool success = virtio_inject_interrupt(dev);
 
         microkit_notify(console->tx_ch);
         return success;
@@ -266,7 +266,7 @@ static bool virtio_console_handle_rx(struct virtio_console_device *console)
      * available data. In this case we do not set the IRQ status. */
     if (transferred) {
         virtio_set_interrupt_status(&console->virtio_device, true, false);
-        bool success = virq_inject(console->virtio_device.irq_routing_info);
+        bool success = virtio_inject_interrupt(&console->virtio_device);
         return success;
     }
 

--- a/src/virtio/mmio.c
+++ b/src/virtio/mmio.c
@@ -313,12 +313,6 @@ static void virtio_virq_default_ack(irq_routing_info_t irq_routing_info, void *c
 {
 }
 
-bool virtio_mmio_irq_inject(virtio_device_t *dev)
-{
-    /* @billn, this whole MMIO thing should be refactored into two distinct bus + device layer like PCI. */
-    return virq_inject(dev->irq_routing_info);
-}
-
 bool virtio_mmio_register_device(virtio_device_t *dev, uintptr_t region_base, uintptr_t region_size,
                                  irq_routing_info_t irq_routing_info)
 {

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -141,7 +141,7 @@ static bool virtio_net_set_device_config(struct virtio_device *dev, uint32_t off
 static bool virtio_net_respond(struct virtio_device *dev)
 {
     virtio_set_interrupt_status(dev, true, false);
-    bool success = virq_inject(dev->irq_routing_info);
+    bool success = virtio_inject_interrupt(dev);
     return success;
 }
 

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -225,5 +225,23 @@ void virtio_set_interrupt_status(struct virtio_device *dev, bool used_buffer, bo
          * virtIO spec 4.1.4.5.1 Device Requirements: ISR status capability
          */
         assert(pci_device_set_irq_status(dev->transport.pci.pci_handle, dev->regs.InterruptStatus != 0));
+        /* Since PCI INTx IRQ is level triggered we must deassert the line. */
+        if (!dev->regs.InterruptStatus) {
+            virq_set_level(dev->irq_routing_info, false);
+        }
+    }
+}
+
+bool virtio_inject_interrupt(struct virtio_device *dev)
+{
+    switch (dev->transport_type) {
+    case VIRTIO_TRANSPORT_PCI:
+        /* PCI INTx IRQ is level triggered. */
+        return virq_set_level(dev->irq_routing_info, true);
+    case VIRTIO_TRANSPORT_MMIO:
+        return virq_inject(dev->irq_routing_info);
+    default:
+        assert(0);
+        return false;
     }
 }


### PR DESCRIPTION
Previously the code treated virtual PCI devices' interrupts as edge triggered which is incorrect.

Depends on https://github.com/au-ts/libvmm/pull/296