### PR TITLE
x86_64: fix crashes when the guest switches CPU mode

### DIFF
--- a/include/libvmm/arch/x86_64/vcpu.h
+++ b/include/libvmm/arch/x86_64/vcpu.h
@@ -48,10 +48,12 @@
  * Note: "IA-32e" is just Intel's name for long mode.
  * Consult [1c] for more details
  */
-#define IA32_EFER_LME (BIT(8) | BIT(10)) /* Enable IA-32e mode operation */
+
+#define IA32_EFER_LME BIT(8)  /* Long mode active */
+#define IA32_EFER_LMA BIT(10) /* Enable IA-32e mode operation */
 
 /* Long mode default */
-#define IA32_EFER_LM_DEFAULT (IA32_EFER_LME)
+#define IA32_EFER_LM_DEFAULT (IA32_EFER_LME | IA32_EFER_LMA)
 
 /* The 32-bit EFLAGS/RFLAGS register contains a group of status flags, a control flag, and a group of system flags.
  * We don't use anything here during boot to mask all IRQs, but the 2nd bit must always be set as 1. See [1d]

--- a/include/libvmm/arch/x86_64/vcpu.h
+++ b/include/libvmm/arch/x86_64/vcpu.h
@@ -24,6 +24,7 @@
 #define CR0_PG BIT(31) /* Paging On */
 #define CR0_CD BIT(30) /* Cache Disable */
 #define CR0_NW BIT(29) /* Not Write-through */
+#define CR0_NE BIT(5)  /* Numeric Error */
 #define CR0_ET BIT(4)  /* Hardcoded to 1 */
 #define CR0_PE BIT(0)  /* Protection Enable */
 

--- a/src/arch/x86_64/cr_access.c
+++ b/src/arch/x86_64/cr_access.c
@@ -9,6 +9,7 @@
 #include <libvmm/util/util.h>
 #include <libvmm/arch/x86_64/apic.h>
 #include <libvmm/arch/x86_64/vmcs.h>
+#include <libvmm/arch/x86_64/vcpu.h>
 
 /* Documents referenced:
  * 1. Intel® 64 and IA-32 Architectures Software Developer’s Manual
@@ -154,7 +155,20 @@ bool handle_cr_access(seL4_VCPUContext *vctx, seL4_Word qualification)
         }
     }
 #endif
+    case 0: {
+        if (get_access_type(qualification) == MOV_TO_CR) {
+            /* See "vcpu_set_up_control_registers()" in vcpu.c for an explainer on why we do this. */
+            uint64_t guest_requested_cr0 = get_write_operand(vctx, qualification);
 
+            microkit_vcpu_x86_write_vmcs(0, VMX_GUEST_CR0, guest_requested_cr0 | CR0_NE);
+            microkit_vcpu_x86_write_vmcs(0, VMX_CONTROL_CR0_READ_SHADOW, guest_requested_cr0);
+            return true;
+        } else if (get_access_type(qualification) == MOV_FROM_CR) {
+            /* It is architecturally impossible to get a VM Exit for CR0 read.
+             * See "26.1.3 Instructions That Cause VM Exits Conditionally" of [1] */
+            assert(false);
+        }
+    }
     default:
         LOG_VMM_ERR("unhandled CR%d access, access type %d\n", get_cr_number(qualification),
                     get_access_type(qualification));

--- a/src/arch/x86_64/cr_access.c
+++ b/src/arch/x86_64/cr_access.c
@@ -162,6 +162,27 @@ bool handle_cr_access(seL4_VCPUContext *vctx, seL4_Word qualification)
 
             microkit_vcpu_x86_write_vmcs(0, VMX_GUEST_CR0, guest_requested_cr0 | CR0_NE);
             microkit_vcpu_x86_write_vmcs(0, VMX_CONTROL_CR0_READ_SHADOW, guest_requested_cr0);
+
+            /* On real hardware, setting THEN clearing CR0.PG have side effects. We must emulate
+             * this on software or we will get invalid state on VM resume.
+             * See section "Switching Out of IA-32e Mode Operation" of [1]:
+             * "Deactivate IA-32e mode by clearing CR0.PG = 0. This causes the processor to set IA32_EFER.LMA = 0." */
+            seL4_Word efer = microkit_vcpu_x86_read_vmcs(0, VMX_GUEST_EFER);
+            seL4_Word entry_ctrl = microkit_vcpu_x86_read_vmcs(0, VMX_CONTROL_ENTRY_CONTROLS);
+
+            if (!(guest_requested_cr0 & CR0_PG)) {
+                /* If we are in long mode then we must drop out of long mode. */
+                if (efer & IA32_EFER_LMA) {
+                    microkit_vcpu_x86_write_vmcs(0, VMX_GUEST_EFER, efer & ~IA32_EFER_LMA);
+                    microkit_vcpu_x86_write_vmcs(0, VMX_CONTROL_ENTRY_CONTROLS, entry_ctrl & ~VMCS_VENC_ENABLE_IA32E);
+                }
+            } else {
+                /* If paging is enabled, check if we should enter long mode. */
+                if (efer & IA32_EFER_LME) {
+                    microkit_vcpu_x86_write_vmcs(0, VMX_GUEST_EFER, efer | IA32_EFER_LMA);
+                    microkit_vcpu_x86_write_vmcs(0, VMX_CONTROL_ENTRY_CONTROLS, entry_ctrl | VMCS_VENC_ENABLE_IA32E);
+                }
+            }
             return true;
         } else if (get_access_type(qualification) == MOV_FROM_CR) {
             /* It is architecturally impossible to get a VM Exit for CR0 read.

--- a/src/arch/x86_64/vcpu.c
+++ b/src/arch/x86_64/vcpu.c
@@ -75,6 +75,35 @@ static bool vcpu_set_up_control_registers(uint64_t cr0, uint64_t cr3, uint64_t c
     /* Prevent guest from turning off VM mode */
     microkit_vcpu_x86_write_vmcs(GUEST_BOOT_VCPU_ID, VMX_CONTROL_CR4_MASK, CR4_EN_MASK);
 
+    /* From [1]:
+     * "The first processors to support VMX operation require that the following
+     * bits be 1 in VMX operation: CR0.PE, CR0.NE, CR0.PG, and CR4.VMXE. The
+     * restrictions on CR0.PE and CR0.PG imply that VMX operation is supported
+     * only in paged protected mode (including IA-32e mode). Therefore, guest
+     * software cannot be run in unpaged protected mode or in real-address mode.
+     *
+     * Later processors support a VM-execution control called “unrestricted guest”
+     * (see Section 25.6.2). If this control is 1, CR0.PE and CR0.PG may be 0 in
+     * VMX non-root operation (even if the capability MSR IA32_VMX_CR0_FIXED0
+     * reports otherwise).1 Such processors allow guest software to run in
+     * unpaged protected mode or in real-address mode"
+     *
+     * Then from [1]:
+     * "MOV to CR0. The MOV to CR0 instruction causes a VM exit unless the value
+     * of its source operand matches, for the position of each bit set in the CR0
+     * guest/host mask, the corresponding bit in the CR0 read shadow. (If every bit
+     * is clear in the CR0 guest/host mask, MOV to CR0 cannot cause a VM exit.)"
+     *
+     * Therefore, because the hardware requires CR0.NE to be 1 at all times during
+     * VMX operation, letting the guest write directly to this bit will raise #GP
+     * inside the guest and can cause a triple fault if the guest attempts to clear it.
+     *
+     * By setting CR0.NE in VMX_CONTROL_CR0_MASK, we force a VM-exit (Control Register Access)
+     * whenever the guest attempts to alter CR0, allowing us to safely intercept the write,
+     * enforce the hardware requirement (NE=1) in the real VMX_GUEST_CR0.
+     */
+    microkit_vcpu_x86_write_vmcs(GUEST_BOOT_VCPU_ID, VMX_CONTROL_CR0_MASK, CR0_NE);
+
     /* Check that all CR0 and CR4 features we need are supported by the host.
      * We perform this check because seL4 will clear any unsupported feature bits. */
     uint64_t read_back_cr0 = microkit_vcpu_x86_read_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_CR0);

--- a/src/arch/x86_64/vcpu.c
+++ b/src/arch/x86_64/vcpu.c
@@ -101,8 +101,11 @@ static bool vcpu_set_up_control_registers(uint64_t cr0, uint64_t cr3, uint64_t c
      * By setting CR0.NE in VMX_CONTROL_CR0_MASK, we force a VM-exit (Control Register Access)
      * whenever the guest attempts to alter CR0, allowing us to safely intercept the write,
      * enforce the hardware requirement (NE=1) in the real VMX_GUEST_CR0.
+     *
+     * We must also set CR0_PG as there are side effects when the guest turns OFF paging.
+     * See handle_cr_access() of cr_access.c for more details.
      */
-    microkit_vcpu_x86_write_vmcs(GUEST_BOOT_VCPU_ID, VMX_CONTROL_CR0_MASK, CR0_NE);
+    microkit_vcpu_x86_write_vmcs(GUEST_BOOT_VCPU_ID, VMX_CONTROL_CR0_MASK, CR0_NE | CR0_PG);
 
     /* Check that all CR0 and CR4 features we need are supported by the host.
      * We perform this check because seL4 will clear any unsupported feature bits. */


### PR DESCRIPTION
Fixed a few crashes I ran into while trying out desktop Linux distros on libvmm with OVMF. See the commits for more details.