### PR TITLE
x86_64/apic: MIN_VECTOR is 16 not 32.

### DIFF
--- a/src/arch/x86_64/apic.c
+++ b/src/arch/x86_64/apic.c
@@ -43,7 +43,7 @@ char lapic_regs[LAPIC_REG_BLOCK_SIZE];
  */
 
 /* [1] "12.5.2 Valid Interrupt Vectors" */
-#define MIN_VECTOR 32
+#define MIN_VECTOR 16
 
 #define LAPIC_NUM_ISR_IRR_TMR_32B 8
 #define MAX_VECTOR (LAPIC_NUM_ISR_IRR_TMR_32B * 32)


### PR DESCRIPTION
I made a mistake while reading the Intel SDM. Before this commit, if the guest chooses an interrupt vector between 16 and 31 it will never get the interrupt. Fixes Windows hanging on boot.