### PR TITLE
vmm.mk: only enable UBSAN on Microkit debug configs

### DIFF
--- a/vmm.mk
+++ b/vmm.mk
@@ -82,8 +82,12 @@ endif
 CFILES += ${ARCH_INDEP_FILES}
 OBJECTS := $(subst src,libvmm,${CFILES:.c=.o})
 
-# Enable LLVM UBSAN to trap on detected undefined behaviour
-CFLAGS += -fsanitize=undefined -fsanitize-trap=undefined -Wall -Werror -Wno-unused-function
+CFLAGS += -Wall -Werror -Wno-unused-function
+
+# Enable LLVM UBSAN to trap on detected undefined behaviour for debug configurations
+ifneq ($(findstring debug,$(MICROKIT_CONFIG)),)
+    CFLAGS += -fsanitize=undefined -fsanitize-trap=undefined
+endif
 
 # Generate dependencies automatically
 CFLAGS += -MD -Wall -Werror -Wno-unused-function


### PR DESCRIPTION
It doesn't make sense to enable UBSAN on release or benchmark configs because you won't see the crash print. So the performance is degraded for no reason.