### PR TITLE
virtio_pci: various fixes for OVMF

### DIFF
--- a/include/libvmm/virtio/pci.h
+++ b/include/libvmm/virtio/pci.h
@@ -58,6 +58,7 @@
 #define VIRTIO_PCI_VENDOR_ID             0x1AF4
 #define VIRTIO_PCI_MODERN_BASE_DEVICE_ID 0x1040 // "non-transitional"
 #define VIRTIO_PCI_QUEUE_NUM_MAX         0x2
+#define VIRTIO_PCI_QUEUE_SIZE            0x100
 
 typedef struct virtio_pci_data {
     uint32_t device_id;

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -107,6 +107,7 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t offset, uint
         break;
     case VIRTIO_PCI_COMMON_Q_SIZE:
         *data = VIRTIO_DEFAULT_QUEUE_SIZE;
+        dev->vqs[dev->regs.QueueSel].virtq.num = VIRTIO_PCI_QUEUE_SIZE;
         break;
     case VIRTIO_PCI_COMMON_Q_ENABLE:
         *data = dev->vqs[dev->regs.QueueSel].ready;

--- a/src/virtio/pci.c
+++ b/src/virtio/pci.c
@@ -102,6 +102,9 @@ static bool virtio_pci_common_reg_read(virtio_device_t *dev, size_t offset, uint
     case VIRTIO_PCI_COMMON_CFG_GENERATION:
         *data = dev->regs.ConfigGeneration;
         break;
+    case VIRTIO_PCI_COMMON_Q_SELECT:
+        *data = dev->regs.QueueSel;
+        break;
     case VIRTIO_PCI_COMMON_Q_SIZE:
         *data = VIRTIO_DEFAULT_QUEUE_SIZE;
         break;


### PR DESCRIPTION
Fixes the VMM crashing when OVMF probes our virtio PCI devices.