### PR TITLE
Various fixes to our virtual PCI bus implementation

### DIFF
--- a/examples/virtio_pci/README.md
+++ b/examples/virtio_pci/README.md
@@ -40,7 +40,7 @@ If you encounter this crash, you must manually retrieve the correct
 physical addresses from QEMU and update your configuration.
 
 1. Access the QEMU Monitor
-While your QEMU instance is running, press Ctrl + A, release
+While your QEMU instance is running, press Ctrl + a, release
 both keys, and then press c. You will be dropped into the QEMU
 monitor prompt:
 

--- a/examples/virtio_pci/client_vm/x86_64/guest_arch_init.c
+++ b/examples/virtio_pci/client_vm/x86_64/guest_arch_init.c
@@ -16,8 +16,6 @@
 #include <sddf/network/config.h>
 #include <sddf/timer/config.h>
 
-// @billn remove all serial stuff once virtio console works
-
 /* Device slot of the virtio console device on bus 0.
  * Host bridge = 0, ISA bridge = 1 so we must avoid these.
  * Then on Intel, the integrated graphics is conventionally on slot 2 as well...

--- a/include/libvmm/pci.h
+++ b/include/libvmm/pci.h
@@ -34,6 +34,8 @@
  * via the DTS on ARM or DSDT on x86. */
 bool pci_bus_init(uint64_t ecam_gpa, uint32_t ecam_size, uint64_t mmio_aperature_gpa, uint64_t mmio_aperature_size);
 
+bool pci_bus_get_mmio_aperature(uint64_t *mmio_aperature_gpa, uint64_t *mmio_aperature_size);
+
 /* Information about the device during the initial registration process. */
 typedef struct pci_device_register_data {
     uint16_t vendor_id;

--- a/src/pci.c
+++ b/src/pci.c
@@ -694,6 +694,18 @@ bool pci_register_device_mmio_bar(pci_dev_handle_t pci_dev_handle, uint8_t bar_i
     return true;
 }
 
+bool pci_bus_get_mmio_aperature(uint64_t *mmio_aperature_gpa, uint64_t *mmio_aperature_size)
+{
+    if (!pci_bus.initialised) {
+        LOG_VMM_ERR("virtual PCI not yet initialised\n");
+        return false;
+    }
+
+    *mmio_aperature_gpa = pci_bus.mmio_aperature.gpa;
+    *mmio_aperature_size = pci_bus.mmio_aperature.size;
+    return true;
+}
+
 bool pci_bus_init(uint64_t ecam_gpa, uint32_t ecam_size, uint64_t mmio_aperature_gpa, uint64_t mmio_aperature_size)
 {
     /* x86 does not need ECAM for PCI */

--- a/src/pci.c
+++ b/src/pci.c
@@ -49,6 +49,7 @@
 #define PCI_CFG_OFFSET_BAR4          0x1C
 #define PCI_CFG_OFFSET_BAR5          0x20
 #define PCI_CFG_OFFSET_BAR6          0x24
+#define PCI_CFG_OFFSET_CARDBUS       0x28
 #define PCI_CFG_OFFSET_CAP_DATA      0x40
 
 #define PCI_HEADER_TYPE_MULTIFUNCTION 0x80
@@ -253,8 +254,8 @@ static bool pci_ecam_emulate_access(pci_dev_handle_t handle, bool is_read, int a
             config_space->command = (uint16_t)*data & pci_device->sticky_cmd_bits;
             break;
         }
-        case REG_RANGE(PCI_CFG_OFFSET_BAR1, PCI_CFG_OFFSET_BAR2): {
-            uint8_t dev_bar_id = (config_space_offset - PCI_CFG_OFFSET_BAR1) / 0x4;
+        case REG_RANGE(PCI_CFG_OFFSET_BAR1, PCI_CFG_OFFSET_CARDBUS): {
+            uint8_t dev_bar_id = (config_space_offset - PCI_CFG_OFFSET_BAR1) / sizeof(uint32_t);
             assert(dev_bar_id < PCI_NUM_BARS_PER_CONFIG_SPACE);
 
             // @billn handle 64-bit BARs

--- a/src/pci.c
+++ b/src/pci.c
@@ -261,19 +261,48 @@ static bool pci_ecam_emulate_access(pci_dev_handle_t handle, bool is_read, int a
             // Memory negotiation process:
             //     1. The driver writes all 1s to the BAR register.
             //     2. The device writes the size mask ~(size - 1) to the BAR register.
-            //     3. The driver writes the original value (all 0s in our code) back
-            //         to the BAR register. (no action from the device)
-            //     4. The driver allocates memory from the memory resources, and writes
-            //         the allocated address to the BAR register.
-            //     5. The device parse the memory address and bookkeep it.
+            //     3. The driver writes the requested address to the BAR register.
+            //     4. The driver allocates memory from the memory resources.
             if (pci_device->bars[dev_bar_id].size) {
+                struct pci_bar_memory_bits *bar = &config_space->bars[dev_bar_id];
                 if (*data == 0xFFFFFFFF) {
-                    struct pci_bar_memory_bits *bar = &config_space->bars[dev_bar_id];
                     bar->base_address = (~(pci_device->bars[dev_bar_id].size - 1)) >> 4;
-                } else if (*data != 0x0) {
-                    struct pci_bar_memory_bits *bar = &config_space->bars[dev_bar_id];
+                } else {
                     uint32_t guest_allocated_addr = *data & 0xFFFFFFF0;   // Ignore control bits
-                    bar->base_address = guest_allocated_addr >> 4;       // 16-byte aligned
+
+                    if (!guest_allocated_addr) {
+                        bar->base_address = 0;
+                        pci_device->bars[dev_bar_id].gpa = 0;
+
+                        /* TODO remove ept/vm exception handler */
+                        return true;
+                    }
+
+                    if (guest_allocated_addr < pci_bus.mmio_aperature.gpa) {
+                        LOG_VMM_ERR("guest attempted to allocate BAR %d at GPA 0%x below MMIO aperature\n", dev_bar_id,
+                                    guest_allocated_addr);
+                        return true;
+                    }
+                    if (guest_allocated_addr + pci_device->bars[dev_bar_id].size
+                        > pci_bus.mmio_aperature.gpa + pci_bus.mmio_aperature.size) {
+                        LOG_VMM_ERR("guest attempted to allocate BAR %d at GPA 0%x above MMIO aperature\n", dev_bar_id,
+                                    guest_allocated_addr);
+                        return true;
+                    }
+
+                    bar->base_address = guest_allocated_addr >> 4; // 16-byte aligned
+
+                    if (guest_allocated_addr == (uint32_t)pci_device->bars[dev_bar_id].gpa) {
+                        /* Guest negotiated the same GPA, no need to do anything. */
+                        return true;
+                    }
+
+                    if (pci_device->bars[dev_bar_id].gpa
+                        && (guest_allocated_addr != (uint32_t)pci_device->bars[dev_bar_id].gpa)) {
+                        LOG_VMM_ERR("relocating a PCI MMIO BAR is unimplemented\n");
+                        return false;
+                    }
+
                     pci_device->bars[dev_bar_id].gpa = guest_allocated_addr;
 
                     /* We just need 3 bits to represent the BAR index (0-5), so we can stuff it
@@ -284,7 +313,7 @@ static bool pci_ecam_emulate_access(pci_dev_handle_t handle, bool is_read, int a
                     uint64_t bar_idx_mask = (uint64_t)dev_bar_id << 61;
                     cookie |= bar_idx_mask;
 
-                    bool register_ok;
+                    bool register_ok = false;
 #if defined(CONFIG_ARCH_ARM)
                     register_ok = fault_register_vm_exception_handler(guest_allocated_addr,
                                                                       pci_device->bars[dev_bar_id].size,

--- a/src/pci.c
+++ b/src/pci.c
@@ -223,8 +223,11 @@ static bool pci_bar_fault_handler(size_t vcpu_id, size_t offset, size_t qualific
 #endif
     }
 
-    bool success = pci_device->bars[bar_idx].callback(handle, offset, is_read, access_width_bytes, &data,
-                                                      pci_device->bars[bar_idx].cookie);
+    bool success = true;
+    if (pci_device->bars[bar_idx].callback) {
+        success = pci_device->bars[bar_idx].callback(handle, offset, is_read, access_width_bytes, &data,
+                                                     pci_device->bars[bar_idx].cookie);
+    }
 
     if (success && is_read) {
 #if defined(CONFIG_ARCH_ARM)


### PR DESCRIPTION
Fixes garbage PCI MMIO BAR addresses in the virtio_pci example on x86:
```
[    0.046456] PCI host bridge to bus 0000:00
[    0.046457] pci_bus 0000:00: root bus resource [mem 0x40000000-0x4007ffff window]
[    0.046458] pci_bus 0000:00: root bus resource [bus 00]
[    0.046550] pci 0000:00:00.0: [8086:1237] type 00 class 0x060000 conventional PCI endpoint
[    0.046918] pci 0000:00:01.0: [8086:7000] type 00 class 0x060100 conventional PCI endpoint
[    0.046918] pci 0000:00:01.3: [8086:7113] type 00 class 0x068000 conventional PCI endpoint
[    0.046918] pci 0000:00:03.0: [1af4:1043] type 00 class 0x078000 conventional PCI endpoint
[    0.046918] pci 0000:00:03.0: BAR 0 [mem 0xffffc000-0xffffffff]
[    0.047164] pci 0000:00:04.0: [1af4:1041] type 00 class 0x020000 conventional PCI endpoint
[    0.047918] pci 0000:00:04.0: BAR 0 [mem 0xffffc000-0xffffffff]
[    0.047918] pci 0000:00:05.0: [1af4:1042] type 00 class 0x010000 conventional PCI endpoint
[    0.047918] pci 0000:00:05.0: BAR 0 [mem 0xffffc000-0xffffffff]
...
[    0.050114] PCI: Using ACPI for IRQ routing
[    0.050115] PCI: pci_cache_line_size set to 64 bytes
[    0.050208] pci 0000:00:03.0: BAR 0 [mem 0xffffc000-0xffffffff]: can't claim; no compatible bridge window
[    0.050232] pci 0000:00:04.0: BAR 0 [mem 0xffffc000-0xffffffff]: can't claim; no compatible bridge window
[    0.050255] pci 0000:00:05.0: BAR 0 [mem 0xffffc000-0xffffffff]: can't claim; no compatible bridge window
```

Also contains a few precursor improvements for https://github.com/au-ts/libvmm/issues/279.