### PR TITLE
virtio: deassert interrupt on reset

### DIFF
--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -169,6 +169,7 @@ static inline void virtio_blk_reset(struct virtio_device *dev)
     }
     assert(blk_queue_empty_req(&device_state(dev)->queue_h));
     assert(blk_queue_empty_resp(&device_state(dev)->queue_h));
+    virtio_set_interrupt_status(dev, false, false);
     memset(&dev->regs, 0, sizeof(virtio_device_regs_t));
     memset(device_state(dev)->reqsbk, 0, sizeof((device_state(dev)->reqsbk)));
 

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -60,6 +60,7 @@ static void virtio_console_reset(struct virtio_device *dev)
         dev->vqs[i].virtq.num = 0;
     }
 
+    virtio_set_interrupt_status(dev, false, false);
     memset(&dev->regs, 0, sizeof(virtio_device_regs_t));
     virtio_console_regs_init(dev);
 }

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -49,6 +49,7 @@ static void virtio_net_reset(struct virtio_device *dev)
         dev->vqs[i].virtq.num = 0;
     }
 
+    virtio_set_interrupt_status(dev, false, false);
     memset(&dev->regs, 0, sizeof(virtio_device_regs_t));
     virtio_net_regs_init(dev);
 }


### PR DESCRIPTION
Just to be safe, since PCI INTx interrupts are level triggered, so virtio_set_interrupt_status() will have a lingering side effect. If the guest didn't clear the ISR then reset the device, it can get infinitely interrupted.