### PR TITLE
hpet: add missing timer handle invalidate

### DIFF
--- a/src/arch/x86_64/hpet.c
+++ b/src/arch/x86_64/hpet.c
@@ -182,6 +182,8 @@ void hpet_handle_timer_ntfn(uint64_t comparator)
 {
     assert(comparator <= NUM_TIM_CAP_VAL);
 
+    hpet_regs.comparators[comparator].timeout_handle_valid = false;
+
     if (!counter_on()) {
         return;
     }


### PR DESCRIPTION
This can cause the HPET to cancel the LAPIC or other timer devices' timeouts.