### PR TITLE
uefi: add hardware info fw cfg blob 

### DIFF
--- a/examples/uefi/vmm.c
+++ b/examples/uefi/vmm.c
@@ -42,7 +42,8 @@ uintptr_t guest_flash_vaddr;
 uint64_t guest_flash_size;
 
 /* OVMF expects a standard PC PCI bus, so we just make a small aperature at an arbitrary guest
- * RAM location. */
+ * RAM location to trigger libvmm to build a virtual PCI bus. But otherwise this example doesn't
+ * use the virtual PCI unless you extend it to do so. */
 #define PCI_MMIO_APERATURE_GPA 0xE0000000
 #define PCI_MMIO_APERATURE_SIZE 0x200000
 

--- a/include/libvmm/uefi/hardware_info.h
+++ b/include/libvmm/uefi/hardware_info.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * The struct definitions in this file is a reimplementation from an equivalent file in EDK II:
+ * https://github.com/tianocore/edk2/blob/3fec6254088b8585e35f660b4fe289b179a15349/OvmfPkg/Library/HardwareInfoLib/HardwareInfoTypesLib.h
+ * https://github.com/tianocore/edk2/blob/3fec6254088b8585e35f660b4fe289b179a15349/OvmfPkg/Library/HardwareInfoLib/HardwareInfoPciHostBridgeLib.h
+ *
+ * Hardware info types' definitions.
+ * General hardware info types to parse the binary data
+ * Copyright 2021 - 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+enum {
+    HW_INFO_TYPE_UNDEFINED = 0,
+    HW_INFO_TYPE_HOST_BRIDGE = 1,
+    HW_INFO_TYPE_QEMU_UEFI_VARS = 2,
+    HW_INFO_TYPE_SVSM_VIRTIO_MMIO = 0x1000,
+};
+
+struct hw_info_header {
+    uint64_t type;
+    uint64_t size;
+} __attribute__((packed));
+
+/* Host bridge resources information. */
+struct host_bridge_info {
+    /* Feature tracking, initially 0 */
+    uint64_t version;
+
+    /* Host bridge enabled attributes (EFI_PCI_ATTRIBUTE_*) */
+    uint64_t attributes;
+
+    union {
+        uint32_t uint32;
+        struct {
+            uint32_t dma_above_4g : 1;
+            uint32_t no_extended_config_space : 1;
+            uint32_t combine_mem_pmem : 1;
+            uint32_t reserved : 29;
+        } bits;
+    } flags;
+
+    /* Bus number range */
+    uint8_t bus_nr_start;
+    uint8_t bus_nr_last;
+
+    uint8_t padding[2];
+
+    /*
+     * IO aperture
+     */
+    uint64_t io_start;
+    uint64_t io_size;
+
+    /*
+     * 32-bit MMIO aperture
+     */
+    uint64_t mem_start;
+    uint64_t mem_size;
+
+    /*
+     * 32-bit prefetchable MMIO aperture
+     */
+    uint64_t pmem_start;
+    uint64_t pmem_size;
+
+    /*
+     * 64-bit MMIO aperture
+     */
+    uint64_t mem_above_4g_start;
+    uint64_t mem_above_4g_size;
+
+    /*
+     * 64-bit prefetchable MMIO aperture
+     */
+    uint64_t pmem_above_4g_start;
+    uint64_t pmem_above_4g_size;
+
+    /*
+     * MMIO accessible PCIe config space (ECAM)
+     */
+    uint64_t pcie_config_start;
+    uint64_t pcie_config_size;
+} __attribute__((packed));
+
+struct hw_info_pci_host_bridge {
+    struct hw_info_header header;
+    struct host_bridge_info body;
+} __attribute__((packed));
+
+/*
+  https://github.com/tianocore/edk2/blob/3fec6254088b8585e35f660b4fe289b179a15349/MdePkg/Include/Protocol/PciRootBridgeIo.h#L4
+  PCI Root Bridge I/O protocol as defined in the UEFI 2.0 specification.
+
+  PCI Root Bridge I/O protocol is used by PCI Bus Driver to perform PCI Memory, PCI I/O,
+  and PCI Configuration cycles on a PCI Root Bridge. It also provides services to perform
+  different types of bus mastering DMA.
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+ */
+#define EFI_PCI_ATTRIBUTE_ISA_MOTHERBOARD_IO    0x0001
+#define EFI_PCI_ATTRIBUTE_ISA_IO                0x0002
+#define EFI_PCI_ATTRIBUTE_VGA_PALETTE_IO        0x0004
+#define EFI_PCI_ATTRIBUTE_VGA_MEMORY            0x0008
+#define EFI_PCI_ATTRIBUTE_VGA_IO                0x0010
+#define EFI_PCI_ATTRIBUTE_IDE_PRIMARY_IO        0x0020
+#define EFI_PCI_ATTRIBUTE_IDE_SECONDARY_IO      0x0040
+#define EFI_PCI_ATTRIBUTE_MEMORY_WRITE_COMBINE  0x0080
+#define EFI_PCI_ATTRIBUTE_MEMORY_CACHED         0x0800
+#define EFI_PCI_ATTRIBUTE_MEMORY_DISABLE        0x1000
+#define EFI_PCI_ATTRIBUTE_DUAL_ADDRESS_CYCLE    0x8000
+#define EFI_PCI_ATTRIBUTE_ISA_IO_16             0x10000
+#define EFI_PCI_ATTRIBUTE_VGA_PALETTE_IO_16     0x20000
+#define EFI_PCI_ATTRIBUTE_VGA_IO_16             0x40000

--- a/src/arch/x86_64/uefi.c
+++ b/src/arch/x86_64/uefi.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <libvmm/guest.h>
 #include <libvmm/guest_ram.h>
 #include <libvmm/pci.h>
 #include <libvmm/util/util.h>
@@ -18,6 +19,8 @@
 #include <libvmm/uefi/table_loader.h>
 #include <libvmm/uefi/hardware_info.h>
 #include <sddf/util/util.h>
+
+extern guest_t guest;
 
 /* Document referenced:
  * https://github.com/tianocore/edk2/blob/edk2-stable202605/OvmfPkg/README */
@@ -104,6 +107,12 @@ bool uefi_setup_images(uintptr_t firm_src, size_t firm_size, uintptr_t dsdt_src,
         return false;
     }
 
+    uint64_t mmio_aperature_gpa, mmio_aperature_size;
+    if (!pci_bus_get_mmio_aperature(&mmio_aperature_gpa, &mmio_aperature_size)) {
+        LOG_VMM_ERR("Virtual PCI bus must be initialised for UEFI\n");
+        return false;
+    }
+
     void *dest = gpa_to_hva(flash_gpa + (flash_size - firm_size), firm_size);
     if (!dest) {
         LOG_VMM_ERR(
@@ -138,9 +147,6 @@ bool uefi_setup_images(uintptr_t firm_src, size_t firm_size, uintptr_t dsdt_src,
     }
 
     /* Metadata about our virtual PCI bus */
-    uint64_t mmio_aperature_gpa, mmio_aperature_size;
-    assert(pci_bus_get_mmio_aperature(&mmio_aperature_gpa, &mmio_aperature_size));
-
     uefi_hw_info_pci.header = (struct hw_info_header) {
         .type = HW_INFO_TYPE_HOST_BRIDGE,
         .size = sizeof(struct host_bridge_info),

--- a/src/arch/x86_64/uefi.c
+++ b/src/arch/x86_64/uefi.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <libvmm/guest_ram.h>
+#include <libvmm/pci.h>
 #include <libvmm/util/util.h>
 #include <libvmm/arch/x86_64/vcpu.h>
 #include <libvmm/arch/x86_64/uefi.h>
@@ -15,6 +16,7 @@
 #include <libvmm/arch/x86_64/acpi.h>
 #include <libvmm/uefi/fw_cfg.h>
 #include <libvmm/uefi/table_loader.h>
+#include <libvmm/uefi/hardware_info.h>
 #include <sddf/util/util.h>
 
 /* Document referenced:
@@ -28,6 +30,8 @@
 /* These are defined in OVMF but only on loongarch, we will reuse them for the table loader */
 #define ACPI_XSDP_FWCFG_FILENAME "etc/acpi/rsdp"
 #define ACPI_TABLES_FWCFG_FILENAME "etc/acpi/tables"
+/* https://github.com/tianocore/edk2/blob/b03a21a63e3bd001f52c527e5a57feddb53a690b/OvmfPkg/Library/PciHostBridgeUtilityLib/PciHostBridgeUtilityLib.c#L468 */
+#define HW_INFO_FWCFG_FILENAME "etc/hardware-info"
 
 /* Backing storage for the E820 table we need to provide to the firmware, static since
  * the fw_cfg code expects the lifetime of the buffer to be equal to the lifetime of the VMM.
@@ -57,6 +61,9 @@ static qemu_loader_entry_t uefi_table_loader[UEFI_MAX_NUM_TABLE_LOADER_CMD];
 #define COMMAND_LINE_BUF_SIZE (COMMAND_LINE_SIZE + 1)
 static char uefi_linux_cmdline[COMMAND_LINE_BUF_SIZE] = { 0 };
 static uint32_t uefi_linux_cmdline_size = 0;
+
+/* Same but for the PCI metadata structure. */
+struct hw_info_pci_host_bridge uefi_hw_info_pci;
 
 bool uefi_setup_images(uintptr_t firm_src, size_t firm_size, uintptr_t dsdt_src, size_t dsdt_size, uint64_t flash_gpa,
                        size_t flash_size)
@@ -127,6 +134,33 @@ bool uefi_setup_images(uintptr_t firm_src, size_t firm_size, uintptr_t dsdt_src,
     if (!fw_cfg_add_named_file(E820_FWCFG_FILENAME, strlen(E820_FWCFG_FILENAME), (uint8_t *)&uefi_e820,
                                sizeof(struct boot_e820_entry) * num_guest_ram_regions)) {
         LOG_VMM_ERR("Failed to add '%s' file to fw cfg\n", E820_FWCFG_FILENAME);
+        return false;
+    }
+
+    /* Metadata about our virtual PCI bus */
+    uint64_t mmio_aperature_gpa, mmio_aperature_size;
+    assert(pci_bus_get_mmio_aperature(&mmio_aperature_gpa, &mmio_aperature_size));
+
+    uefi_hw_info_pci.header = (struct hw_info_header) {
+        .type = HW_INFO_TYPE_HOST_BRIDGE,
+        .size = sizeof(struct host_bridge_info),
+    };
+    uefi_hw_info_pci.body = (struct host_bridge_info) {
+        .flags.bits.combine_mem_pmem = 1,
+        .flags.bits.dma_above_4g = 1,
+        .flags.bits.no_extended_config_space = 1,
+        .attributes = EFI_PCI_ATTRIBUTE_ISA_MOTHERBOARD_IO | EFI_PCI_ATTRIBUTE_ISA_IO | EFI_PCI_ATTRIBUTE_ISA_IO_16,
+        .io_start = 0,
+        .io_size = 0,
+        .mem_start = mmio_aperature_gpa,
+        .mem_size = mmio_aperature_size,
+        .pcie_config_start = 0,
+        .pcie_config_size = 0,
+    };
+
+    if (!fw_cfg_add_named_file(HW_INFO_FWCFG_FILENAME, strlen(HW_INFO_FWCFG_FILENAME), (uint8_t *)&uefi_hw_info_pci,
+                               sizeof(struct hw_info_pci_host_bridge))) {
+        LOG_VMM_ERR("Failed to add '%s' file to fw cfg\n", HW_INFO_FWCFG_FILENAME);
         return false;
     }
 


### PR DESCRIPTION
This is the protocol OVMF provides for the hypervisor to communicate
the details of its virtual PCI bus to the firmware. The firmware then
uses this information to allocate addresses for all PCI devices' BARs.
This is necessary because unlike Linux or Windows, OVMF does not have
the capability to parse our compiled DSDT to find this information.

With this commit, OVMF will now recognise our virtIO Network and Block
devices. So now it can boot a guest OS installed on the virtIO Block
device, rather than having to manually load a Linux kernel, initrd and
cmdline.