### PR TITLE
apic: fix IRQ dropping when the line is unmasked

### DIFF
--- a/src/arch/x86_64/apic.c
+++ b/src/arch/x86_64/apic.c
@@ -731,6 +731,12 @@ bool ioapic_fault_handle(seL4_VCPUContext *vctx, uint64_t offset, seL4_Word qual
                                 ioapic_regs.virq_handle_map[i].ack_fn(X86_IOAPIC_IRQ_ROUTE(0, 1),
                                                                       ioapic_regs.virq_handle_map[i].ack_data);
                             }
+
+                            /* Attempt reinjection as well */
+                            if (ioapic_regs.pin_asserted[i]) {
+                                inject_ioapic_irq(0, i);
+                            }
+
                             break;
                         }
                     }


### PR DESCRIPTION
For level triggered interrupts, when the I/O APIC line is unmasked, we should check whether the line is still asserted and reinject the interrupt to not lose the edge.