### PR TITLE
treewide: use BIT instead of BIT_LOW

### DIFF
--- a/include/libvmm/util/util.h
+++ b/include/libvmm/util/util.h
@@ -38,9 +38,6 @@ static void assert_fail(const char *assertion, const char *file, unsigned int li
     __builtin_trap();
 }
 
-#define BIT_LOW(n)  (1ul<<(n))
-#define BIT_HIGH(n) (1ul<<(n - 32 ))
-
 #ifndef MIN
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -11,6 +11,9 @@
 #include <libvmm/virtio/pci.h>
 #include <libvmm/virtio/virtq.h>
 
+/* Handling feature bits in the high 32 bits of a 64 bits word */
+#define BIT_HIGH(n) (1ul<<(n - 32 ))
+
 /*
  * Default maximum capacity of each virtIO queue. Currently applies to all
  * virtIO queues for all virtIO devices. In the future, this could be

--- a/src/arch/aarch64/cpuif.c
+++ b/src/arch/aarch64/cpuif.c
@@ -82,7 +82,7 @@ static const aarch64_sysreg_info_t cpuif_reginfo[] = {
 static int sysreg_fault_get_rt(uint64_t hsr)
 {
     /* Make sure the instruction length bit == 1 for 32-bits instructions. */
-    if (BIT_LOW(ESR_EL2_IL_BIT)) {
+    if (BIT(ESR_EL2_IL_BIT)) {
         return (hsr >> ISS_SYSREG_RT_SHIFT) & ISS_SYSREG_RT_MASK;
     } else {
         printf("sysreg_fault_get_rt() for 16-bits instructions not implemented.\n");

--- a/src/arch/aarch64/guest.c
+++ b/src/arch/aarch64/guest.c
@@ -12,9 +12,9 @@
  */
 
 #define SPSR_PMODE_EL1H 5
-#define SPSR_ASYNC_ABORT_MASK_BIT BIT_LOW(8)
-#define SPSR_IRQ_MASK_BIT BIT_LOW(7)
-#define SPSR_FIQ_MASK_BIT BIT_LOW(6)
+#define SPSR_ASYNC_ABORT_MASK_BIT BIT(8)
+#define SPSR_IRQ_MASK_BIT BIT(7)
+#define SPSR_FIQ_MASK_BIT BIT(6)
 
 /* Global state for managing the guest. */
 guest_t guest;

--- a/src/arch/aarch64/vgic/vgic_v3.c
+++ b/src/arch/aarch64/vgic/vgic_v3.c
@@ -209,7 +209,7 @@ static void vgic_redist_reset(struct gic_redist_map *redist, int vcpu_id, bool i
 
     if (is_last_vcpu) {
         // if this is the last vcpu in sequence, mark this redistributor frame as the last.
-        redist->typer |= BIT_LOW(4);
+        redist->typer |= BIT(4);
     }
 
     // set processor number

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -185,11 +185,11 @@ static inline bool virtio_blk_get_device_features(struct virtio_device *dev, uin
     switch (dev->regs.DeviceFeaturesSel) {
     /* feature bits 0 to 31 */
     case 0:
-        *features = BIT_LOW(VIRTIO_BLK_F_FLUSH);
-        *features = *features | BIT_LOW(VIRTIO_BLK_F_BLK_SIZE);
-        *features = *features | BIT_LOW(VIRTIO_BLK_F_SIZE_MAX);
-        *features = *features | BIT_LOW(VIRTIO_BLK_F_SEG_MAX);
-        *features = *features | BIT_LOW(VIRTIO_BLK_F_TOPOLOGY);
+        *features = BIT(VIRTIO_BLK_F_FLUSH);
+        *features = *features | BIT(VIRTIO_BLK_F_BLK_SIZE);
+        *features = *features | BIT(VIRTIO_BLK_F_SIZE_MAX);
+        *features = *features | BIT(VIRTIO_BLK_F_SEG_MAX);
+        *features = *features | BIT(VIRTIO_BLK_F_TOPOLOGY);
         break;
     /* features bits 32 to 63 */
     case 1:
@@ -211,11 +211,11 @@ static inline bool virtio_blk_set_driver_features(struct virtio_device *dev, uin
     bool success = false;
 
     uint32_t device_features = 0;
-    device_features |= BIT_LOW(VIRTIO_BLK_F_FLUSH);
-    device_features |= BIT_LOW(VIRTIO_BLK_F_BLK_SIZE);
-    device_features |= BIT_LOW(VIRTIO_BLK_F_SIZE_MAX);
-    device_features |= BIT_LOW(VIRTIO_BLK_F_SEG_MAX);
-    device_features |= BIT_LOW(VIRTIO_BLK_F_TOPOLOGY);
+    device_features |= BIT(VIRTIO_BLK_F_FLUSH);
+    device_features |= BIT(VIRTIO_BLK_F_BLK_SIZE);
+    device_features |= BIT(VIRTIO_BLK_F_SIZE_MAX);
+    device_features |= BIT(VIRTIO_BLK_F_SEG_MAX);
+    device_features |= BIT(VIRTIO_BLK_F_TOPOLOGY);
 
     switch (dev->regs.DriverFeaturesSel) {
     /* feature bits 0 to 31 */

--- a/src/virtio/console.c
+++ b/src/virtio/console.c
@@ -33,12 +33,11 @@ static void virtio_console_features_print(uint32_t features)
 {
     /* Dump the features given in a human-readable format */
     LOG_CONSOLE("Dumping features (0x%lx):\n", features);
-    LOG_CONSOLE("feature VIRTIO_CONSOLE_F_SIZE set to %s\n",
-                BIT_LOW(VIRTIO_CONSOLE_F_SIZE) & features ? "true" : "false");
+    LOG_CONSOLE("feature VIRTIO_CONSOLE_F_SIZE set to %s\n", BIT(VIRTIO_CONSOLE_F_SIZE) & features ? "true" : "false");
     LOG_CONSOLE("feature VIRTIO_CONSOLE_F_MULTIPORT set to %s\n",
-                BIT_LOW(VIRTIO_CONSOLE_F_MULTIPORT) & features ? "true" : "false");
+                BIT(VIRTIO_CONSOLE_F_MULTIPORT) & features ? "true" : "false");
     LOG_CONSOLE("feature VIRTIO_CONSOLE_F_EMERG_WRITE set to %s\n",
-                BIT_LOW(VIRTIO_CONSOLE_F_EMERG_WRITE) & features ? "true" : "false");
+                BIT(VIRTIO_CONSOLE_F_EMERG_WRITE) & features ? "true" : "false");
 }
 
 static void virtio_console_regs_init(struct virtio_device *dev)

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -76,11 +76,11 @@ static bool virtio_net_get_device_features(struct virtio_device *dev, uint32_t *
     switch (dev->regs.DeviceFeaturesSel) {
     /* Feature bits 0 to 31 */
     case 0:
-        *features = BIT_LOW(VIRTIO_NET_F_MAC);
+        *features = BIT(VIRTIO_NET_F_MAC);
         if (virtio_net_csum_offload(dev)) {
             /* There is no need for the guest to compute full checksums in software
              * since we will clear it anyways. */
-            *features |= BIT_LOW(VIRTIO_NET_F_CSUM);
+            *features |= BIT(VIRTIO_NET_F_CSUM);
         }
         break;
     /* Features bits 32 to 63 */
@@ -102,7 +102,7 @@ static bool virtio_net_set_driver_features(struct virtio_device *dev, uint32_t f
     /* Feature bits 0 to 31 */
     case 0:
         /** F_MAC is required */
-        success = (features & BIT_LOW(VIRTIO_NET_F_MAC));
+        success = (features & BIT(VIRTIO_NET_F_MAC));
         break;
 
     /* Features bits 32 to 63 */

--- a/src/virtio/sound.c
+++ b/src/virtio/sound.c
@@ -146,7 +146,7 @@ static const char *code_to_str(uint32_t code)
 
 static void virtio_snd_respond(struct virtio_device *dev)
 {
-    dev->regs.InterruptStatus = BIT_LOW(0);
+    dev->regs.InterruptStatus = BIT(0);
     bool success = virq_inject(dev->virq);
     assert(success);
 }


### PR DESCRIPTION
This was just too confusing, lets just use BIT everywhere. For virtio feature bits in the high 32 bits of a 64 bits word I have maintained the BIT_HIGH macro, now in the virtio header rather than util.h to discourage people from using it.

Closes https://github.com/au-ts/libvmm/issues/401