### PR TITLE
x86_64/msr: move MTRR logic to separate file 

### DIFF
--- a/include/libvmm/arch/x86_64/mtrr.h
+++ b/include/libvmm/arch/x86_64/mtrr.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Virtualisation of the x86 Memory Type Range Registers */
+
+bool initialise_mtrr(void);
+bool msr_is_mtrr(uint64_t msr, bool is_read);
+bool handle_mtrr_msr_read(uint64_t msr, uint64_t *result);
+bool handle_mtrr_msr_write(uint64_t msr, uint64_t value);

--- a/src/arch/x86_64/msr.c
+++ b/src/arch/x86_64/msr.c
@@ -27,11 +27,7 @@
 #define IA32_PLATFORM_ID (0x17)
 #define IA32_SPEC_CTRL (0x48)
 #define IA32_PRED_CMD (0x49)
-#define IA32_PPIN_CTL (0x4e)
-#define IA32_BIOS_UPDT_TRIG (0x79)
-#define IA32_MKTME_KEYID_PARTITIONING (0x87)
 #define IA32_BIOS_SIGN_ID (0x8b)
-#define IA32_CORE_CAPABILITIES (0xcf)
 #define IA32_MISC_ENABLE (0x1a0)
 #define IA32_MCG_CAP (0x179)
 #define IA32_MCG_STATUS (0x17a)
@@ -68,34 +64,8 @@
 #define IA32_MTRR_FIX4K_F0000 (0x26E)
 #define IA32_MTRR_FIX4K_F8000 (0x26F)
 
-#define MSR_RAPL_POWER_UNIT  (0x606)
-#define MSR_PKG_ENERGY_STATUS (0x611)
-#define MSR_PP0_ENERGY_STATUS (0x639)
-#define MSR_DRAM_ENERGY_STATUS (0x619)
-#define MSR_PP1_ENERGY_STATUS (0x641)
-#define MSR_PLATFORM_ENERGY_COUNTER (0x64d)
-#define MSR_PPERF (0x64e)
-#define MSR_SMI_COUNT (0x34)
-#define MSR_CORE_C3_RESIDENCY (0x3fc)
-#define MSR_CORE_C6_RESIDENCY (0x3fd)
-#define MSR_CORE_C7_RESIDENCY (0x3fe)
-#define MSR_PKG_C2_RESIDENCY (0x60d)
-#define MSR_PKG_C2_RESIDENCY_ALT (0x3f8)
-#define MSR_PKG_C4_RESIDENCY (0x3f9)
-#define MSR_PKG_C6_RESIDENCY (0x3fa)
-#define MSR_OS_MAILBOX_INTERFACE		0xB0
-#define MSR_OS_MAILBOX_DATA			0xB1
-
-// @billn seems to be some sort of fencing instruction control
-// https://gruss.cc/files/msrtemplating.pdf
-#define MSR_UNKNOWN1 (0xc0011029)
-
 #define IA32_APIC_BASE (0x1b)
 #define IA32_FEATURE_CONTROL (0x3a)
-#define MISC_FEATURE_ENABLES (0x140)
-#define MSR_PLATFORM_INFO (0xce)
-
-#define MSR_TEST_CTRL (0x33)
 
 /* x86-64 specific MSRs */
 #define MSR_EFER            0xc0000080 /* extended feature register */

--- a/src/arch/x86_64/msr.c
+++ b/src/arch/x86_64/msr.c
@@ -13,6 +13,7 @@
 #include <libvmm/arch/x86_64/fault.h>
 #include <libvmm/arch/x86_64/guest_time.h>
 #include <libvmm/arch/x86_64/memory_space.h>
+#include <libvmm/arch/x86_64/mtrr.h>
 
 #include <x86intrin.h>
 
@@ -34,36 +35,6 @@
 #define IA32_PAT (0x277)
 #define IA32_XSS (0xda0)
 
-#define IA32_MTRRCAP (0xfe)
-#define IA32_MTRR_DEF_TYPE (0x2ff)
-#define IA32_MTRR_PHYSBASE0 (0x200)
-#define IA32_MTRR_PHYSMASK0 (0x201)
-#define IA32_MTRR_PHYSBASE1 (0x202)
-#define IA32_MTRR_PHYSMASK1 (0x203)
-#define IA32_MTRR_PHYSBASE2 (0x204)
-#define IA32_MTRR_PHYSMASK2 (0x205)
-#define IA32_MTRR_PHYSBASE3 (0x206)
-#define IA32_MTRR_PHYSMASK3 (0x207)
-#define IA32_MTRR_PHYSBASE4 (0x208)
-#define IA32_MTRR_PHYSMASK4 (0x209)
-#define IA32_MTRR_PHYSBASE5 (0x20A)
-#define IA32_MTRR_PHYSMASK5 (0x20B)
-#define IA32_MTRR_PHYSBASE6 (0x20C)
-#define IA32_MTRR_PHYSMASK6 (0x20D)
-#define IA32_MTRR_PHYSBASE7 (0x20E)
-#define IA32_MTRR_PHYSMASK7 (0x20F)
-#define IA32_MTRR_FIX64K_00000 (0x250)
-#define IA32_MTRR_FIX16K_80000 (0x258)
-#define IA32_MTRR_FIX16K_A0000 (0x259)
-#define IA32_MTRR_FIX4K_C0000 (0x268)
-#define IA32_MTRR_FIX4K_C8000 (0x269)
-#define IA32_MTRR_FIX4K_D0000 (0x26A)
-#define IA32_MTRR_FIX4K_D8000 (0x26B)
-#define IA32_MTRR_FIX4K_E0000 (0x26C)
-#define IA32_MTRR_FIX4K_E8000 (0x26D)
-#define IA32_MTRR_FIX4K_F0000 (0x26E)
-#define IA32_MTRR_FIX4K_F8000 (0x26F)
-
 #define IA32_APIC_BASE (0x1b)
 #define IA32_FEATURE_CONTROL (0x3a)
 
@@ -74,24 +45,8 @@
 #define MSR_CSTAR           0xc0000083 /* compat mode SYSCALL target */
 #define MSR_SYSCALL_MASK    0xc0000084 /* EFLAGS mask for syscall */
 
-/* MTRRs virtualisation */
-#define MTRR_MAX_VARIABLES 8
-
-struct mtrr_state {
-    uint64_t mtrr_def_type;
-    uint64_t fixed_64k;    /* 0x250 */
-    uint64_t fixed_16k[2]; /* 0x258, 0x259 */
-    uint64_t fixed_4k[8];  /* 0x268 - 0x26F */
-
-    struct {
-        uint64_t base;
-        uint64_t mask;
-    } variable[MTRR_MAX_VARIABLES];
-};
-
 static bool msrs_initialised = false;
 static uint32_t apic_base_msr_mask = 0;
-static struct mtrr_state mtrr_state;
 
 bool initialise_msrs(bool bsp)
 {
@@ -100,9 +55,7 @@ bool initialise_msrs(bool bsp)
          * Is a boot strap processor. */
         apic_base_msr_mask = BIT(8);
 
-        /* See "IA32_MTRR_DEF_TYPE MSR"
-         * Enable MTRRs */
-        mtrr_state.mtrr_def_type = BIT(11);
+        assert(initialise_mtrr());
     }
 
     msrs_initialised = true;
@@ -119,68 +72,41 @@ bool emulate_rdmsr(seL4_VCPUContext *vctx)
 
     uint64_t result = 0;
 
-    switch (vctx->ecx) {
-    case MSR_EFER:
-        result = microkit_vcpu_x86_read_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_EFER);
-        break;
-    case IA32_TIME_STAMP_COUNTER:
-        result = guest_time_tsc_now();
-        break;
-    case MSR_STAR:
-    case MSR_LSTAR:
-    case MSR_CSTAR:
-    case MSR_SYSCALL_MASK:
-        result = microkit_vcpu_x86_read_msr(GUEST_BOOT_VCPU_ID, vctx->ecx);
-        break;
-    case IA32_APIC_BASE:
-        /* Figure 11-5. IA32_APIC_BASE MSR (APIC_BASE_MSR in P6 Family)
-         *                   enable    is boot cpu? */
-        result = LAPIC_GPA | BIT(11) | apic_base_msr_mask;
-        break;
-    case IA32_SPEC_CTRL:
-        // @billn revisit, I think we should use Virtualize IA32_SPEC_CTRL
-        // in Tertiary Processor-Based VM-Execution Controls
-        break;
-    case IA32_PAT:
-        result = microkit_vcpu_x86_read_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_PAT);
-        break;
-    case IA32_MTRRCAP:
-        /* "Table 2-2. IA-32 Architectural MSRs (Contd.)" "IA32_MTRRCAP (MTRRcap)"
-           "Fixed range MTRRs are supported when set" + WC supported. */
-        result = MTRR_MAX_VARIABLES | BIT(8) | BIT(10);
-        break;
-    case IA32_MTRR_DEF_TYPE:
-        result = mtrr_state.mtrr_def_type;
-        break;
-    case IA32_MTRR_PHYSBASE0 ... IA32_MTRR_PHYSMASK7: {
-        int index = (vctx->ecx - IA32_MTRR_PHYSBASE0) / 2;
-        int is_mask = vctx->ecx % 2;
-        if (is_mask) {
-            result = mtrr_state.variable[index].mask;
-        } else {
-            result = mtrr_state.variable[index].base;
+    if (msr_is_mtrr(vctx->ecx, true)) {
+        assert(handle_mtrr_msr_read(vctx->ecx, &result));
+    } else {
+        switch (vctx->ecx) {
+        case MSR_EFER:
+            result = microkit_vcpu_x86_read_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_EFER);
+            break;
+        case IA32_TIME_STAMP_COUNTER:
+            result = guest_time_tsc_now();
+            break;
+        case MSR_STAR:
+        case MSR_LSTAR:
+        case MSR_CSTAR:
+        case MSR_SYSCALL_MASK:
+            result = microkit_vcpu_x86_read_msr(GUEST_BOOT_VCPU_ID, vctx->ecx);
+            break;
+        case IA32_APIC_BASE:
+            /* Figure 11-5. IA32_APIC_BASE MSR (APIC_BASE_MSR in P6 Family)
+             *                   enable    is boot cpu? */
+            result = LAPIC_GPA | BIT(11) | apic_base_msr_mask;
+            break;
+        case IA32_SPEC_CTRL:
+            // @billn revisit, I think we should use Virtualize IA32_SPEC_CTRL
+            // in Tertiary Processor-Based VM-Execution Controls
+            break;
+        case IA32_PAT:
+            result = microkit_vcpu_x86_read_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_PAT);
+            break;
+        case IA32_PLATFORM_ID:
+            result = 0;
+            break;
+        default:
+            LOG_FAULT("unknown MSR read 0x%lx\n", vctx->ecx);
+            return false;
         }
-        break;
-    }
-    case IA32_MTRR_FIX64K_00000:
-        result = mtrr_state.fixed_64k;
-        break;
-    case IA32_MTRR_FIX16K_80000 ... IA32_MTRR_FIX16K_A0000: {
-        int index = vctx->ecx - IA32_MTRR_FIX16K_80000;
-        result = mtrr_state.fixed_16k[index];
-        break;
-    }
-    case IA32_MTRR_FIX4K_C0000 ... IA32_MTRR_FIX4K_F8000: {
-        int index = vctx->ecx - IA32_MTRR_FIX4K_C0000;
-        result = mtrr_state.fixed_4k[index];
-        break;
-    }
-    case IA32_PLATFORM_ID:
-        result = 0;
-        break;
-    default:
-        LOG_FAULT("unknown MSR read 0x%lx\n", vctx->ecx);
-        return false;
     }
 
     LOG_FAULT("handling RDMSR 0x%lx, result 0x%lx\n", vctx->ecx, result);
@@ -201,77 +127,55 @@ bool emulate_wrmsr(seL4_VCPUContext *vctx)
 
     LOG_FAULT("handling WRMSR 0x%lx, value 0x%lx\n", vctx->ecx, value);
 
-    switch (vctx->ecx) {
-    case IA32_APIC_BASE:
+    if (msr_is_mtrr(vctx->ecx, false)) {
+        assert(handle_mtrr_msr_write(vctx->ecx, value));
+    } else {
+        switch (vctx->ecx) {
+        case IA32_APIC_BASE:
         /* Make sure that the guest isn't transitioning our virtual APIC into an invalid state.
          * See Figure 11-5. IA32_APIC_BASE MSR (APIC_BASE_MSR in P6 Family) for bit definitions. */
-        if (value & BIT(10)) {
-            LOG_VMM_ERR("guest tried to enable x2APIC via IA32_APIC_BASE\n");
+            if (value & BIT(10)) {
+                LOG_VMM_ERR("guest tried to enable x2APIC via IA32_APIC_BASE\n");
+                return false;
+            }
+
+            uint64_t requested_apic_base = value & ~0xFFFull;
+            if (requested_apic_base != LAPIC_GPA) {
+                LOG_VMM_ERR("Guest tried to relocate APIC base to 0x%lx\n", requested_apic_base);
+                return false;
+            }
+
+            if (!(value & BIT(11))) {
+                LOG_VMM_ERR("Guest tried to globally disable the APIC (not supported)\n");
+                return false;
+            }
+
+            break;
+        case MSR_EFER:
+            microkit_vcpu_x86_write_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_EFER, value);
+            break;
+        case IA32_PAT:
+            microkit_vcpu_x86_write_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_PAT, value);
+            break;
+        case MSR_STAR:
+        case MSR_LSTAR:
+        case MSR_CSTAR:
+        case MSR_SYSCALL_MASK:
+            microkit_vcpu_x86_write_msr(GUEST_BOOT_VCPU_ID, vctx->ecx, value);
+            return true;
+        case IA32_PRED_CMD:
+        case IA32_SPEC_CTRL:
+            // @billn revisit, security concerns same as IA32_SPEC_CTRL, as they are used for speculative exec controls
+            break;
+        case IA32_XSS:
+            if (value != 0) {
+                LOG_VMM_ERR("unexpected value 0x%lx written to IA32_XSS\n", value);
+            }
+            break;
+        default:
+            LOG_VMM("unknown wrmsr 0x%lx, value 0x%lx\n", vctx->ecx, value);
             return false;
         }
-
-        uint64_t requested_apic_base = value & ~0xFFFull;
-        if (requested_apic_base != LAPIC_GPA) {
-            LOG_VMM_ERR("Guest tried to relocate APIC base to 0x%lx\n", requested_apic_base);
-            return false;
-        }
-
-        if (!(value & BIT(11))) {
-            LOG_VMM_ERR("Guest tried to globally disable the APIC (not supported)\n");
-            return false;
-        }
-
-        break;
-    case MSR_EFER:
-        microkit_vcpu_x86_write_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_EFER, value);
-        break;
-    case IA32_PAT:
-        microkit_vcpu_x86_write_vmcs(GUEST_BOOT_VCPU_ID, VMX_GUEST_PAT, value);
-        break;
-    case IA32_MTRR_DEF_TYPE:
-        mtrr_state.mtrr_def_type = value;
-        break;
-    case IA32_MTRR_PHYSBASE0 ... IA32_MTRR_PHYSMASK7: {
-        int index = (vctx->ecx - IA32_MTRR_PHYSBASE0) / 2;
-        int is_mask = vctx->ecx % 2;
-        if (is_mask) {
-            mtrr_state.variable[index].mask = value;
-        } else {
-            mtrr_state.variable[index].base = value;
-        }
-        break;
-    }
-    case IA32_MTRR_FIX64K_00000:
-        mtrr_state.fixed_64k = value;
-        break;
-    case IA32_MTRR_FIX16K_80000 ... IA32_MTRR_FIX16K_A0000: {
-        int index = vctx->ecx - IA32_MTRR_FIX16K_80000;
-        mtrr_state.fixed_16k[index] = value;
-        break;
-    }
-    case IA32_MTRR_FIX4K_C0000 ... IA32_MTRR_FIX4K_F8000: {
-        int index = vctx->ecx - IA32_MTRR_FIX4K_C0000;
-        mtrr_state.fixed_4k[index] = value;
-        break;
-    }
-    case MSR_STAR:
-    case MSR_LSTAR:
-    case MSR_CSTAR:
-    case MSR_SYSCALL_MASK:
-        microkit_vcpu_x86_write_msr(GUEST_BOOT_VCPU_ID, vctx->ecx, value);
-        return true;
-    case IA32_PRED_CMD:
-    case IA32_SPEC_CTRL:
-        // @billn revisit, security concerns same as IA32_SPEC_CTRL, as they are used for speculative exec controls
-        break;
-    case IA32_XSS:
-        if (value != 0) {
-            LOG_VMM_ERR("unexpected value 0x%lx written to IA32_XSS\n", value);
-        }
-        break;
-    default:
-        LOG_VMM("unknown wrmsr 0x%lx, value 0x%lx\n", vctx->ecx, value);
-        return false;
     }
 
     return true;

--- a/src/arch/x86_64/mtrr.c
+++ b/src/arch/x86_64/mtrr.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <sddf/util/util.h>
+#include <libvmm/util/util.h>
+#include <libvmm/arch/x86_64/msr.h>
+
+/* Virtualisation of the x86 Memory Type Range Registers */
+
+/* Documents referenced:
+ * 1. Intel® 64 and IA-32 Architectures Software Developer’s Manual
+ *    Combined Volumes: 1, 2A, 2B, 2C, 2D, 3A, 3B, 3C, 3D, and 4
+ *    Order Number: 325462-080US June 2023
+ */
+
+#define IA32_MTRRCAP (0xfe)
+#define IA32_MTRR_DEF_TYPE (0x2ff)
+#define IA32_MTRR_PHYSBASE0 (0x200)
+#define IA32_MTRR_PHYSMASK0 (0x201)
+#define IA32_MTRR_PHYSBASE1 (0x202)
+#define IA32_MTRR_PHYSMASK1 (0x203)
+#define IA32_MTRR_PHYSBASE2 (0x204)
+#define IA32_MTRR_PHYSMASK2 (0x205)
+#define IA32_MTRR_PHYSBASE3 (0x206)
+#define IA32_MTRR_PHYSMASK3 (0x207)
+#define IA32_MTRR_PHYSBASE4 (0x208)
+#define IA32_MTRR_PHYSMASK4 (0x209)
+#define IA32_MTRR_PHYSBASE5 (0x20A)
+#define IA32_MTRR_PHYSMASK5 (0x20B)
+#define IA32_MTRR_PHYSBASE6 (0x20C)
+#define IA32_MTRR_PHYSMASK6 (0x20D)
+#define IA32_MTRR_PHYSBASE7 (0x20E)
+#define IA32_MTRR_PHYSMASK7 (0x20F)
+#define IA32_MTRR_FIX64K_00000 (0x250)
+#define IA32_MTRR_FIX16K_80000 (0x258)
+#define IA32_MTRR_FIX16K_A0000 (0x259)
+#define IA32_MTRR_FIX4K_C0000 (0x268)
+#define IA32_MTRR_FIX4K_C8000 (0x269)
+#define IA32_MTRR_FIX4K_D0000 (0x26A)
+#define IA32_MTRR_FIX4K_D8000 (0x26B)
+#define IA32_MTRR_FIX4K_E0000 (0x26C)
+#define IA32_MTRR_FIX4K_E8000 (0x26D)
+#define IA32_MTRR_FIX4K_F0000 (0x26E)
+#define IA32_MTRR_FIX4K_F8000 (0x26F)
+
+#define MTRR_MAX_VARIABLES 8
+
+struct mtrr_state {
+    uint64_t mtrr_def_type;
+    uint64_t fixed_64k;    /* 0x250 */
+    uint64_t fixed_16k[2]; /* 0x258, 0x259 */
+    uint64_t fixed_4k[8];  /* 0x268 - 0x26F */
+
+    struct {
+        uint64_t base;
+        uint64_t mask;
+    } variable[MTRR_MAX_VARIABLES];
+};
+
+static struct mtrr_state mtrr_state;
+
+bool initialise_mtrr(void)
+{
+    /* See "IA32_MTRR_DEF_TYPE MSR"
+     * Enable MTRRs */
+    mtrr_state.mtrr_def_type = BIT(11);
+    return true;
+}
+
+bool msr_is_mtrr(uint64_t msr, bool is_read)
+{
+    if (is_read) {
+        switch (msr) {
+        case IA32_MTRRCAP:
+        case IA32_MTRR_DEF_TYPE:
+        case IA32_MTRR_PHYSBASE0 ... IA32_MTRR_PHYSMASK7:
+        case IA32_MTRR_FIX64K_00000:
+        case IA32_MTRR_FIX16K_80000 ... IA32_MTRR_FIX16K_A0000:
+        case IA32_MTRR_FIX4K_C0000 ... IA32_MTRR_FIX4K_F8000:
+            return true;
+        default:
+            return false;
+        }
+    } else {
+        switch (msr) {
+        case IA32_MTRR_DEF_TYPE:
+        case IA32_MTRR_PHYSBASE0 ... IA32_MTRR_PHYSMASK7:
+        case IA32_MTRR_FIX64K_00000:
+        case IA32_MTRR_FIX16K_80000 ... IA32_MTRR_FIX16K_A0000:
+        case IA32_MTRR_FIX4K_C0000 ... IA32_MTRR_FIX4K_F8000:
+            return true;
+        default:
+            return false;
+        }
+    }
+}
+
+bool handle_mtrr_msr_read(uint64_t msr, uint64_t *result)
+{
+    switch (msr) {
+    case IA32_MTRRCAP:
+        /* "Table 2-2. IA-32 Architectural MSRs (Contd.)" "IA32_MTRRCAP (MTRRcap)"
+           "Fixed range MTRRs are supported when set" + WC supported. */
+        *result = MTRR_MAX_VARIABLES | BIT(8) | BIT(10);
+        break;
+    case IA32_MTRR_DEF_TYPE:
+        *result = mtrr_state.mtrr_def_type;
+        break;
+    case IA32_MTRR_PHYSBASE0 ... IA32_MTRR_PHYSMASK7: {
+        int index = (msr - IA32_MTRR_PHYSBASE0) / 2;
+        int is_mask = msr % 2;
+        if (is_mask) {
+            *result = mtrr_state.variable[index].mask;
+        } else {
+            *result = mtrr_state.variable[index].base;
+        }
+        break;
+    }
+    case IA32_MTRR_FIX64K_00000:
+        *result = mtrr_state.fixed_64k;
+        break;
+    case IA32_MTRR_FIX16K_80000 ... IA32_MTRR_FIX16K_A0000: {
+        int index = msr - IA32_MTRR_FIX16K_80000;
+        *result = mtrr_state.fixed_16k[index];
+        break;
+    }
+    case IA32_MTRR_FIX4K_C0000 ... IA32_MTRR_FIX4K_F8000: {
+        int index = msr - IA32_MTRR_FIX4K_C0000;
+        *result = mtrr_state.fixed_4k[index];
+        break;
+    }
+    default:
+        LOG_VMM_ERR("invalid MSR 0x%lx\n", msr);
+        return false;
+    }
+    return true;
+}
+
+bool handle_mtrr_msr_write(uint64_t msr, uint64_t value)
+{
+    switch (msr) {
+    case IA32_MTRR_DEF_TYPE:
+        mtrr_state.mtrr_def_type = value;
+        break;
+    case IA32_MTRR_PHYSBASE0 ... IA32_MTRR_PHYSMASK7: {
+        int index = (msr - IA32_MTRR_PHYSBASE0) / 2;
+        int is_mask = msr % 2;
+        if (is_mask) {
+            mtrr_state.variable[index].mask = value;
+        } else {
+            mtrr_state.variable[index].base = value;
+        }
+        break;
+    }
+    case IA32_MTRR_FIX64K_00000:
+        mtrr_state.fixed_64k = value;
+        break;
+    case IA32_MTRR_FIX16K_80000 ... IA32_MTRR_FIX16K_A0000: {
+        int index = msr - IA32_MTRR_FIX16K_80000;
+        mtrr_state.fixed_16k[index] = value;
+        break;
+    }
+    case IA32_MTRR_FIX4K_C0000 ... IA32_MTRR_FIX4K_F8000: {
+        int index = msr - IA32_MTRR_FIX4K_C0000;
+        mtrr_state.fixed_4k[index] = value;
+        break;
+    }
+    default:
+        LOG_VMM_ERR("invalid MSR 0x%lx\n", msr);
+        return false;
+    }
+    return true;
+}

--- a/vmm.mk
+++ b/vmm.mk
@@ -43,7 +43,8 @@ X86_64_FILES = src/arch/x86_64/fault.c \
 			   src/arch/x86_64/guest_time.c \
 			   src/arch/x86_64/cmos.c \
 			   src/arch/x86_64/cr_access.c \
-			   src/arch/x86_64/uefi.c
+			   src/arch/x86_64/uefi.c \
+			   src/arch/x86_64/mtrr.c
 
 # VIRTIO MMIO and PCI depends on sddf
 ifeq ($(strip $(SDDF)),)


### PR DESCRIPTION
To prevent msr.c from being bloated.