### PR TITLE
virtio/block: feature happy if guest request subset

### DIFF
--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -224,7 +224,7 @@ static inline bool virtio_blk_set_driver_features(struct virtio_device *dev, uin
     switch (dev->regs.DriverFeaturesSel) {
     /* feature bits 0 to 31 */
     case 0:
-        success = (features == device_features);
+        success = (device_features & features) == features;
         break;
     /* features bits 32 to 63 */
     case 1:


### PR DESCRIPTION
It is valid for the guest to only negotiate a subset of the features that our virtual device offers. So don't throw an error if this is the case. Fix OVMF not binding with our virtio block device.