### PR TITLE
ci: don't use HTTPS for VSwitch test

### DIFF
--- a/ci/tests/vswitch.py
+++ b/ci/tests/vswitch.py
@@ -35,7 +35,7 @@ async def test_virtio_net_wget(
         await wait_for_output(backend, b"# ")
 
         # VM 0 should reach the internet
-        await send_input(backend, b"wget https://trustworthy.systems/song\n")
+        await send_input(backend, b"wget http://trustworthy.systems/song\n")
         await wait_for_output(backend, b"'song' saved")
         await send_input(backend, b"cat song\n")
         await wait_for_output(backend, b"Implementation deep and fine.")
@@ -51,7 +51,7 @@ async def test_virtio_net_wget(
         await send_input(backend, b"root\n")
         await wait_for_output(backend, b"# ")
 
-        await send_input(backend, b"wget https://trustworthy.systems/song\n")
+        await send_input(backend, b"wget http://trustworthy.systems/song\n")
         await wait_for_output(backend, b"'song' saved")
         await send_input(backend, b"cat song\n")
         await wait_for_output(backend, b"Implementation deep and fine.")
@@ -77,7 +77,7 @@ async def test_virtio_net_wget(
         await send_input(backend, b"root\n")
         await wait_for_output(backend, b"# ")
 
-        await send_input(backend, b"wget https://trustworthy.systems/song\n")
+        await send_input(backend, b"wget http://trustworthy.systems/song\n")
         await wait_for_output(backend, b"'song' saved")
         await send_input(backend, b"cat song\n")
         await wait_for_output(backend, b"Implementation deep and fine.")


### PR DESCRIPTION
I forgot about the VSwitch in https://github.com/au-ts/libvmm/pull/396.

The NTP is flaky sometimes and is out of our control. So when the VM fails to set the date and time, HTTPS won't work and the download tests will fail due to factors out of our control. Which is quite annoying.

So let's just do HTTP download like before, but I'll leave the automatic date and time setting via NTP in still.