### PR TITLE
x86_64: refactor and fix incorrect PIO read behaviour 

### DIFF
--- a/include/libvmm/arch/x86_64/ioports.h
+++ b/include/libvmm/arch/x86_64/ioports.h
@@ -9,10 +9,18 @@
 #include <stdbool.h>
 #include <libvmm/util/util.h>
 
+/* Utility functions to decode a PIO VM Exit qualification. */
 bool pio_fault_is_read(seL4_Word qualification);
 bool pio_fault_is_write(seL4_Word qualification);
 bool pio_fault_is_string_op(seL4_Word qualification);
 uint16_t pio_fault_addr(seL4_Word qualification);
 int pio_fault_to_access_width_bytes(seL4_Word qualification);
 
-void emulate_ioport_noop_access(seL4_VCPUContext *vctx, uint64_t f_qualification);
+/* Write the result of a port IO read emulation to vCPU general purpose registers
+ * while respecting architectural rules. */
+void pio_emulate_read(uint64_t qualification, seL4_VCPUContext *vctx, uint32_t data);
+
+/* Retrieve the data of a port IO write instruction. */
+uint32_t pio_get_write_data(uint64_t qualification, seL4_VCPUContext *vctx);
+
+void emulate_ioport_noop_access(uint64_t qualification, seL4_VCPUContext *vctx);

--- a/src/arch/x86_64/acpi.c
+++ b/src/arch/x86_64/acpi.c
@@ -173,9 +173,9 @@ bool pm1a_cnt_pio_fault_handle(size_t vcpu_id, uint16_t port_offset, size_t qual
 
     if (port_offset == 0) {
         if (pio_fault_is_read(qualification)) {
-            vctx->eax = pm1_control_reg;
+            pio_emulate_read(qualification, vctx, pm1_control_reg);
         } else {
-            pm1_control_reg = vctx->eax & 0xffff;
+            pm1_control_reg = pio_get_write_data(qualification, vctx);
         }
 
     } else {
@@ -194,9 +194,9 @@ bool pm1a_evt_pio_fault_handle(size_t vcpu_id, uint16_t port_offset, size_t qual
 
     if (port_offset == 2) {
         if (pio_fault_is_read(qualification)) {
-            vctx->eax = pm1_enable_reg;
+            pio_emulate_read(qualification, vctx, pm1_enable_reg);
         } else {
-            pm1_enable_reg = vctx->eax;
+            pm1_enable_reg = pio_get_write_data(qualification, vctx);
             if (acpi_pm_timer_can_irq()) {
                 LOG_ACPI_INFO("ACPI PM Timer Overflow IRQ ON!\n");
                 assert(false);
@@ -204,10 +204,10 @@ bool pm1a_evt_pio_fault_handle(size_t vcpu_id, uint16_t port_offset, size_t qual
         }
     } else if (port_offset == 0) {
         if (pio_fault_is_read(qualification)) {
-            vctx->eax = pm1_status_reg;
+            pio_emulate_read(qualification, vctx, pm1_status_reg);
         } else {
             // @billn sus implement proper set to clear
-            pm1_status_reg = vctx->eax;
+            pm1_status_reg = pio_get_write_data(qualification, vctx);
         }
     } else {
         return false;
@@ -224,7 +224,8 @@ bool pm_timer_pio_fault_handle(size_t vcpu_id, uint16_t port_offset, size_t qual
     assert(access_width_bytes == 4);
     assert(pio_fault_is_read(qualification));
 
-    vctx->eax = convert_ticks_by_frequency(guest_time_tsc_now(), guest_time_tsc_hz(), ACPI_PMT_FREQ_HZ);
+    uint32_t result = convert_ticks_by_frequency(guest_time_tsc_now(), guest_time_tsc_hz(), ACPI_PMT_FREQ_HZ);
+    pio_emulate_read(qualification, vctx, result);
 
     return true;
 }
@@ -237,7 +238,7 @@ bool smi_cmd_pio_fault_handle(size_t vcpu_id, uint16_t port_offset, size_t quali
     assert(access_width_bytes == 1);
     assert(pio_fault_is_write(qualification));
 
-    uint8_t cmd = vctx->eax & 0xff;
+    uint8_t cmd = pio_get_write_data(qualification, vctx);
     if (cmd == ACPI_ENABLE) {
         pm1_control_reg |= BIT(0);
     } else if (cmd == ACPI_DISABLE) {

--- a/src/arch/x86_64/cmos.c
+++ b/src/arch/x86_64/cmos.c
@@ -57,10 +57,9 @@ static struct cmos_state cmos_state = (struct cmos_state) {
 static bool handle_select_port(size_t qualification, seL4_VCPUContext *vctx)
 {
     if (pio_fault_is_read(qualification)) {
-        uint64_t old_eax = vctx->eax;
-        vctx->eax = (((old_eax >> 8)) << 8) | cmos_state.select_reg;
+        pio_emulate_read(qualification, vctx, cmos_state.select_reg);
     } else {
-        cmos_state.select_reg = vctx->eax;
+        cmos_state.select_reg = pio_get_write_data(qualification, vctx);
     }
     return true;
 }
@@ -140,16 +139,15 @@ static bool handle_data_port(size_t qualification, seL4_VCPUContext *vctx)
             result = 0;
             break;
         }
-        uint64_t old_eax = vctx->eax;
-        vctx->eax = (((old_eax >> 8)) << 8) | result;
+        pio_emulate_read(qualification, vctx, result);
     } else {
         switch (selected_cmos_port()) {
         case CMOS_STS_A:
-            cmos_state.status_a = vctx->eax & 0xff;
+            cmos_state.status_a = pio_get_write_data(qualification, vctx);
             break;
         case CMOS_STS_B: {
             uint8_t old_sts_b = cmos_state.status_b;
-            cmos_state.status_b = vctx->eax & 0xff;
+            cmos_state.status_b = pio_get_write_data(qualification, vctx);
             uint8_t new_sts_b = cmos_state.status_b;
             if (!(old_sts_b & BIT(CMOS_STS_B_UIE)) && (new_sts_b & BIT(CMOS_STS_B_UIE))) {
                 LOG_VMM_ERR("rtc update ended interrupt unimplemented\n");
@@ -159,7 +157,8 @@ static bool handle_data_port(size_t qualification, seL4_VCPUContext *vctx)
             break;
         }
         default:
-            LOG_VMM_ERR("write to unimplemented CMOS reg 0x%x, data 0x%lx\n", selected_cmos_port(), vctx->eax);
+            LOG_VMM_ERR("write to unimplemented CMOS reg 0x%x, data 0x%x\n", selected_cmos_port(),
+                        pio_get_write_data(qualification, vctx));
         }
     }
 

--- a/src/arch/x86_64/fault.c
+++ b/src/arch/x86_64/fault.c
@@ -356,7 +356,7 @@ static bool handle_pio_fault(seL4_VCPUContext *vctx, seL4_Word qualification)
         }
     }
 
-    emulate_ioport_noop_access(vctx, qualification);
+    emulate_ioport_noop_access(qualification, vctx);
     return true;
 }
 

--- a/src/arch/x86_64/ioports.c
+++ b/src/arch/x86_64/ioports.c
@@ -68,28 +68,54 @@ uint16_t pio_fault_addr(seL4_Word qualification)
     return (qualification >> PIO_VIOLATION_ADDR_SHIFT) & PIO_VIOLATION_ADDR_MASK;
 }
 
-void emulate_ioport_noop_access(seL4_VCPUContext *vctx, uint64_t f_qualification)
+void pio_emulate_read(uint64_t qualification, seL4_VCPUContext *vctx, uint32_t data)
 {
-    uint64_t is_read = pio_fault_is_read(f_qualification);
-    uint64_t is_string = pio_fault_is_string_op(f_qualification);
+    assert(pio_fault_is_read(qualification));
+    /* We need to preserve the upper bits */
+    switch (pio_fault_to_access_width_bytes(qualification)) {
+    case 1:
+        vctx->eax = (vctx->eax & ~0xFFULL) | (data & 0xFFULL);
+        break;
+    case 2:
+        vctx->eax = (vctx->eax & ~0xFFFFULL) | (data & 0xFFFFULL);
+        break;
+    case 4:
+        /* In long mode this will zero extend. */
+        vctx->eax = data;
+        break;
+    default:
+        LOG_VMM_ERR("unreachable!\n");
+        assert(false);
+    }
+}
+
+uint32_t pio_get_write_data(uint64_t qualification, seL4_VCPUContext *vctx)
+{
+    assert(!pio_fault_is_read(qualification));
+    /* We need to preserve the upper bits */
+    switch (pio_fault_to_access_width_bytes(qualification)) {
+    case 1:
+        return vctx->eax & 0xFFULL;
+    case 2:
+        return vctx->eax & 0xFFFFULL;
+    case 4:
+        return vctx->eax & 0xFFFFFFFFULL;
+    default:
+        LOG_VMM_ERR("unreachable!\n");
+        assert(false);
+        return 0;
+    }
+}
+
+void emulate_ioport_noop_access(uint64_t qualification, seL4_VCPUContext *vctx)
+{
+    uint64_t is_read = pio_fault_is_read(qualification);
+    uint64_t is_string = pio_fault_is_string_op(qualification);
 
     assert(!is_string);
 
     if (is_read) {
         /* An invalid read of port I/O returns all 1s. */
-        switch (pio_fault_to_access_width_bytes(f_qualification)) {
-        case 1:
-            vctx->eax = 0xff;
-            break;
-        case 2:
-            vctx->eax = 0xffff;
-            break;
-        case 4:
-            vctx->eax = 0xffffffff;
-            break;
-        default:
-            LOG_VMM_ERR("unreachable!\n");
-            assert(false);
-        }
+        pio_emulate_read(qualification, vctx, 0xFFFFFFFF);
     }
 }

--- a/src/pci.c
+++ b/src/pci.c
@@ -373,7 +373,6 @@ static bool pci_pio_select_fault_handle(size_t vcpu_id, uint16_t port_offset, si
                                         seL4_VCPUContext *vctx, void *cookie)
 {
     if (pio_fault_is_read(qualification)) {
-        assert(pio_fault_addr(qualification) == PCI_CONFIG_ADDRESS_START_PORT);
         vctx->eax = pci_bus.pio_addr_value;
     } else {
         pci_bus.pio_addr_value = vctx->eax;

--- a/src/pci.c
+++ b/src/pci.c
@@ -373,9 +373,9 @@ static bool pci_pio_select_fault_handle(size_t vcpu_id, uint16_t port_offset, si
                                         seL4_VCPUContext *vctx, void *cookie)
 {
     if (pio_fault_is_read(qualification)) {
-        vctx->eax = pci_bus.pio_addr_value;
+        pio_emulate_read(qualification, vctx, pci_bus.pio_addr_value);
     } else {
-        pci_bus.pio_addr_value = vctx->eax;
+        pci_bus.pio_addr_value = pio_get_write_data(qualification, vctx);
     }
 
     return true;
@@ -420,19 +420,19 @@ static bool pci_pio_data_fault_handle(size_t vcpu_id, uint16_t port_offset, size
     bool success;
     pci_dev_handle_t handle = pci_geo_addr_to_internal_index(bus, dev, func);
     if (pio_fault_is_read(qualification)) {
+        uint64_t result = 0;
         success = pci_ecam_emulate_access(handle, pio_fault_is_read(qualification), access_width_bytes,
-                                          config_space_off, &vctx->eax);
+                                          config_space_off, &result);
 
-        vctx->eax >>= (config_space_off - ROUND_DOWN(config_space_off, 4)) * 8;
+        /* pci_ecam_emulate_access() reads in multiple of 32-bit, so we must shift the answer to get
+         * the correct data. */
+        result >>= (config_space_off - ROUND_DOWN(config_space_off, 4)) * 8;
 
-        if (access_width_bytes == 1) {
-            vctx->eax &= 0xff;
-        } else if (access_width_bytes == 2) {
-            vctx->eax &= 0xffff;
-        }
+        pio_emulate_read(qualification, vctx, result);
     } else {
+        uint64_t data = pio_get_write_data(qualification, vctx);
         success = pci_ecam_emulate_access(handle, pio_fault_is_read(qualification), access_width_bytes,
-                                          config_space_off, &vctx->eax);
+                                          config_space_off, &data);
     }
 
     return success;

--- a/src/pci.c
+++ b/src/pci.c
@@ -388,7 +388,7 @@ static bool pci_pio_data_fault_handle(size_t vcpu_id, uint16_t port_offset, size
     assert(!pio_fault_is_string_op(qualification));
 
     if (!pci_pio_addr_reg_enable(pci_bus.pio_addr_value)) {
-        emulate_ioport_noop_access(vctx, qualification);
+        emulate_ioport_noop_access(qualification, vctx);
         return true;
     }
 
@@ -396,15 +396,15 @@ static bool pci_pio_data_fault_handle(size_t vcpu_id, uint16_t port_offset, size
     uint8_t dev = pci_pio_addr_reg_dev(pci_bus.pio_addr_value);
     uint8_t func = pci_pio_addr_reg_func(pci_bus.pio_addr_value);
     if (bus >= PCI_NUM_BUS) {
-        emulate_ioport_noop_access(vctx, qualification);
+        emulate_ioport_noop_access(qualification, vctx);
         return true;
     }
     if (dev >= PCI_DEV_PER_BUS) {
-        emulate_ioport_noop_access(vctx, qualification);
+        emulate_ioport_noop_access(qualification, vctx);
         return true;
     }
     if (func >= PCI_FUNC_PER_DEV) {
-        emulate_ioport_noop_access(vctx, qualification);
+        emulate_ioport_noop_access(qualification, vctx);
         return true;
     }
 


### PR DESCRIPTION
A port IO read must preserve bits in RAX that is not part of the operation. For example, an 8-bit read must preserve the high 56-bit.

Added helper functions for any devices on the IO bus to correctly implement this behaviour.

Precursor for PR https://github.com/au-ts/libvmm/pull/313 and issue https://github.com/au-ts/libvmm/issues/278.