### PR TITLE
package_guest_images.S: add firmware support

### DIFF
--- a/tools/package_guest_images.S
+++ b/tools/package_guest_images.S
@@ -51,3 +51,11 @@ _guest_dsdt_aml:
 .incbin GUEST_DSDT_AML_PATH
 _guest_dsdt_aml_end:
 #endif
+
+#if defined(GUEST_FIRMWARE_PATH)
+.section .guest_firmware, "aw", @progbits
+.global _guest_firmware, _guest_firmware_end
+_guest_firmware:
+.incbin GUEST_FIRMWARE_PATH
+_guest_firmware_end:
+#endif


### PR DESCRIPTION
Added support for packaging a firmware with the VMM in package_guest_images.S.

Precursor for PR https://github.com/au-ts/libvmm/pull/313 and issue https://github.com/au-ts/libvmm/issues/278.