### PR TITLE
scripts/package_image.sh: recursive copy for metadata

### DIFF
--- a/scripts/package_image.sh
+++ b/scripts/package_image.sh
@@ -21,7 +21,7 @@ mkdir "$DIR_NAME"
 cp "$IMAGE_PATH" "$DIR_NAME"
 if [ "$METADATA_PATH" ];
 then
-    cp "$METADATA_PATH" "$DIR_NAME"
+    cp -r "$METADATA_PATH" "$DIR_NAME"
 fi
 
 tar cf "$TAR_NAME" "$DIR_NAME"


### PR DESCRIPTION
This is useful for internal development when we need to include multiple metadata such as symbol files, etc with a binary that needs to be downloaded from TS website.