### PR TITLE
virtio/block: support chunking requests + other fixes

### DIFF
--- a/include/libvmm/virtio/block.h
+++ b/include/libvmm/virtio/block.h
@@ -180,6 +180,9 @@ typedef struct reqbk {
     uintptr_t sddf_data_cell_base;
     uint32_t sddf_data_offset;
     uint16_t sddf_count;
+    /* What is the current progress of this virtio request? */
+    uint64_t bytes_completed;
+    uint64_t bytes_remaining;
 } reqbk_t;
 
 struct virtio_blk_device {

--- a/include/libvmm/virtio/block.h
+++ b/include/libvmm/virtio/block.h
@@ -150,7 +150,7 @@ where we can't handle large requests when the free cells in the data region isn'
 #define VIRTIO_BLK_DEFAULT_VIRTQ 0
 
 typedef enum {
-    VIRTIO_BLK_REQ_STATE_INVALID = 0,
+    VIRTIO_BLK_REQ_STATE_INVALID = 1,
     VIRTIO_BLK_REQ_STATE_FLUSHING,
     VIRTIO_BLK_REQ_STATE_READING,
     VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED,
@@ -176,12 +176,13 @@ typedef struct reqbk {
     uint64_t virtio_sector;
     uint64_t total_req_size;
     /* For enqueuing sddf req/resp */
-    uint32_t sddf_block_number;
     uintptr_t sddf_data_cell_base;
-    uint32_t sddf_data_offset;
-    uint16_t sddf_count;
-    /* What is the current progress of this virtio request? */
+    uint64_t sddf_data_offset;
+    uint16_t sddf_count_in_flight;
+    /* What is the current progress of this virtio request?
+     * The sum of these == request_bytes_to_body_bytes(total_req_size) */
     uint64_t bytes_completed;
+    uint64_t bytes_in_flight;
     uint64_t bytes_remaining;
 } reqbk_t;
 

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -518,7 +518,9 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
         /* Generate sddf request id and bookkeep the request */
         uint32_t req_id;
         err = ialloc_alloc(&state->ialloc, &req_id);
-        assert(!err);
+        if (err == -1) {
+            goto stop_processing;
+        }
         assert(state->reqsbk[req_id].state == VIRTIO_BLK_REQ_STATE_INVALID);
 
         LOG_BLOCK("----- Begin processing request at descriptor head %u -----\n", desc_head);

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -370,6 +370,130 @@ bool decode_virtio_block_request(virtio_queue_handler_t *vq_handler, uint16_t de
     ret->virtio_sector = header.sector;
     ret->sddf_block_number = sddf_block_number;
     ret->sddf_data_offset = data_offset;
+    ret->bytes_remaining = body_size_bytes;
+    ret->bytes_completed = 0;
+
+    return true;
+}
+
+/* Returns false if request can't be process *right now*. Try again later. */
+static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t req_id)
+{
+    /* Should only be called for virtio blk read or write requests. */
+    assert(reqbk->virtio_req_type == VIRTIO_BLK_T_IN || reqbk->virtio_req_type == VIRTIO_BLK_T_OUT);
+
+    int err;
+    virtio_queue_handler_t *vq = &dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ];
+    struct virtio_blk_device *state = device_state(dev);
+
+    bool resources_ok = true;
+    if (!sddf_make_req_check(state, reqbk->sddf_count)) {
+        /* One of the bookkeeping array is full, give up for now, resources will
+            * become available later. */
+        resources_ok = false;
+    }
+
+    /* Allocate data cells from sddf data region based on sddf_count. This may fail since
+        * there might be fragmentation in the data region or a few requests are using a lot of
+        * space. */
+    if (fsmalloc_alloc(&state->fsmalloc, &reqbk->sddf_data_cell_base, reqbk->sddf_count) == -1) {
+
+        LOG_BLOCK_WARN("Data region is full\n");
+        resources_ok = false;
+
+        // /* Hmm data region is full. Eventually we will be able to service this request. But
+        //     * if the request is larger than the sDDF Block data region then we will never be
+        //     * able to and would deadlock the guest. This is a realistic scenario as OVMF doesn't
+        //     * negotiate VIRTIO_BLK_F_SIZE_MAX and VIRTIO_BLK_F_SEG_MAX which is annoying.
+        //     *
+        //     * Lets try salvaging the situation by splitting the request up and service the
+        //     * request block by block. This is ok for the firmware since performance
+        //     * isn't critical. Once the guest OS boots properly their better driver will take over
+        //     * and negotiate the features. */
+
+        // if (fsmalloc_alloc(&state->fsmalloc, &state->reqsbk[req_id].sddf_data_cell_base, 1) == -1) {
+        //     /* Can't really do anything, give up. */
+        //     LOG_BLOCK_WARN("Data region is full\n");
+        //     resources_ok = false;
+        // } else {
+        //     LOG_VMM("splitting up %s request sector %u, body size %u\n",
+        //             state->reqsbk[req_id].virtio_req_type == VIRTIO_BLK_T_IN ? "Read" : "Write",
+        //             state->reqsbk[req_id].virtio_sector, state->reqsbk[req_id].sddf_block_number,
+        //             request_bytes_to_body_bytes(state->reqsbk[req_id].total_req_size));
+        //     state->reqsbk[req_id].sddf_count = 1;
+        // }
+    }
+
+    if (!resources_ok) {
+        LOG_BLOCK_WARN("out of resource for request at sector %lu, body bytes %lu, sddf count %u\n",
+                       reqbk->virtio_sector, request_bytes_to_body_bytes(reqbk->total_req_size), reqbk->sddf_count);
+        return resources_ok;
+    }
+
+    uintptr_t sddf_offset = reqbk->sddf_data_cell_base
+                          - ((struct virtio_blk_device *)dev->device_data)->data_region;
+
+    LOG_BLOCK("%s request sector %u, sddf block %u, body size %u, data off %u, nums block %u, virtio desc %u\n",
+              reqbk->virtio_req_type == VIRTIO_BLK_T_IN ? "Read" : "Write", reqbk->virtio_sector,
+              reqbk->sddf_block_number, request_bytes_to_body_bytes(reqbk->total_req_size), reqbk->sddf_data_offset,
+              reqbk->sddf_count, reqbk->virtio_desc_head);
+
+    if (reqbk->virtio_req_type == VIRTIO_BLK_T_IN) {
+        err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset, reqbk->sddf_block_number, reqbk->sddf_count,
+                              req_id);
+        assert(!err);
+        reqbk->state = VIRTIO_BLK_REQ_STATE_READING;
+    } else if (reqbk->virtio_req_type == VIRTIO_BLK_T_OUT) {
+        /* If the write request is not aligned on the sddf transfer window, we need
+         * to do a read-modify-write: we need to first read the surrounding
+         * memory, overwrite the memory on the unaligned areas, and then write the
+         * entire memory back to disk.
+         */
+        bool aligned_on_transfer_window = true;
+        if (request_bytes_to_body_bytes(reqbk->total_req_size) % BLK_TRANSFER_SIZE != 0
+            || (reqbk->virtio_sector % (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)) != 0) {
+
+            LOG_BLOCK("...not aligned on transfer window.\n");
+            aligned_on_transfer_window = false;
+        }
+
+        /* Check if this request overlap with other requests, if so, also perform read modify write.
+         * But we queue it up. */
+        bool overlap_with_other_requests = false;
+        for (int i = 0; i < SDDF_MAX_QUEUE_CAPACITY; i++) {
+            if (i != req_id && state->reqsbk[i].state != VIRTIO_BLK_REQ_STATE_INVALID
+                && do_requests_overlap(&state->reqsbk[i], reqbk)
+                && request_is_write(&state->reqsbk[i])) {
+
+                LOG_BLOCK("...overlap with other requests.\n");
+                overlap_with_other_requests = true;
+                break;
+            }
+        }
+
+        if (aligned_on_transfer_window && !overlap_with_other_requests) {
+            /* Normal case, just send a normal write and we are done. */
+            /* Copy data from virtio buffer to sddf buffer */
+            assert(virtio_read_data_from_desc_chain(
+                vq, reqbk->virtio_desc_head, request_bytes_to_body_bytes(reqbk->total_req_size),
+                sizeof(struct virtio_blk_outhdr), (char *)reqbk->sddf_data_cell_base));
+
+            err = blk_enqueue_req(&state->queue_h, BLK_REQ_WRITE, sddf_offset, reqbk->sddf_block_number,
+                                  reqbk->sddf_count, req_id);
+            assert(!err);
+
+            reqbk->state = VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED;
+        } else if (!aligned_on_transfer_window && !overlap_with_other_requests) {
+            /* Read modify write as described above */
+            err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset, reqbk->sddf_block_number,
+                                  reqbk->sddf_count, req_id);
+            assert(!err);
+
+            reqbk->state = VIRTIO_BLK_REQ_STATE_RMW_READING;
+        } else if (overlap_with_other_requests) {
+            reqbk->state = VIRTIO_BLK_REQ_STATE_RMW_QUEUEING;
+        }
+    }
 
     return true;
 }
@@ -408,111 +532,19 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
              * or the guest was malicious. The former is more likely so we
              * will keep the assert for now to catch such issue for further
              * investigations. */
-            uint32_t body_size_bytes = request_bytes_to_body_bytes(state->reqsbk[req_id].total_req_size);
-            assert(body_size_bytes % VIRTIO_BLK_SECTOR_SIZE == 0);
+            assert(state->reqsbk[req_id].bytes_remaining % VIRTIO_BLK_SECTOR_SIZE == 0);
 
-            bool resources_ok = true;
-            if (!sddf_make_req_check(state, state->reqsbk[req_id].sddf_count)) {
-                resources_ok = false;
-            }
-
-            /* Allocate data cells from sddf data region based on sddf_count. This may fail since
-             * there might be fragmentation in the data region or a few requests are using a lot of
-             * space. */
-            if (fsmalloc_alloc(&state->fsmalloc, &state->reqsbk[req_id].sddf_data_cell_base,
-                               state->reqsbk[req_id].sddf_count)
-                == -1) {
-
-                LOG_BLOCK_WARN("Data region is full\n");
-                resources_ok = false;
-            }
-
-            if (!resources_ok) {
-                LOG_BLOCK_WARN("out of resource for request at sector %lu, body bytes %lu, sddf count %u\n",
-                               state->reqsbk[req_id].virtio_sector,
-                               request_bytes_to_body_bytes(state->reqsbk[req_id].total_req_size),
-                               state->reqsbk[req_id].sddf_count);
-
+            if (!dispatch_request(dev, &state->reqsbk[req_id], req_id)) {
                 /* Create backpressure, don't consume this request until the block virtualiser gives us
                  * responses to free up resources */
                 state->reqsbk[req_id].state = VIRTIO_BLK_REQ_STATE_INVALID;
                 ialloc_free(&state->ialloc, req_id);
                 goto stop_processing;
+            } else {
+                nums_consumed += 1;
+                assert(virtio_virtq_pop_avail(vq, &desc_head));
+                break;
             }
-
-            uintptr_t sddf_offset = state->reqsbk[req_id].sddf_data_cell_base
-                                  - ((struct virtio_blk_device *)dev->device_data)->data_region;
-
-            LOG_BLOCK("%s request sector %u, sddf block %u, body size %u, data off %u, nums block %u, virtio desc %u\n",
-                      state->reqsbk[req_id].virtio_req_type == VIRTIO_BLK_T_IN ? "Read" : "Write",
-                      state->reqsbk[req_id].virtio_sector, state->reqsbk[req_id].sddf_block_number,
-                      request_bytes_to_body_bytes(state->reqsbk[req_id].total_req_size),
-                      state->reqsbk[req_id].sddf_data_offset, state->reqsbk[req_id].sddf_count,
-                      state->reqsbk[req_id].virtio_desc_head);
-
-            if (state->reqsbk[req_id].virtio_req_type == VIRTIO_BLK_T_IN) {
-                err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset,
-                                      state->reqsbk[req_id].sddf_block_number, state->reqsbk[req_id].sddf_count,
-                                      req_id);
-                assert(!err);
-                state->reqsbk[req_id].state = VIRTIO_BLK_REQ_STATE_READING;
-            } else if (state->reqsbk[req_id].virtio_req_type == VIRTIO_BLK_T_OUT) {
-                /* If the write request is not aligned on the sddf transfer window, we need
-                * to do a read-modify-write: we need to first read the surrounding
-                * memory, overwrite the memory on the unaligned areas, and then write the
-                * entire memory back to disk.
-                */
-                bool aligned_on_transfer_window = true;
-                if (request_bytes_to_body_bytes(state->reqsbk[req_id].total_req_size) % BLK_TRANSFER_SIZE != 0
-                    || (state->reqsbk[req_id].virtio_sector % (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)) != 0) {
-
-                    LOG_BLOCK("...not aligned on transfer window.\n");
-                    aligned_on_transfer_window = false;
-                }
-
-                /* Check if this request overlap with other requests, if so, also perform read modify write.
-                 * But we queue it up. */
-                bool overlap_with_other_requests = false;
-                for (int i = 0; i < SDDF_MAX_QUEUE_CAPACITY; i++) {
-                    if (i != req_id && state->reqsbk[i].state != VIRTIO_BLK_REQ_STATE_INVALID
-                        && do_requests_overlap(&state->reqsbk[i], &state->reqsbk[req_id])
-                        && request_is_write(&state->reqsbk[i])) {
-
-                        LOG_BLOCK("...overlap with other requests.\n");
-                        overlap_with_other_requests = true;
-                        break;
-                    }
-                }
-
-                if (aligned_on_transfer_window && !overlap_with_other_requests) {
-                    /* Normal case, just send a normal write and we are done. */
-                    /* Copy data from virtio buffer to sddf buffer */
-                    assert(virtio_read_data_from_desc_chain(
-                        vq, state->reqsbk[req_id].virtio_desc_head,
-                        request_bytes_to_body_bytes(state->reqsbk[req_id].total_req_size),
-                        sizeof(struct virtio_blk_outhdr), (char *)state->reqsbk[req_id].sddf_data_cell_base));
-
-                    err = blk_enqueue_req(&state->queue_h, BLK_REQ_WRITE, sddf_offset,
-                                          state->reqsbk[req_id].sddf_block_number, state->reqsbk[req_id].sddf_count,
-                                          req_id);
-                    assert(!err);
-
-                    state->reqsbk[req_id].state = VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED;
-                } else if (!aligned_on_transfer_window && !overlap_with_other_requests) {
-                    /* Read modify write as described above */
-                    err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset,
-                                          state->reqsbk[req_id].sddf_block_number, state->reqsbk[req_id].sddf_count,
-                                          req_id);
-                    assert(!err);
-
-                    state->reqsbk[req_id].state = VIRTIO_BLK_REQ_STATE_RMW_READING;
-                } else if (overlap_with_other_requests) {
-                    state->reqsbk[req_id].state = VIRTIO_BLK_REQ_STATE_RMW_QUEUEING;
-                }
-            }
-            nums_consumed += 1;
-            assert(virtio_virtq_pop_avail(vq, &desc_head));
-            break;
         }
         case VIRTIO_BLK_T_FLUSH: {
             LOG_BLOCK("Request type is VIRTIO_BLK_T_FLUSH\n");

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -122,23 +122,6 @@
 #define VIRTIO_BLK_DEV_ID "libvmm"
 #define SECTORS_IN_TRANSFER_WINDOW (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)
 
-/* Uncomment this to enable debug logging */
-// #define DEBUG_BLOCK
-
-#if defined(DEBUG_BLOCK)
-#define LOG_BLOCK(...)             \
-    do                             \
-    {                              \
-        printf("VIRTIO(BLOCK): "); \
-        printf(__VA_ARGS__);       \
-    } while (0)
-#else
-#define LOG_BLOCK(...) \
-    do                 \
-    {                  \
-    } while (0)
-#endif
-
 #define LOG_BLOCK_WARN(...)               \
     do                                   \
     {                                    \
@@ -247,12 +230,8 @@ static inline bool virtio_blk_set_driver_features(struct virtio_device *dev, uin
 static inline bool virtio_blk_get_device_config(struct virtio_device *dev, uint32_t offset, uint32_t *ret_val)
 {
     struct virtio_blk_device *state = device_state(dev);
-
     uintptr_t config_base_addr = (uintptr_t)&state->config;
     memcpy((void *)ret_val, (void *)(config_base_addr + offset), 4);
-    LOG_BLOCK("get device config with base_addr 0x%x and offset 0x%x has "
-              "value %d\n",
-              config_base_addr, offset, *ret_val);
 
     return true;
 }
@@ -260,19 +239,14 @@ static inline bool virtio_blk_get_device_config(struct virtio_device *dev, uint3
 static inline bool virtio_blk_set_device_config(struct virtio_device *dev, uint32_t offset, uint32_t val)
 {
     struct virtio_blk_device *state = device_state(dev);
-
     uintptr_t config_base_addr = (uintptr_t)&state->config;
     memcpy((void *)(config_base_addr + offset), (void *)&val, 4);
-    LOG_BLOCK("set device config with base_addr 0x%x and offset 0x%x with "
-              "value %d\n",
-              config_base_addr, offset, val);
-
     return true;
 }
 
 /* Check if ialloc and req queue are full.
  * If these all pass then a request without a payload (e.g. flush) can be handled successfully */
-static inline bool sddf_make_req_check(struct virtio_blk_device *state, uint16_t sddf_count)
+static inline bool sddf_make_req_check(struct virtio_blk_device *state)
 {
     if (ialloc_full(&state->ialloc)) {
         LOG_BLOCK_WARN("Request bookkeeping array is full\n");
@@ -287,13 +261,54 @@ static inline bool sddf_make_req_check(struct virtio_blk_device *state, uint16_t
     return true;
 }
 
+/* What is the number of bytes that the guest want to read from/write to the disk? */
+static uint64_t reqbk_to_body_bytes(reqbk_t *reqbk)
+{
+    return reqbk->total_req_size - sizeof(struct virtio_blk_outhdr) - 1;
+}
+
+/* Convert the virtio sector (512b) number into sDDF block (4k) number. */
+static uint64_t reqbk_to_sddf_block_num(reqbk_t *reqbk)
+{
+    return ((reqbk->virtio_sector * VIRTIO_BLK_SECTOR_SIZE) + reqbk->bytes_completed) / BLK_TRANSFER_SIZE;
+}
+
+/* What is the distance from the sDDF block 4k boundary to the first 512b sector in the request? */
+static uint64_t reqbk_to_sddf_data_offset(reqbk_t *reqbk)
+{
+    return ((reqbk->virtio_sector * VIRTIO_BLK_SECTOR_SIZE) + reqbk->bytes_completed) % BLK_TRANSFER_SIZE;
+}
+
+/* How many sDDF 4k blocks do we need to read from or write to for the given request's sector and number
+ * of requesting bytes? */
+static uint64_t reqbk_to_sddf_num_blocks(reqbk_t *reqbk, uint64_t proposed_bytes)
+{
+    assert(proposed_bytes);
+
+    /* Offset within the data cells for reading/writing virtio data */
+    uint64_t data_offset = reqbk_to_sddf_data_offset(reqbk);
+    uint64_t sddf_count = (data_offset + proposed_bytes) / BLK_TRANSFER_SIZE;
+    if ((data_offset + proposed_bytes) % BLK_TRANSFER_SIZE) {
+        /* Request will cross a transfer window or needs to be rounded up to transfer window. */
+        sddf_count++;
+    }
+
+    /* Never returns 0. */
+    assert(sddf_count);
+    return sddf_count;
+}
+
 /* Returns true if both requests hit the same block */
 static bool do_requests_overlap(reqbk_t *req1, reqbk_t *req2)
 {
-    uint32_t start1 = req1->sddf_block_number;
-    uint32_t end1 = start1 + req1->sddf_count - 1;
-    uint32_t start2 = req2->sddf_block_number;
-    uint32_t end2 = start2 + req2->sddf_count - 1;
+    if (req1->bytes_in_flight == 0 || req2->bytes_in_flight == 0) {
+        return false;
+    }
+
+    uint64_t start1 = reqbk_to_sddf_block_num(req1);
+    uint64_t end1 = start1 + reqbk_to_sddf_num_blocks(req1, req1->bytes_in_flight) - 1;
+    uint64_t start2 = reqbk_to_sddf_block_num(req2);
+    uint64_t end2 = start2 + reqbk_to_sddf_num_blocks(req2, req2->bytes_in_flight) - 1;
     return (start1 <= end2 && start2 <= end1);
 }
 
@@ -316,11 +331,6 @@ static inline void virtio_blk_set_req_success(virtio_queue_handler_t *vq_handler
         virtio_write_data_to_desc_chain(vq_handler, reqbk->virtio_desc_head, 1, reqbk->total_req_size - 1, &ok_byte));
 }
 
-static uint64_t request_bytes_to_body_bytes(uint64_t request_bytes)
-{
-    return request_bytes - sizeof(struct virtio_blk_outhdr) - 1;
-}
-
 bool decode_virtio_block_request(virtio_queue_handler_t *vq_handler, uint16_t desc_head, reqbk_t *ret)
 {
     /* A virtio block request looks like this:
@@ -333,8 +343,6 @@ bool decode_virtio_block_request(virtio_queue_handler_t *vq_handler, uint16_t de
        };
        We just need to walk the scatter-gather list, and re-assemble the data
      */
-
-    LOG_BLOCK("decode_virtio_block_request(): decoding desc head %u\n", desc_head);
     uint64_t payload_len = virtio_desc_chain_payload_len(vq_handler, desc_head);
     if (payload_len < sizeof(struct virtio_blk_outhdr) + 1) {
         /* Malicious guest driver */
@@ -351,27 +359,10 @@ bool decode_virtio_block_request(virtio_queue_handler_t *vq_handler, uint16_t de
     assert(
         virtio_read_data_from_desc_chain(vq_handler, desc_head, sizeof(struct virtio_blk_outhdr), 0, (char *)&header));
 
-    /* Step 3: if it's a read or write then calculate sDDF block number and count.
-     * Converting virtio sector number to sddf block number, we are rounding down */
-    uint32_t sddf_block_number = (header.sector * VIRTIO_BLK_SECTOR_SIZE) / BLK_TRANSFER_SIZE;
-
-    uint32_t body_size_bytes = request_bytes_to_body_bytes(payload_len);
-
-    /* Offset within the data cells for reading/writing virtio data */
-    uint32_t data_offset = ((header.sector * VIRTIO_BLK_SECTOR_SIZE) % BLK_TRANSFER_SIZE);
-
-    ret->sddf_count = (data_offset + body_size_bytes) / BLK_TRANSFER_SIZE;
-    if ((data_offset + body_size_bytes) % BLK_TRANSFER_SIZE) {
-        /* Request will cross a transfer window. */
-        ret->sddf_count++;
-    }
-
     ret->virtio_req_type = header.type;
     ret->virtio_sector = header.sector;
-    ret->sddf_block_number = sddf_block_number;
-    ret->sddf_data_offset = data_offset;
-    ret->bytes_remaining = body_size_bytes;
-    ret->bytes_completed = 0;
+    ret->sddf_data_offset = reqbk_to_sddf_data_offset(ret);
+    ret->bytes_remaining = reqbk_to_body_bytes(ret);
 
     return true;
 }
@@ -380,24 +371,27 @@ bool decode_virtio_block_request(virtio_queue_handler_t *vq_handler, uint16_t de
 static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t req_id)
 {
     /* Should only be called for virtio blk read or write requests. */
+    assert(reqbk->state != VIRTIO_BLK_REQ_STATE_INVALID);
     assert(reqbk->virtio_req_type == VIRTIO_BLK_T_IN || reqbk->virtio_req_type == VIRTIO_BLK_T_OUT);
+    assert(reqbk->bytes_remaining);
 
     int err;
     virtio_queue_handler_t *vq = &dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ];
     struct virtio_blk_device *state = device_state(dev);
 
     bool resources_ok = true;
-    if (!sddf_make_req_check(state, reqbk->sddf_count)) {
+    if (!sddf_make_req_check(state)) {
         /* One of the bookkeeping array is full, give up for now, resources will
-            * become available later. */
+         * become available later. */
         resources_ok = false;
     }
 
-    /* Allocate data cells from sddf data region based on sddf_count. This may fail since
-        * there might be fragmentation in the data region or a few requests are using a lot of
-        * space. */
-    if (fsmalloc_alloc(&state->fsmalloc, &reqbk->sddf_data_cell_base, reqbk->sddf_count) == -1) {
-
+    /* Allocate data cells from sddf data region for the entire request. This may fail since
+     * there might be fragmentation in the data region or a few requests are using a lot of
+     * space. */
+    uint64_t proposed_bytes = reqbk->bytes_remaining;
+    uint64_t sddf_num_blocks = reqbk_to_sddf_num_blocks(reqbk, proposed_bytes);
+    if (fsmalloc_alloc(&state->fsmalloc, &reqbk->sddf_data_cell_base, sddf_num_blocks) == -1) {
         LOG_BLOCK_WARN("Data region is full\n");
         resources_ok = false;
 
@@ -425,22 +419,21 @@ static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t
     }
 
     if (!resources_ok) {
-        LOG_BLOCK_WARN("out of resource for request at sector %lu, body bytes %lu, sddf count %u\n",
-                       reqbk->virtio_sector, request_bytes_to_body_bytes(reqbk->total_req_size), reqbk->sddf_count);
+        LOG_BLOCK_WARN("virtio block: out of resource for request at sector %lu, body bytes %lu, sddf count %lu\n",
+                       reqbk->virtio_sector, reqbk_to_body_bytes(reqbk), sddf_num_blocks);
         return resources_ok;
     }
 
-    uintptr_t sddf_offset = reqbk->sddf_data_cell_base
-                          - ((struct virtio_blk_device *)dev->device_data)->data_region;
+    uintptr_t sddf_offset = reqbk->sddf_data_cell_base - ((struct virtio_blk_device *)dev->device_data)->data_region;
+    uint64_t sddf_block = reqbk_to_sddf_block_num(reqbk);
 
-    LOG_BLOCK("%s request sector %u, sddf block %u, body size %u, data off %u, nums block %u, virtio desc %u\n",
-              reqbk->virtio_req_type == VIRTIO_BLK_T_IN ? "Read" : "Write", reqbk->virtio_sector,
-              reqbk->sddf_block_number, request_bytes_to_body_bytes(reqbk->total_req_size), reqbk->sddf_data_offset,
-              reqbk->sddf_count, reqbk->virtio_desc_head);
+    reqbk->sddf_count_in_flight = sddf_num_blocks;
+    reqbk->bytes_remaining -= proposed_bytes;
+    reqbk->bytes_in_flight += proposed_bytes;
+    assert(reqbk->bytes_completed + reqbk->bytes_in_flight + reqbk->bytes_remaining == reqbk_to_body_bytes(reqbk));
 
     if (reqbk->virtio_req_type == VIRTIO_BLK_T_IN) {
-        err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset, reqbk->sddf_block_number, reqbk->sddf_count,
-                              req_id);
+        err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset, sddf_block, sddf_num_blocks, req_id);
         assert(!err);
         reqbk->state = VIRTIO_BLK_REQ_STATE_READING;
     } else if (reqbk->virtio_req_type == VIRTIO_BLK_T_OUT) {
@@ -450,10 +443,8 @@ static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t
          * entire memory back to disk.
          */
         bool aligned_on_transfer_window = true;
-        if (request_bytes_to_body_bytes(reqbk->total_req_size) % BLK_TRANSFER_SIZE != 0
-            || (reqbk->virtio_sector % (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)) != 0) {
+        if (proposed_bytes % BLK_TRANSFER_SIZE != 0 || reqbk->sddf_data_offset != 0) {
 
-            LOG_BLOCK("...not aligned on transfer window.\n");
             aligned_on_transfer_window = false;
         }
 
@@ -462,10 +453,8 @@ static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t
         bool overlap_with_other_requests = false;
         for (int i = 0; i < SDDF_MAX_QUEUE_CAPACITY; i++) {
             if (i != req_id && state->reqsbk[i].state != VIRTIO_BLK_REQ_STATE_INVALID
-                && do_requests_overlap(&state->reqsbk[i], reqbk)
-                && request_is_write(&state->reqsbk[i])) {
+                && do_requests_overlap(&state->reqsbk[i], reqbk) && request_is_write(&state->reqsbk[i])) {
 
-                LOG_BLOCK("...overlap with other requests.\n");
                 overlap_with_other_requests = true;
                 break;
             }
@@ -474,19 +463,18 @@ static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t
         if (aligned_on_transfer_window && !overlap_with_other_requests) {
             /* Normal case, just send a normal write and we are done. */
             /* Copy data from virtio buffer to sddf buffer */
-            assert(virtio_read_data_from_desc_chain(
-                vq, reqbk->virtio_desc_head, request_bytes_to_body_bytes(reqbk->total_req_size),
-                sizeof(struct virtio_blk_outhdr), (char *)reqbk->sddf_data_cell_base));
+            assert(reqbk->sddf_data_offset == 0); /* Should be aligned */
+            assert(virtio_read_data_from_desc_chain(vq, reqbk->virtio_desc_head, proposed_bytes,
+                                                    sizeof(struct virtio_blk_outhdr) + reqbk->bytes_completed,
+                                                    (char *)reqbk->sddf_data_cell_base));
 
-            err = blk_enqueue_req(&state->queue_h, BLK_REQ_WRITE, sddf_offset, reqbk->sddf_block_number,
-                                  reqbk->sddf_count, req_id);
+            err = blk_enqueue_req(&state->queue_h, BLK_REQ_WRITE, sddf_offset, sddf_block, sddf_num_blocks, req_id);
             assert(!err);
 
             reqbk->state = VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED;
         } else if (!aligned_on_transfer_window && !overlap_with_other_requests) {
             /* Read modify write as described above */
-            err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset, reqbk->sddf_block_number,
-                                  reqbk->sddf_count, req_id);
+            err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, sddf_offset, sddf_block, sddf_num_blocks, req_id);
             assert(!err);
 
             reqbk->state = VIRTIO_BLK_REQ_STATE_RMW_READING;
@@ -512,7 +500,6 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
     bool have_responses = false;
     int nums_consumed = 0;
 
-    LOG_BLOCK("------------- handle_client_requests start loop -------------\n");
     uint16_t desc_head;
     while (virtio_virtq_peek_avail(vq, &desc_head)) {
         /* Generate sddf request id and bookkeep the request */
@@ -521,9 +508,8 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
         if (err == -1) {
             goto stop_processing;
         }
-        assert(state->reqsbk[req_id].state == VIRTIO_BLK_REQ_STATE_INVALID);
+        memset(&state->reqsbk[req_id], 0, sizeof(reqbk_t));
 
-        LOG_BLOCK("----- Begin processing request at descriptor head %u -----\n", desc_head);
         assert(decode_virtio_block_request(vq, desc_head, &state->reqsbk[req_id]));
 
         switch (state->reqsbk[req_id].virtio_req_type) {
@@ -549,8 +535,7 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
             }
         }
         case VIRTIO_BLK_T_FLUSH: {
-            LOG_BLOCK("Request type is VIRTIO_BLK_T_FLUSH\n");
-            if (!sddf_make_req_check(state, 0)) {
+            if (!sddf_make_req_check(state)) {
                 state->reqsbk[req_id].state = VIRTIO_BLK_REQ_STATE_INVALID;
                 ialloc_free(&state->ialloc, req_id);
                 goto stop_processing;
@@ -564,8 +549,7 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
             break;
         }
         case VIRTIO_BLK_T_GET_ID: {
-            LOG_BLOCK("Request type is VIRTIO_BLK_T_GET_ID\n");
-            uint32_t body_bytes = request_bytes_to_body_bytes(state->reqsbk[req_id].total_req_size);
+            uint32_t body_bytes = reqbk_to_body_bytes(&state->reqsbk[req_id]);
             uint64_t bytes_to_write = MIN(body_bytes, sizeof(VIRTIO_BLK_DEV_ID));
             assert(virtio_write_data_to_desc_chain(vq, state->reqsbk[req_id].virtio_desc_head, bytes_to_write,
                                                    sizeof(struct virtio_blk_outhdr), VIRTIO_BLK_DEV_ID));
@@ -599,19 +583,16 @@ stop_processing:
 static bool virtio_blk_queue_notify(struct virtio_device *dev)
 {
     int nums_consumed = 0;
-    LOG_BLOCK("virtio_blk_queue_notify calling handle_client_requests\n");
     bool have_responses = handle_client_requests(dev, &nums_consumed);
 
     bool virq_inject_success = true;
     if (have_responses) {
-        LOG_BLOCK("virtio_blk_queue_notify dropped requests\n");
         virtio_set_interrupt_status(dev, true, false);
         virq_inject_success = virtio_inject_interrupt(dev);
     }
 
     struct virtio_blk_device *state = device_state(dev);
     if (nums_consumed && !blk_queue_plugged_req(&state->queue_h)) {
-        LOG_BLOCK("virtio_blk_queue_notify notified virt\n");
         microkit_notify(state->server_ch);
     }
 
@@ -620,8 +601,6 @@ static bool virtio_blk_queue_notify(struct virtio_device *dev)
 
 bool virtio_blk_handle_resp(struct virtio_blk_device *state)
 {
-    LOG_BLOCK(" ----------- Blk virt notified VMM ----------- \n");
-
     int err = 0;
     struct virtio_device *dev = &state->virtio_device;
 
@@ -642,17 +621,17 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
         reqbk_t *reqbk = &state->reqsbk[sddf_ret_id];
         assert(reqbk->state != VIRTIO_BLK_REQ_STATE_INVALID);
 
-        LOG_BLOCK("----- Response for request at descriptor head %u -----\n", reqbk->virtio_desc_head);
-
         bool resp_success = false;
         if (sddf_ret_status == BLK_RESP_OK) {
             resp_success = true;
             switch (reqbk->virtio_req_type) {
             case VIRTIO_BLK_T_IN: {
                 /* Copy data into guest RAM */
-                assert(virtio_write_data_to_desc_chain(
-                    vq, reqbk->virtio_desc_head, request_bytes_to_body_bytes(reqbk->total_req_size),
-                    sizeof(struct virtio_blk_outhdr), (char *)(reqbk->sddf_data_cell_base + reqbk->sddf_data_offset)));
+                assert(virtio_write_data_to_desc_chain(vq, reqbk->virtio_desc_head, reqbk->bytes_in_flight,
+                                                       sizeof(struct virtio_blk_outhdr) + reqbk->bytes_completed,
+                                                       (char *)(reqbk->sddf_data_cell_base + reqbk->sddf_data_offset)));
+                reqbk->bytes_completed += reqbk->bytes_in_flight;
+                reqbk->bytes_in_flight = 0;
                 break;
             }
             case VIRTIO_BLK_T_OUT: {
@@ -662,21 +641,28 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
                      * surrounding read.
                      */
                     assert(virtio_read_data_from_desc_chain(
-                        vq, reqbk->virtio_desc_head, request_bytes_to_body_bytes(reqbk->total_req_size),
-                        sizeof(struct virtio_blk_outhdr),
+                        vq, reqbk->virtio_desc_head, reqbk->bytes_in_flight,
+                        sizeof(struct virtio_blk_outhdr) + reqbk->bytes_completed,
                         (char *)(reqbk->sddf_data_cell_base + reqbk->sddf_data_offset)));
 
                     state->reqsbk[sddf_ret_id].state = VIRTIO_BLK_REQ_STATE_RMW_WRITING;
                     err = blk_enqueue_req(&state->queue_h, BLK_REQ_WRITE,
                                           reqbk->sddf_data_cell_base
                                               - ((struct virtio_blk_device *)dev->device_data)->data_region,
-                                          reqbk->sddf_block_number, reqbk->sddf_count, sddf_ret_id);
+                                          reqbk_to_sddf_block_num(reqbk), reqbk->sddf_count_in_flight, sddf_ret_id);
                     assert(!err);
                     virt_notify = true;
                     read_write_modify_inflight = true;
                     /* The virtIO request is not complete yet so we don't tell the driver
                      * (just skip over to next request) */
                     continue;
+                } else if (reqbk->state == VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED
+                           || reqbk->state == VIRTIO_BLK_REQ_STATE_RMW_WRITING) {
+                    reqbk->bytes_completed += reqbk->bytes_in_flight;
+                    reqbk->bytes_in_flight = 0;
+                } else {
+                    /* unreachable unless bugs */
+                    assert(false);
                 }
                 break;
             }
@@ -690,6 +676,12 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
                 break;
             }
             }
+
+            assert(reqbk->bytes_completed + reqbk->bytes_in_flight + reqbk->bytes_remaining
+                   == reqbk_to_body_bytes(reqbk));
+
+            assert(!reqbk->bytes_remaining);
+            assert(!reqbk->bytes_in_flight);
 
             if (reqbk->state == VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED
                 || reqbk->state == VIRTIO_BLK_REQ_STATE_RMW_WRITING) {
@@ -724,7 +716,8 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
                                                        - ((struct virtio_blk_device *)dev->device_data)->data_region;
 
                             err = blk_enqueue_req(&state->queue_h, BLK_REQ_READ, next_sddf_offset,
-                                                  state->reqsbk[i].sddf_block_number, state->reqsbk[i].sddf_count, i);
+                                                  reqbk_to_sddf_block_num(&state->reqsbk[i]),
+                                                  state->reqsbk[i].sddf_count_in_flight, i);
                             assert(!err);
 
                             virt_notify = true;
@@ -748,7 +741,7 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
          * success status.
          */
         if (reqbk->virtio_req_type == VIRTIO_BLK_T_IN || reqbk->virtio_req_type == VIRTIO_BLK_T_OUT) {
-            fsmalloc_free(&state->fsmalloc, reqbk->sddf_data_cell_base, reqbk->sddf_count);
+            fsmalloc_free(&state->fsmalloc, reqbk->sddf_data_cell_base, reqbk->sddf_count_in_flight);
         }
 
         virtio_virtq_add_used(vq, reqbk->virtio_desc_head, 0);
@@ -762,9 +755,7 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
 
     int nums_pending_cmds_consumed = 0;
     if (!read_write_modify_inflight) {
-        LOG_BLOCK("virtio_blk_handle_resp calling handle_client_requests\n");
         handle_client_requests(dev, &nums_pending_cmds_consumed);
-        LOG_BLOCK("handle_client_requests consumed %d reqs\n", nums_pending_cmds_consumed);
         if (nums_pending_cmds_consumed) {
             virt_notify = true;
         }
@@ -780,7 +771,6 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
     }
 
     if (virt_notify) {
-        LOG_BLOCK("virtio_blk_handle_resp virt notify\n");
         microkit_notify(state->server_ch);
     }
 

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -336,7 +336,7 @@ bool decode_virtio_block_request(virtio_queue_handler_t *vq_handler, uint16_t de
 
     LOG_BLOCK("decode_virtio_block_request(): decoding desc head %u\n", desc_head);
     uint64_t payload_len = virtio_desc_chain_payload_len(vq_handler, desc_head);
-    if (payload_len < sizeof(struct virtio_blk_outhdr)) {
+    if (payload_len < sizeof(struct virtio_blk_outhdr) + 1) {
         /* Malicious guest driver */
         LOG_BLOCK_ERR("decode_virtio_block_request(): desc head %u, payload length %lu bytes too short\n", desc_head,
                       payload_len);

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -839,7 +839,7 @@ static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, 
     fsmalloc_init(&blk_dev->fsmalloc, data_region, BLK_TRANSFER_SIZE, num_sddf_cells, &blk_dev->fsmalloc_avail_bitarr,
                   blk_dev->fsmalloc_avail_bitarr_words, BITS_2_WORDS64(num_sddf_cells));
 
-    ialloc_init(&blk_dev->ialloc, blk_dev->ialloc_idxlist, num_sddf_cells);
+    ialloc_init(&blk_dev->ialloc, blk_dev->ialloc_idxlist, SDDF_MAX_QUEUE_CAPACITY);
 
     return dev;
 }

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -91,6 +91,12 @@
  * to dispatch RMW for the first request, wait asynchronously for that to finish. Then dispatch
  * RMW for the second request.
  *
+ * When the guest did not negotiate VIRTIO_BLK_F_SIZE_MAX or VIRTIO_BLK_F_SEG_MAX, it is possible
+ * that it will give us a request with a data size that exceeds our sDDF block data region size.
+ * Meaning we will never be able to satisfy the request and leading to the guest deadlocking. To
+ * solve this problem the device will divide the request up into multiple smaller chunk and process
+ * them sequentially, then only consider the request completed when it have finished with all the chunks.
+ *
  * Therefore each virtio block request has an attached state machine. A request can be in one of the
  * following states at any given time:
  * 1. Flushing
@@ -121,6 +127,11 @@
 
 #define VIRTIO_BLK_DEV_ID "libvmm"
 #define SECTORS_IN_TRANSFER_WINDOW (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)
+
+/* If we need to split up the guest's request into multiple chunks for reason explained above then
+ * make the chunk equal to a quarter of the data region. This is arbitrarily chosen, can be increased
+ * or decreased safely up to the data region size. */
+#define CHUNK_SIZE_BYTES ((SDDF_MAX_DATA_CELLS / 4) * BLK_TRANSFER_SIZE)
 
 #define LOG_BLOCK_WARN(...)               \
     do                                   \
@@ -244,23 +255,6 @@ static inline bool virtio_blk_set_device_config(struct virtio_device *dev, uint3
     return true;
 }
 
-/* Check if ialloc and req queue are full.
- * If these all pass then a request without a payload (e.g. flush) can be handled successfully */
-static inline bool sddf_make_req_check(struct virtio_blk_device *state)
-{
-    if (ialloc_full(&state->ialloc)) {
-        LOG_BLOCK_WARN("Request bookkeeping array is full\n");
-        return false;
-    }
-
-    if (blk_queue_full_req(&state->queue_h)) {
-        LOG_BLOCK_WARN("Request queue is full\n");
-        return false;
-    }
-
-    return true;
-}
-
 /* What is the number of bytes that the guest want to read from/write to the disk? */
 static uint64_t reqbk_to_body_bytes(reqbk_t *reqbk)
 {
@@ -361,7 +355,6 @@ bool decode_virtio_block_request(virtio_queue_handler_t *vq_handler, uint16_t de
 
     ret->virtio_req_type = header.type;
     ret->virtio_sector = header.sector;
-    ret->sddf_data_offset = reqbk_to_sddf_data_offset(ret);
     ret->bytes_remaining = reqbk_to_body_bytes(ret);
 
     return true;
@@ -380,42 +373,32 @@ static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t
     struct virtio_blk_device *state = device_state(dev);
 
     bool resources_ok = true;
-    if (!sddf_make_req_check(state)) {
-        /* One of the bookkeeping array is full, give up for now, resources will
-         * become available later. */
-        resources_ok = false;
-    }
 
     /* Allocate data cells from sddf data region for the entire request. This may fail since
      * there might be fragmentation in the data region or a few requests are using a lot of
-     * space. */
+     * space.
+     *
+     * But if the entire request can't fit in the data region then we will have to split it up.
+     *
+     * We check against `reqbk_to_body_bytes(reqbk)` rather than reqbk->bytes_remaining here
+     * because this will be called again in `virtio_blk_handle_resp` and the situation might
+     * change such that the remaining chunks will be under SDDF_MAX_DATA_CELLS. But we might
+     * not have enough resources for them and fail. We cannot fail in `virtio_blk_handle_resp`
+     * so once the request is chunked it stays chunked. */
     uint64_t proposed_bytes = reqbk->bytes_remaining;
     uint64_t sddf_num_blocks = reqbk_to_sddf_num_blocks(reqbk, proposed_bytes);
+    if (reqbk_to_sddf_num_blocks(reqbk, reqbk_to_body_bytes(reqbk)) > SDDF_MAX_DATA_CELLS) {
+        proposed_bytes = MIN(CHUNK_SIZE_BYTES, reqbk->bytes_remaining);
+        sddf_num_blocks = reqbk_to_sddf_num_blocks(reqbk, proposed_bytes);
+    }
+
     if (fsmalloc_alloc(&state->fsmalloc, &reqbk->sddf_data_cell_base, sddf_num_blocks) == -1) {
+        /* Data region is full. Eventually we will be able to service this request.
+         * We should only get here if this is a fresh request and this function was called from
+         * handle_client_requests(). */
+        assert(reqbk->bytes_completed == 0);
         LOG_BLOCK_WARN("Data region is full\n");
         resources_ok = false;
-
-        // /* Hmm data region is full. Eventually we will be able to service this request. But
-        //     * if the request is larger than the sDDF Block data region then we will never be
-        //     * able to and would deadlock the guest. This is a realistic scenario as OVMF doesn't
-        //     * negotiate VIRTIO_BLK_F_SIZE_MAX and VIRTIO_BLK_F_SEG_MAX which is annoying.
-        //     *
-        //     * Lets try salvaging the situation by splitting the request up and service the
-        //     * request block by block. This is ok for the firmware since performance
-        //     * isn't critical. Once the guest OS boots properly their better driver will take over
-        //     * and negotiate the features. */
-
-        // if (fsmalloc_alloc(&state->fsmalloc, &state->reqsbk[req_id].sddf_data_cell_base, 1) == -1) {
-        //     /* Can't really do anything, give up. */
-        //     LOG_BLOCK_WARN("Data region is full\n");
-        //     resources_ok = false;
-        // } else {
-        //     LOG_VMM("splitting up %s request sector %u, body size %u\n",
-        //             state->reqsbk[req_id].virtio_req_type == VIRTIO_BLK_T_IN ? "Read" : "Write",
-        //             state->reqsbk[req_id].virtio_sector, state->reqsbk[req_id].sddf_block_number,
-        //             request_bytes_to_body_bytes(state->reqsbk[req_id].total_req_size));
-        //     state->reqsbk[req_id].sddf_count = 1;
-        // }
     }
 
     if (!resources_ok) {
@@ -427,6 +410,7 @@ static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t
     uintptr_t sddf_offset = reqbk->sddf_data_cell_base - ((struct virtio_blk_device *)dev->device_data)->data_region;
     uint64_t sddf_block = reqbk_to_sddf_block_num(reqbk);
 
+    reqbk->sddf_data_offset = reqbk_to_sddf_data_offset(reqbk);
     reqbk->sddf_count_in_flight = sddf_num_blocks;
     reqbk->bytes_remaining -= proposed_bytes;
     reqbk->bytes_in_flight += proposed_bytes;
@@ -489,7 +473,6 @@ static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t
 /* Returns true if there are responses ready for the guest */
 static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_consumed)
 {
-    int err = 0;
     /* If multiqueue feature bit negotiated, should read which queue from
        dev->QueueNotify, but for now we just assume it's the one and only default
        queue */
@@ -504,8 +487,11 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
     while (virtio_virtq_peek_avail(vq, &desc_head)) {
         /* Generate sddf request id and bookkeep the request */
         uint32_t req_id;
-        err = ialloc_alloc(&state->ialloc, &req_id);
-        if (err == -1) {
+        if (ialloc_alloc(&state->ialloc, &req_id) == -1) {
+            goto stop_processing;
+        }
+        if (blk_queue_full_req(&state->queue_h)) {
+            ialloc_free(&state->ialloc, req_id);
             goto stop_processing;
         }
         memset(&state->reqsbk[req_id], 0, sizeof(reqbk_t));
@@ -535,15 +521,10 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
             }
         }
         case VIRTIO_BLK_T_FLUSH: {
-            if (!sddf_make_req_check(state)) {
-                state->reqsbk[req_id].state = VIRTIO_BLK_REQ_STATE_INVALID;
-                ialloc_free(&state->ialloc, req_id);
-                goto stop_processing;
-            }
-
             state->reqsbk[req_id].state = VIRTIO_BLK_REQ_STATE_FLUSHING;
 
-            err = blk_enqueue_req(&state->queue_h, BLK_REQ_FLUSH, 0, 0, 0, req_id);
+            int err = blk_enqueue_req(&state->queue_h, BLK_REQ_FLUSH, 0, 0, 0, req_id);
+            assert(!err);
             nums_consumed += 1;
             assert(virtio_virtq_pop_avail(vq, &desc_head));
             break;
@@ -679,9 +660,23 @@ bool virtio_blk_handle_resp(struct virtio_blk_device *state)
 
             assert(reqbk->bytes_completed + reqbk->bytes_in_flight + reqbk->bytes_remaining
                    == reqbk_to_body_bytes(reqbk));
-
-            assert(!reqbk->bytes_remaining);
             assert(!reqbk->bytes_in_flight);
+            /* If we get here then the current chunk in the request have been completed in full.
+             * Process the next chunk if we still have work to do for this request. */
+            if (reqbk->bytes_remaining) {
+                fsmalloc_free(&state->fsmalloc, reqbk->sddf_data_cell_base, reqbk->sddf_count_in_flight);
+                reqbk->sddf_data_cell_base = 0;
+                reqbk->sddf_count_in_flight = 0;
+
+                /* This should not fail since we have freed resources of the previous chunk and all the
+                 * chunks are the same size if a request is chunked.
+                 * i.e. fsmalloc_free have already made contiguous free hole for the next chunk. */
+                assert(dispatch_request(dev, reqbk, sddf_ret_id));
+                virt_notify = true;
+
+                /* Skip over to the next request, this request have not finished yet. */
+                continue;
+            }
 
             if (reqbk->state == VIRTIO_BLK_REQ_STATE_WRITING_ALIGNED
                 || reqbk->state == VIRTIO_BLK_REQ_STATE_RMW_WRITING) {


### PR DESCRIPTION
Previously, the device will hang the guest if the guest did not
negotiate VIRTIO_BLK_F_SIZE_MAX or VIRTIO_BLK_F_SEG_MAX and passed a
request that is larger than the sDDF Block data region. Since the device
will never be able to service the request.

Now, the device is smart enough to detect this and process the large
request in chunks if necessary.

This is required for OVMF since it doesn't negotiate the features and
just make huge requests.

Then I made other refactors and fixes.