### PR TITLE
virtio/block: performance improvements

### DIFF
--- a/include/libvmm/virtio/block.h
+++ b/include/libvmm/virtio/block.h
@@ -136,14 +136,6 @@ struct virtio_blk_outhdr {
 
 /* Device (backend) implementation */
 
-/* Restrict the guest driver to only send 4x 32K segment per request at any given time.
- * Thus each request have a maximum size of 128K. Note that the sDDF Block data region size is 512K.
- * This limit is chosen to minimise fragmentation in the data region. */
-
-/* Maximum size of any single segment */
-#define VIRTIO_BLK_SIZE_MAX (BLK_TRANSFER_SIZE * 8)
-/* Maximum number of segments in a request */
-#define VIRTIO_BLK_SEG_MAX 4
 // TODO: instead of hardcoding these, get it from the tool
 /* Maximum number of buffers in sddf data region */
 #define SDDF_MAX_DATA_CELLS 32768
@@ -198,6 +190,7 @@ struct virtio_blk_device {
     reqbk_t reqsbk[SDDF_MAX_QUEUE_CAPACITY];
     /* Data struct that handles allocation and freeing of fixed size data cells
      * in sDDF memory region */
+    size_t num_sddf_data_cells;
     fsmalloc_t fsmalloc;
     bitarray_t fsmalloc_avail_bitarr;
     uint64_t fsmalloc_avail_bitarr_words[BITS_2_WORDS64(SDDF_MAX_DATA_CELLS)];

--- a/include/libvmm/virtio/block.h
+++ b/include/libvmm/virtio/block.h
@@ -146,7 +146,7 @@ struct virtio_blk_outhdr {
 #define VIRTIO_BLK_SEG_MAX 4
 // TODO: instead of hardcoding these, get it from the tool
 /* Maximum number of buffers in sddf data region */
-#define SDDF_MAX_DATA_CELLS 128
+#define SDDF_MAX_DATA_CELLS 32768
 /* Maximum sddf queue capacity */
 #define SDDF_MAX_QUEUE_CAPACITY 128
 

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -829,8 +829,6 @@ static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, 
                               ? (data_region_size / BLK_TRANSFER_SIZE)
                               : SDDF_MAX_DATA_CELLS;
 
-    assert(num_sddf_cells == queue_capacity);
-
     virtio_blk_config_init(blk_dev);
 
     fsmalloc_init(&blk_dev->fsmalloc, data_region, BLK_TRANSFER_SIZE, num_sddf_cells, &blk_dev->fsmalloc_avail_bitarr,

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -128,10 +128,8 @@
 #define VIRTIO_BLK_DEV_ID "libvmm"
 #define SECTORS_IN_TRANSFER_WINDOW (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)
 
-/* If we need to split up the guest's request into multiple chunks for reason explained above then
- * make the chunk equal to a quarter of the data region. This is arbitrarily chosen, can be increased
- * or decreased safely up to the data region size. */
-#define CHUNK_SIZE_BYTES ((SDDF_MAX_DATA_CELLS / 4) * BLK_TRANSFER_SIZE)
+/* Maximum number of segments in a request */
+#define VIRTIO_BLK_SEG_MAX 4
 
 #define LOG_BLOCK_WARN(...)               \
     do                                   \
@@ -150,6 +148,21 @@
 static inline struct virtio_blk_device *device_state(struct virtio_device *dev)
 {
     return (struct virtio_blk_device *)dev->device_data;
+}
+
+/* Maximum size of any single segment, a quarter of the data region size is a safe number,
+ * since we will set VIRTIO_BLK_SEG_MAX to 4. */
+static size_t virtio_blk_size_max(struct virtio_device *dev)
+{
+    return (device_state(dev)->num_sddf_data_cells * BLK_TRANSFER_SIZE) / 4;
+}
+
+/* If we need to split up the guest's request into multiple chunks because it is too large
+ * to be handled in one go then service it in virtio_blk_size_max() chunks. This is only
+ * ever a problem on OVMF because it doesn't negotiate VIRTIO_BLK_SEG_MAX and VIRTIO_BLK_SIZE_MAX .*/
+static size_t virtio_blk_chunk_size_bytes(struct virtio_device *dev)
+{
+    return virtio_blk_size_max(dev);
 }
 
 static void virtio_blk_regs_init(struct virtio_device *dev)
@@ -389,7 +402,7 @@ static bool dispatch_request(struct virtio_device *dev, reqbk_t *reqbk, uint32_t
     uint64_t proposed_bytes = reqbk->bytes_remaining;
     uint64_t sddf_num_blocks = reqbk_to_sddf_num_blocks(reqbk, proposed_bytes);
     if (reqbk_to_sddf_num_blocks(reqbk, reqbk_to_body_bytes(reqbk)) > SDDF_MAX_DATA_CELLS) {
-        proposed_bytes = MIN(CHUNK_SIZE_BYTES, reqbk->bytes_remaining);
+        proposed_bytes = MIN(virtio_blk_chunk_size_bytes(dev), reqbk->bytes_remaining);
         sddf_num_blocks = reqbk_to_sddf_num_blocks(reqbk, proposed_bytes);
     }
 
@@ -785,7 +798,7 @@ static inline void virtio_blk_config_init(struct virtio_blk_device *blk_dev)
         blk_dev->config.blk_size = storage_info->sector_size;
     }
 
-    blk_dev->config.size_max = VIRTIO_BLK_SIZE_MAX;
+    blk_dev->config.size_max = virtio_blk_size_max(&blk_dev->virtio_device);
     blk_dev->config.seg_max = VIRTIO_BLK_SEG_MAX;
 
     blk_dev->config.topology.physical_block_exp =
@@ -828,6 +841,7 @@ static struct virtio_device *virtio_blk_init(struct virtio_blk_device *blk_dev, 
     size_t num_sddf_cells = (data_region_size / BLK_TRANSFER_SIZE) < SDDF_MAX_DATA_CELLS
                               ? (data_region_size / BLK_TRANSFER_SIZE)
                               : SDDF_MAX_DATA_CELLS;
+    blk_dev->num_sddf_data_cells = num_sddf_cells;
 
     virtio_blk_config_init(blk_dev);
 


### PR DESCRIPTION
See commit messages for details.

The idea is that the device should allow the user of libvmm to create a larger sDDF Block data region so that larger and more requests can be inflight per guest queue kick.

To take advantage of this optimisation, the user will need to create a larger data region in the metaprogram:
```diff
-    blk_system.add_client(vmm_client0, partition=partition)
+    blk_system.add_client(vmm_client0, partition=partition, data_size=0x8000000) # 128MiB available for block reqs
```

The default from sdfgen is just 512 KiB.