### PR TITLE
x86_64: fix incorrect CR8 R/W handling

### DIFF
--- a/src/arch/x86_64/cr_access.c
+++ b/src/arch/x86_64/cr_access.c
@@ -141,12 +141,15 @@ bool handle_cr_access(seL4_VCPUContext *vctx, seL4_Word qualification)
     switch (get_cr_number(qualification)) {
 #if APIC_VIRT_LEVEL < APIC_VIRT_LEVEL_APICV
     case 8: {
+        /* CR8 is the high bits of the TPR https://wiki.osdev.org/CPU_Registers_x86-64#CR8 */
         if (get_access_type(qualification) == MOV_TO_CR) {
-            return lapic_write_fault_handle(REG_LAPIC_TPR, get_write_operand(vctx, qualification));
+            uint8_t cr8 = get_write_operand(vctx, qualification);
+            uint8_t tpr = (cr8 & 0xF) << 4;
+            return lapic_write_fault_handle(REG_LAPIC_TPR, tpr);
         } else if (get_access_type(qualification) == MOV_FROM_CR) {
             uint32_t data;
             bool success = lapic_read_fault_handle(REG_LAPIC_TPR, &data);
-            write_to_read_operand(vctx, qualification, data);
+            write_to_read_operand(vctx, qualification, (data >> 4) & 0xF);
             return success;
         }
     }


### PR DESCRIPTION
This is a mistake I made in PR #327, CR8 is actually the high bits of TPR not the full TPR