### PR TITLE
examples: disable TSC watchdog on nested virt

### DIFF
--- a/examples/simple/vmm.c
+++ b/examples/simple/vmm.c
@@ -32,7 +32,8 @@
 #elif defined(BOARD_x86_64_generic_vtx)
 #define TIMER_DRV_CH 10
 #define GUEST_RAM_START_GPA LOW_RAM_START_GPA
-#define GUEST_CMDLINE "earlyprintk=serial,0x3f8,115200 debug console=ttyS0,115200 earlycon=serial,0x3f8,115200 loglevel=8"
+#define GUEST_CMDLINE_HW "earlyprintk=serial,0x3f8,115200 debug console=ttyS0,115200 earlycon=serial,0x3f8,115200 loglevel=8"
+#define GUEST_CMDLINE_QEMU "earlyprintk=serial,0x3f8,115200 debug console=ttyS0,115200 earlycon=serial,0x3f8,115200 loglevel=8 tsc=nowatchdog"
 #elif defined(BOARD_zcu102)
 #define GUEST_RAM_START_GPA     0x800000000
 #define GUEST_DTB_GPA           0x80E000000
@@ -129,8 +130,26 @@ void init(void)
 
     seL4_VCPUContext initial_regs;
     linux_x86_setup_ret_t linux_setup;
+    char *cmdline;
+    /* Reading a TSC does not cause a VM Exit, but the HPET does. On QEMU, the nested virtualisation overhead
+     * is too high, leading to Linux's watchdog timer complaining:
+     * [    3.568257] clocksource: Watchdog hpet read timed out. Readout sequence took: 57800ns
+     * [    4.064535] clocksource: Watchdog hpet read timed out. Readout sequence took: 62000ns
+     * [    9.064695] watchdog_print_freq_timeout: 7 callbacks suppressed
+     * [    9.066802] clocksource: Watchdog hpet read timed out. Readout sequence took: 217500ns
+     * [    9.568591] clocksource: Watchdog hpet read timed out. Readout sequence took: 72900ns
+     *
+     * So lets turn off the TSC watchdog if the VMM detects that it is running on QEMU. This is sound because
+     * the virtual HPET time is derived from the TSC, and this problem doesn't manifest on hardware.
+     */
+    if (hypervisor_present()) {
+        cmdline = GUEST_CMDLINE_QEMU;
+    } else {
+        cmdline = GUEST_CMDLINE_HW;
+    }
+
     if (!linux_setup_images((uintptr_t)_guest_kernel_image, kernel_size, (uintptr_t)_guest_initrd_image, initrd_size,
-                            _guest_dsdt_aml, dsdt_aml_size, GUEST_CMDLINE, &initial_regs, &linux_setup)) {
+                            _guest_dsdt_aml, dsdt_aml_size, cmdline, &initial_regs, &linux_setup)) {
         LOG_VMM_ERR("Failed to initialise guest images\n");
         return;
     }

--- a/examples/uefi/vmm.c
+++ b/examples/uefi/vmm.c
@@ -12,7 +12,8 @@
 #define TIMER_DRV_CH 10
 #define GUEST_RAM_START_GPA LOW_RAM_START_GPA
 #define GUEST_FLASH_START_GPA 0xffa00000 /* Correspond to SDF */
-#define GUEST_CMDLINE "earlyprintk=serial,0x3f8,115200 debug console=ttyS0,115200 earlycon=serial,0x3f8,115200 loglevel=8"
+#define GUEST_CMDLINE_HW "earlyprintk=serial,0x3f8,115200 debug console=ttyS0,115200 earlycon=serial,0x3f8,115200 loglevel=8"
+#define GUEST_CMDLINE_QEMU "earlyprintk=serial,0x3f8,115200 debug console=ttyS0,115200 earlycon=serial,0x3f8,115200 loglevel=8 tsc=nowatchdog"
 
 #define SERIAL_IRQ_CH 1
 
@@ -99,8 +100,26 @@ void init(void)
         return;
     }
 
+    char *cmdline;
+    /* Reading a TSC does not cause a VM Exit, but the HPET does. On QEMU, the nested virtualisation overhead
+     * is too high, leading to Linux's watchdog timer complaining:
+     * [    3.568257] clocksource: Watchdog hpet read timed out. Readout sequence took: 57800ns
+     * [    4.064535] clocksource: Watchdog hpet read timed out. Readout sequence took: 62000ns
+     * [    9.064695] watchdog_print_freq_timeout: 7 callbacks suppressed
+     * [    9.066802] clocksource: Watchdog hpet read timed out. Readout sequence took: 217500ns
+     * [    9.568591] clocksource: Watchdog hpet read timed out. Readout sequence took: 72900ns
+     *
+     * So lets turn off the TSC watchdog if the VMM detects that it is running on QEMU. This is sound because
+     * the virtual HPET time is derived from the TSC, and this problem doesn't manifest on hardware.
+     */
+    if (hypervisor_present()) {
+        cmdline = GUEST_CMDLINE_QEMU;
+    } else {
+        cmdline = GUEST_CMDLINE_HW;
+    }
+
     if (!uefi_add_linux_boot((uintptr_t)_guest_kernel_image, kernel_size, (uintptr_t)_guest_initrd_image, initrd_size,
-                             (char *)GUEST_CMDLINE)) {
+                             (char *)cmdline)) {
         LOG_VMM_ERR("Failed to initialise UEFI firmware\n");
         return;
     }

--- a/examples/virtio_pci/client_vm/x86_64/guest_arch_init.c
+++ b/examples/virtio_pci/client_vm/x86_64/guest_arch_init.c
@@ -65,7 +65,8 @@ extern net_queue_handle_t net_tx_queue;
 static linux_x86_setup_ret_t linux_setup;
 static seL4_VCPUContext initial_regs;
 
-#define GUEST_CMDLINE "debug console=hvc0 loglevel=8"
+#define GUEST_CMDLINE_HW "debug console=hvc0 loglevel=8"
+#define GUEST_CMDLINE_QEMU "debug console=hvc0 loglevel=8 tsc=nowatchdog"
 #define GUEST_RAM_SIZE 0x10000000
 #define GUEST_RAM_HVA 0x20000000
 
@@ -115,8 +116,25 @@ bool guest_arch_init(void)
         return false;
     }
 
+    char *cmdline;
+    /* Reading a TSC does not cause a VM Exit, but the HPET does. On QEMU, the nested virtualisation overhead
+     * is too high, leading to Linux's watchdog timer complaining:
+     * [    3.568257] clocksource: Watchdog hpet read timed out. Readout sequence took: 57800ns
+     * [    4.064535] clocksource: Watchdog hpet read timed out. Readout sequence took: 62000ns
+     * [    9.064695] watchdog_print_freq_timeout: 7 callbacks suppressed
+     * [    9.066802] clocksource: Watchdog hpet read timed out. Readout sequence took: 217500ns
+     * [    9.568591] clocksource: Watchdog hpet read timed out. Readout sequence took: 72900ns
+     *
+     * So lets turn off the TSC watchdog if the VMM detects that it is running on QEMU. This is sound because
+     * the virtual HPET time is derived from the TSC, and this problem doesn't manifest on hardware.
+     */
+    if (hypervisor_present()) {
+        cmdline = GUEST_CMDLINE_QEMU;
+    } else {
+        cmdline = GUEST_CMDLINE_HW;
+    }
     if (!linux_setup_images((uintptr_t)_guest_kernel_image, kernel_size, (uintptr_t)_guest_initrd_image, initrd_size,
-                            _guest_dsdt_aml, dsdt_aml_size, GUEST_CMDLINE, &initial_regs, &linux_setup)) {
+                            _guest_dsdt_aml, dsdt_aml_size, cmdline, &initial_regs, &linux_setup)) {
         LOG_VMM_ERR("Failed to initialise guest images\n");
         return false;
     }

--- a/include/libvmm/util/util.h
+++ b/include/libvmm/util/util.h
@@ -93,4 +93,6 @@ static inline void cpuid(uint32_t leaf, uint32_t subleaf, uint32_t *a, uint32_t 
 {
     __asm__ __volatile__("cpuid" : "=a"(*a), "=b"(*b), "=c"(*c), "=d"(*d) : "a"(leaf), "c"(subleaf));
 }
+
+bool hypervisor_present(void);
 #endif

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -38,3 +38,35 @@ uint64_t convert_ticks_by_frequency(uint64_t ticks, uint64_t in_freq, uint64_t o
     uint64_t rem;
     return udiv128by64to64(HIGH_128B_WORD(intermediate), LOW_128B_WORD(intermediate), in_freq, &rem);
 }
+
+#if defined(CONFIG_ARCH_X86_64)
+/*
+ * CPUID bits for detecting the kernel is running as a guest.
+ *
+ * These bits correspond to the strings "KVMKVMKVM" for KVM and "TCGTCGTCGTCG"
+ * for QEMU's Tiny Code Generator (TCG).
+ *
+ * https://docs.kernel.org/virt/kvm/x86/cpuid.html.
+ */
+#define KVM_CPUID_SIGNATURE 0x40000000
+
+#define CPUID_TCG_EBX 0x54474354
+#define CPUID_TCG_ECX 0x43544743
+#define CPUID_TCG_EDX 0x47435447
+#define CPUID_KVM_EBX 0x4b4d564b
+#define CPUID_KVM_ECX 0x564b4d56
+#define CPUID_KVM_EDX 0x4d
+
+bool hypervisor_present(void)
+{
+    uint32_t a, b, c, d;
+    cpuid(KVM_CPUID_SIGNATURE, 0, &a, &b, &c, &d);
+
+    if ((b == CPUID_KVM_EBX && c == CPUID_KVM_ECX && d == CPUID_KVM_EDX)
+        || (b == CPUID_TCG_EBX && c == CPUID_TCG_ECX && d == CPUID_TCG_EDX)) {
+        return true;
+    }
+    return false;
+}
+
+#endif


### PR DESCRIPTION
When the VMM is running nested on x86_64 QEMU, Linux will complain about HPET reads being too slow:
```
[    3.568257] clocksource: Watchdog hpet read timed out. Readout sequence took: 57800ns
[    4.064535] clocksource: Watchdog hpet read timed out. Readout sequence took: 62000ns
[    9.064695] watchdog_print_freq_timeout: 7 callbacks suppressed
[    9.066802] clocksource: Watchdog hpet read timed out. Readout sequence took: 217500ns
[    9.568591] clocksource: Watchdog hpet read timed out. Readout sequence took: 72900ns
```

This is because the overhead of nested virtualisation is too high, I don't see this problem on real hardware. So lets turn off the TSC watchdog when the VMM detects that it is definitely running on a hypervisor. This is sound because the emulated HPET's time is derived from the system's TSC anyways.