### PR TITLE
x86_64/acpi: fix truncated FADT

### DIFF
--- a/include/libvmm/arch/x86_64/acpi.h
+++ b/include/libvmm/arch/x86_64/acpi.h
@@ -291,6 +291,10 @@ struct fadt {
     struct address_structure X_PMTimerBlock;
     struct address_structure X_GPE0Block;
     struct address_structure X_GPE1Block;
+
+    struct address_structure SleepControlReg;
+    struct address_structure SleepStatusReg;
+    uint64_t HypervisorVendorIdentity;
 } __attribute__((packed));
 
 ////////////////////////////////////////


### PR DESCRIPTION
We declare that our FADT is version 6, but used the layout of an older version which have missing field. So the guest will see that our FADT is truncated, as reported by WinDbg:

```
kd> !acpitable FACP
FADT -- fffff8061dc4a060
dumpFADT: (fffff8061dc4a060) Length (0x0000f4) is not the size of the FADT (0x000114)
```

After this fix windbg will recognise that our FADT is fully valid.