### PR TITLE
ci: don't use HTTPS for download test

### DIFF
--- a/ci/test_groups.json
+++ b/ci/test_groups.json
@@ -2,7 +2,7 @@
     "groups": [
         {
             "test_name": "virtIO Network",
-            "test_args": "virtio_network_https_download,virtio_network_ping,vswitch",
+            "test_args": "virtio_network_http_download,virtio_network_ping,vswitch",
             "artifact_suffix": "virtio-net"
         },
         {

--- a/ci/tests/virtio_net_wget.py
+++ b/ci/tests/virtio_net_wget.py
@@ -24,7 +24,7 @@ async def test_virtio_net_wget(
         await wait_for_output(backend, b"buildroot login: ")
         await send_input(backend, b"root\n")
         await wait_for_output(backend, b"# ")
-        await send_input(backend, b"wget https://trustworthy.systems/song\n")
+        await send_input(backend, b"wget http://trustworthy.systems/song\n")
         await wait_for_output(backend, b"'song' saved")
         await send_input(backend, b"cat song\n")
         await wait_for_output(backend, b"Implementation deep and fine.")
@@ -32,7 +32,7 @@ async def test_virtio_net_wget(
 
 # export
 TEST_CASES = matrix.generate_example_test_cases(
-    "virtio_network_https_download",
+    "virtio_network_http_download",
     ["virtio_mmio", "virtio_pci"],
     test_fn=test_virtio_net_wget,
     backend_fn=common.virtio_backend_fn,


### PR DESCRIPTION
The NTP is flaky sometimes and is out of our control. So when the VM fails to set the date and time, HTTPS won't work and the download tests will fail due to factors out of our control. Which is quite annoying.

So let's just do HTTP download like before, but I'll leave the automatic date and time setting via NTP in still.

Edit: maybe we are getting rate limited which is more likely than the public NTP being flaky.