### PR TITLE
x86_64/hpet: fix comparator config read not being returned to guest

### DIFF
--- a/src/arch/x86_64/hpet.c
+++ b/src/arch/x86_64/hpet.c
@@ -97,15 +97,15 @@ static uint32_t hpet_counter_offset = 0;
 static struct hpet_regs hpet_regs = {
     // 32-bit main counter, 3 comparators (only 1 periodic capable), legacy IRQ routing capable, tick rate = 10MHz
     .general_capabilities = GENERAL_CAP_MASK,
-    .comparators[0] = { .config = TIM0_CONF_MASK,
+    .comparators[0] = { .config = TIM0_CONF_MASK | (TIM0_IOAPIC_PIN << Tn_INT_ROUTE_CNF_SHIFT),
                         .config_mask = TIM0_CONF_MASK,
                         .timeout_handle_valid = false,
                         .irq_registered = false },
-    .comparators[1] = { .config = TIM1_CONF_MASK,
+    .comparators[1] = { .config = TIM1_CONF_MASK | (TIM1_IOAPIC_PIN << Tn_INT_ROUTE_CNF_SHIFT),
                         .config_mask = TIM1_CONF_MASK,
                         .timeout_handle_valid = false,
                         .irq_registered = false },
-    .comparators[2] = { .config = TIM2_CONF_MASK,
+    .comparators[2] = { .config = TIM2_CONF_MASK | (TIM2_IOAPIC_PIN << Tn_INT_ROUTE_CNF_SHIFT),
                         .config_mask = TIM2_CONF_MASK,
                         .timeout_handle_valid = false,
                         .irq_registered = false },

--- a/src/arch/x86_64/hpet.c
+++ b/src/arch/x86_64/hpet.c
@@ -410,9 +410,13 @@ bool hpet_fault_handle(seL4_VCPUContext *vctx, uint64_t offset, seL4_Word qualif
             data = 0;
 
         } else if (hpet_fault_on_config(offset, &comparator)) {
-            return hpet_fault_handle_config_read(comparator, &data, decoded_ins);
+            if (!hpet_fault_handle_config_read(comparator, &data, decoded_ins)) {
+                return false;
+            }
         } else if (hpet_fault_on_comparator(offset, &comparator)) {
-            return hpet_fault_handle_comparator_read(comparator, &data, decoded_ins);
+            if (!hpet_fault_handle_comparator_read(comparator, &data, decoded_ins)) {
+                return false;
+            }
         } else {
             LOG_VMM_ERR("Reading unknown HPET register offset 0x%lx\n", offset);
             return false;


### PR DESCRIPTION
Fixes Linux printing these errors on console, since we were just
returning garbage before:

  [    0.101305] hpet: Channel #0 config: Unknown bits 0x40000000
  [    0.102083] hpet: Channel https://github.com/au-ts/libvmm/pull/1 config: Unknown bits 0x40000000
  [    0.102893] hpet: Channel https://github.com/au-ts/libvmm/pull/2 config: Unknown bits 0x40000040