### PR TITLE
virtio/blk+net: add indirect feature

### DIFF
--- a/include/libvmm/virtio/config.h
+++ b/include/libvmm/virtio/config.h
@@ -67,6 +67,10 @@
 #define VIRTIO_F_ANY_LAYOUT     27
 #endif /* VIRTIO_CONFIG_NO_LEGACY */
 
+/* Negotiating this feature indicates that the driver can use
+ * descriptors with the VIRTQ_DESC_F_INDIRECT flag set */
+#define VIRTIO_F_INDIRECT_DESC 28
+
 /* v1.0 compliant. */
 #define VIRTIO_F_VERSION_1      32
 

--- a/include/libvmm/virtio/iterator.h
+++ b/include/libvmm/virtio/iterator.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <libvmm/virq.h>
+#include <libvmm/virtio/virtq.h>
+#include <libvmm/virtio/virtio.h>
+
+/* An "iterator" over a descriptor chain that can contain both
+ * ordinary buffers and indirect buffers tables. */
+
+typedef struct virtio_desc_chain_iterator {
+    virtio_queue_handler_t *vq_handler;
+    uint16_t curr_desc;
+    size_t steps;
+    bool in_indrect;
+    size_t curr_indirect_pos;
+    size_t indirect_steps;
+    size_t indirect_table_entries;
+    bool terminated;
+} virtio_desc_chain_iterator_t;
+
+/* Given a descriptor head and a handle to the virtqueue, create a
+ * forward iterator of the chain. */
+bool virtio_desc_chain_iterator_new(virtio_queue_handler_t *vq_handler, uint16_t desc_head,
+                                    virtio_desc_chain_iterator_t *ret);
+
+typedef enum virtio_desc_chain_iterator_status {
+    VIRTIO_ITERATOR_ERROR = 1, /* Chain is malformed */
+    VIRTIO_ITERATOR_MOVED,     /* The iterator had yielded a result */
+    VIRTIO_ITERATOR_EXHAUSTED, /* Nothing more. */
+} virtio_desc_chain_iterator_status_t;
+
+virtio_desc_chain_iterator_status_t virtio_desc_chain_iterator_next(virtio_desc_chain_iterator_t *iter, uint64_t *gpa,
+                                                                    size_t *len);

--- a/include/libvmm/virtio/virtio.h
+++ b/include/libvmm/virtio/virtio.h
@@ -19,7 +19,7 @@
  * virtIO queues for all virtIO devices. In the future, this could be
  * configurable but our use-cases have not required it yet.
  */
-#define VIRTIO_DEFAULT_QUEUE_SIZE 128
+#define VIRTIO_DEFAULT_QUEUE_SIZE 512
 
 /*
  * All terminology used and functionality of the virtIO device implementation

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -128,8 +128,8 @@
 #define VIRTIO_BLK_DEV_ID "libvmm"
 #define SECTORS_IN_TRANSFER_WINDOW (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE)
 
-/* Maximum number of segments in a request */
-#define VIRTIO_BLK_SEG_MAX 4
+/* Maximum size of any single segment */
+#define VIRTIO_BLK_SIZE_MAX 4096
 
 #define LOG_BLOCK_WARN(...)               \
     do                                   \
@@ -150,19 +150,19 @@ static inline struct virtio_blk_device *device_state(struct virtio_device *dev)
     return (struct virtio_blk_device *)dev->device_data;
 }
 
-/* Maximum size of any single segment, a quarter of the data region size is a safe number,
- * since we will set VIRTIO_BLK_SEG_MAX to 4. */
-static size_t virtio_blk_size_max(struct virtio_device *dev)
+/* Maximum number of segments in a request, a quarter of the data region should be a safe number.
+ * But virtio-win's viostor seems to misbehave if this number is creater than the queue size...  */
+static size_t virtio_blk_seg_max(struct virtio_device *dev)
 {
-    return (device_state(dev)->num_sddf_data_cells * BLK_TRANSFER_SIZE) / 4;
+    return MIN(VIRTIO_DEFAULT_QUEUE_SIZE, (device_state(dev)->num_sddf_data_cells) / 4);
 }
 
 /* If we need to split up the guest's request into multiple chunks because it is too large
- * to be handled in one go then service it in virtio_blk_size_max() chunks. This is only
+ * to be handled in one go then service it in chunks. This is only
  * ever a problem on OVMF because it doesn't negotiate VIRTIO_BLK_SEG_MAX and VIRTIO_BLK_SIZE_MAX .*/
 static size_t virtio_blk_chunk_size_bytes(struct virtio_device *dev)
 {
-    return virtio_blk_size_max(dev);
+    return ((device_state(dev)->num_sddf_data_cells) / 4) * BLK_TRANSFER_SIZE;
 }
 
 static void virtio_blk_regs_init(struct virtio_device *dev)
@@ -522,7 +522,11 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
              * or the guest was malicious. The former is more likely so we
              * will keep the assert for now to catch such issue for further
              * investigations. */
-            assert(state->reqsbk[req_id].bytes_remaining % VIRTIO_BLK_SECTOR_SIZE == 0);
+            if (state->reqsbk[req_id].bytes_remaining % VIRTIO_BLK_SECTOR_SIZE) {
+                LOG_BLOCK_ERR("request size %lu is not multiple of sector size\n",
+                              state->reqsbk[req_id].bytes_remaining);
+                assert(false);
+            }
 
             if (!dispatch_request(dev, &state->reqsbk[req_id], req_id)) {
                 /* Create backpressure, don't consume this request until the block virtualiser gives us
@@ -794,20 +798,16 @@ static inline void virtio_blk_config_init(struct virtio_blk_device *blk_dev)
     blk_storage_info_t *storage_info = blk_dev->storage_info;
 
     blk_dev->config.capacity = (BLK_TRANSFER_SIZE / VIRTIO_BLK_SECTOR_SIZE) * storage_info->capacity;
-    if (storage_info->block_size != 0) {
-        blk_dev->config.blk_size = storage_info->block_size * BLK_TRANSFER_SIZE;
-    } else {
-        blk_dev->config.blk_size = storage_info->sector_size;
-    }
+    blk_dev->config.blk_size = VIRTIO_BLK_SECTOR_SIZE;
 
-    blk_dev->config.size_max = virtio_blk_size_max(&blk_dev->virtio_device);
-    blk_dev->config.seg_max = VIRTIO_BLK_SEG_MAX;
+    blk_dev->config.size_max = VIRTIO_BLK_SIZE_MAX;
+    blk_dev->config.seg_max = virtio_blk_seg_max(&blk_dev->virtio_device);
 
     blk_dev->config.topology.physical_block_exp =
         3; // 2^3 = 8 logical blocks in 1 physical block (sDDF transfer window)
     blk_dev->config.topology.alignment_offset = 0;
     blk_dev->config.topology.min_io_size = 8;
-    blk_dev->config.topology.opt_io_size = blk_dev->config.topology.min_io_size;
+    blk_dev->config.topology.opt_io_size = 0;
 }
 
 static virtio_device_funs_t functions = {

--- a/src/virtio/block.c
+++ b/src/virtio/block.c
@@ -203,6 +203,7 @@ static inline bool virtio_blk_get_device_features(struct virtio_device *dev, uin
         *features = *features | BIT(VIRTIO_BLK_F_SIZE_MAX);
         *features = *features | BIT(VIRTIO_BLK_F_SEG_MAX);
         *features = *features | BIT(VIRTIO_BLK_F_TOPOLOGY);
+        *features = *features | BIT(VIRTIO_F_INDIRECT_DESC);
         break;
     /* features bits 32 to 63 */
     case 1:
@@ -229,6 +230,7 @@ static inline bool virtio_blk_set_driver_features(struct virtio_device *dev, uin
     device_features |= BIT(VIRTIO_BLK_F_SIZE_MAX);
     device_features |= BIT(VIRTIO_BLK_F_SEG_MAX);
     device_features |= BIT(VIRTIO_BLK_F_TOPOLOGY);
+    device_features |= BIT(VIRTIO_F_INDIRECT_DESC);
 
     switch (dev->regs.DriverFeaturesSel) {
     /* feature bits 0 to 31 */

--- a/src/virtio/iterator.c
+++ b/src/virtio/iterator.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <libvmm/guest_ram.h>
+#include <libvmm/virq.h>
+#include <libvmm/virtio/virtq.h>
+#include <libvmm/virtio/virtio.h>
+#include <libvmm/virtio/iterator.h>
+
+bool virtio_desc_chain_iterator_new(virtio_queue_handler_t *vq_handler, uint16_t desc_head,
+                                    virtio_desc_chain_iterator_t *ret)
+{
+    struct virtq *virtq = &vq_handler->virtq;
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
+
+    if (desc_head >= virtq->num) {
+        LOG_VMM_ERR("descriptor head %u is out of bound %u.\n", desc_head, virtq->num);
+        return false;
+    }
+    if (!desc_ring[desc_head].len) {
+        LOG_VMM_ERR("descriptor head %u have zero size buffer.\n", desc_head);
+        return false;
+    }
+
+    ret->vq_handler = vq_handler;
+    ret->curr_desc = desc_head;
+    ret->terminated = false;
+    ret->steps = 0;
+
+    if (desc_ring[desc_head].flags & VIRTQ_DESC_F_INDIRECT) {
+        ret->in_indrect = true;
+        ret->curr_indirect_pos = 0;
+        ret->indirect_steps = 0;
+
+        size_t indirect_table_size = desc_ring[desc_head].len;
+        if (!indirect_table_size || indirect_table_size % sizeof(struct virtq_desc)) {
+            LOG_VMM_ERR("bad indirect table length %zu at desc %u\n", indirect_table_size, desc_head);
+            return false;
+        }
+        ret->indirect_table_entries = indirect_table_size / sizeof(struct virtq_desc);
+    } else {
+        ret->in_indrect = false;
+    }
+
+    return true;
+}
+
+virtio_desc_chain_iterator_status_t virtio_desc_chain_iterator_next(virtio_desc_chain_iterator_t *iter, uint64_t *gpa,
+                                                                    size_t *len)
+{
+    if (iter->terminated) {
+        return VIRTIO_ITERATOR_EXHAUSTED;
+    }
+
+    struct virtq *virtq = &iter->vq_handler->virtq;
+    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
+
+    if (iter->in_indrect) {
+        if (!desc_ring[iter->curr_desc].len) {
+            LOG_VMM_ERR("descriptor %u have zero size buffer.\n", iter->curr_desc);
+            return VIRTIO_ITERATOR_ERROR;
+        }
+        if (iter->indirect_steps > iter->indirect_table_entries) {
+            LOG_VMM_ERR("indirect table at desc %u is longer than expected or have loop\n", iter->curr_desc);
+            return VIRTIO_ITERATOR_ERROR;
+        }
+        if (iter->curr_indirect_pos >= iter->indirect_table_entries) {
+            LOG_VMM_ERR("bad next index %zu for indirect table at desc %u\n", iter->curr_indirect_pos, iter->curr_desc);
+            return VIRTIO_ITERATOR_ERROR;
+        }
+
+        struct virtq_desc *indirect_descs = gpa_to_hva(desc_ring[iter->curr_desc].addr,
+                                                       sizeof(struct virtq_desc) * iter->indirect_table_entries);
+        if (!indirect_descs) {
+            LOG_VMM_ERR("bad indirect table GPA 0x%lx at desc %u\n", desc_ring[iter->curr_desc].addr, iter->curr_desc);
+            return VIRTIO_ITERATOR_ERROR;
+        }
+        if (indirect_descs[iter->curr_indirect_pos].flags & VIRTQ_DESC_F_INDIRECT) {
+            LOG_VMM_ERR("nested indirect table at desc %u\n", iter->curr_desc);
+            return VIRTIO_ITERATOR_ERROR;
+        }
+
+        *gpa = indirect_descs[iter->curr_indirect_pos].addr;
+        *len = indirect_descs[iter->curr_indirect_pos].len;
+        iter->indirect_steps += 1;
+
+        if (indirect_descs[iter->curr_indirect_pos].flags & VIRTQ_DESC_F_NEXT) {
+            iter->curr_indirect_pos = indirect_descs[iter->curr_indirect_pos].next;
+        } else {
+            /* An indirect table is always the last descriptor. */
+            iter->terminated = true;
+        }
+
+    } else {
+        if (iter->curr_desc >= virtq->num) {
+            LOG_VMM_ERR("descriptor %u is out of bound %u.\n", iter->curr_desc, virtq->num);
+            return VIRTIO_ITERATOR_ERROR;
+        }
+        if (iter->steps > virtq->num) {
+            LOG_VMM_ERR("loop in descriptor %u.\n", iter->curr_desc);
+            return VIRTIO_ITERATOR_ERROR;
+        }
+        if (!desc_ring[iter->curr_desc].len) {
+            LOG_VMM_ERR("descriptor %u have zero size buffer.\n", iter->curr_desc);
+            return VIRTIO_ITERATOR_ERROR;
+        }
+
+        *gpa = desc_ring[iter->curr_desc].addr;
+        *len = desc_ring[iter->curr_desc].len;
+
+        if (!(desc_ring[iter->curr_desc].flags & VIRTQ_DESC_F_NEXT)) {
+            iter->terminated = true;
+        } else {
+            iter->curr_desc = desc_ring[iter->curr_desc].next;
+            iter->steps++;
+
+            if (iter->curr_desc >= virtq->num) {
+                LOG_VMM_ERR("next descriptor %u is out of bound %u.\n", iter->curr_desc, virtq->num);
+                return VIRTIO_ITERATOR_ERROR;
+            }
+
+            if (desc_ring[iter->curr_desc].flags & VIRTQ_DESC_F_INDIRECT) {
+                iter->in_indrect = true;
+                iter->curr_indirect_pos = 0;
+                iter->indirect_steps = 0;
+
+                size_t indirect_table_size = desc_ring[iter->curr_desc].len;
+                if (!indirect_table_size || indirect_table_size % sizeof(struct virtq_desc)) {
+                    LOG_VMM_ERR("bad indirect table length %zu at desc %u\n", indirect_table_size, iter->curr_desc);
+                    return VIRTIO_ITERATOR_ERROR;
+                }
+                iter->indirect_table_entries = indirect_table_size / sizeof(struct virtq_desc);
+            }
+        }
+    }
+
+    return VIRTIO_ITERATOR_MOVED;
+}

--- a/src/virtio/net.c
+++ b/src/virtio/net.c
@@ -77,6 +77,7 @@ static bool virtio_net_get_device_features(struct virtio_device *dev, uint32_t *
     /* Feature bits 0 to 31 */
     case 0:
         *features = BIT(VIRTIO_NET_F_MAC);
+        *features |= BIT(VIRTIO_F_INDIRECT_DESC);
         if (virtio_net_csum_offload(dev)) {
             /* There is no need for the guest to compute full checksums in software
              * since we will clear it anyways. */

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -12,6 +12,7 @@
 #include <libvmm/pci.h>
 #include <libvmm/virtio/virtq.h>
 #include <libvmm/virtio/virtio.h>
+#include <libvmm/virtio/iterator.h>
 
 /* These are incorrect if VIRTIO_F_EVENT_IDX feature is negotitated, but we don't support that for now. */
 static inline size_t virtio_desc_ring_size_bytes(struct virtq *virtq)
@@ -52,118 +53,115 @@ struct virtq_used *virtio_get_used_ring(struct virtq *virtq)
 uint64_t virtio_desc_chain_payload_len(virtio_queue_handler_t *vq_handler, uint16_t desc_head)
 {
     assert(vq_handler->ready);
-    struct virtq *virtq = &vq_handler->virtq;
-    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
 
-    uint64_t loop_iter_count = 0;
     uint64_t payload_len = 0;
-    uint16_t curr_desc = desc_head;
+    uint64_t unused, desc_len;
+    virtio_desc_chain_iterator_t iter;
+    if (!virtio_desc_chain_iterator_new(vq_handler, desc_head, &iter)) {
+        LOG_VMM_ERR("failed to create iterator\n");
+        return 0;
+    }
+
     while (true) {
-        if (loop_iter_count > virtq->num || curr_desc >= virtq->num) {
-            LOG_VMM_ERR("bad descriptor chain starting at %u\n", desc_head);
+        virtio_desc_chain_iterator_status_t status = virtio_desc_chain_iterator_next(&iter, &unused, &desc_len);
+        if (status == VIRTIO_ITERATOR_ERROR) {
             return 0;
+        } else if (status == VIRTIO_ITERATOR_MOVED) {
+            payload_len += desc_len;
+        } else if (status == VIRTIO_ITERATOR_EXHAUSTED) {
+            return payload_len;
         }
-
-        payload_len += desc_ring[curr_desc].len;
-        if (!(desc_ring[curr_desc].flags & VIRTQ_DESC_F_NEXT)) {
-            break;
-        }
-
-        curr_desc = desc_ring[curr_desc].next;
-        loop_iter_count++;
-    };
-    return payload_len;
+    }
 }
 
 bool virtio_read_data_from_desc_chain(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint64_t bytes_to_read,
                                       uint64_t read_off, char *data)
 {
     assert(vq_handler->ready);
-    struct virtq *virtq = &vq_handler->virtq;
-    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
+
+    virtio_desc_chain_iterator_t iter;
+    if (!virtio_desc_chain_iterator_new(vq_handler, desc_head, &iter)) {
+        LOG_VMM_ERR("failed to create iterator\n");
+        return 0;
+    }
 
     uint64_t current_list_byte = read_off;
     uint64_t end_list_byte = read_off + bytes_to_read;
     uint64_t current_desc_start_byte = 0;
-
-    uint16_t curr_desc = desc_head;
-    uint64_t loop_iter_count = 0;
     while (true) {
-        if (loop_iter_count > virtq->num || curr_desc >= virtq->num) {
-            LOG_VMM_ERR("bad descriptor chain starting at %u\n", desc_head);
+        uint64_t desc_gpa, desc_len;
+        virtio_desc_chain_iterator_status_t status = virtio_desc_chain_iterator_next(&iter, &desc_gpa, &desc_len);
+        if (status == VIRTIO_ITERATOR_ERROR) {
             return false;
+        } else if (status == VIRTIO_ITERATOR_MOVED) {
+            uint64_t current_desc_end_byte = current_desc_start_byte + desc_len;
+
+            if (current_list_byte >= current_desc_start_byte && current_list_byte < current_desc_end_byte) {
+                /* This descriptor have what we need, copy it over to `data`. */
+                uint64_t copy_size = MIN(current_desc_end_byte, end_list_byte) - current_list_byte;
+                uint64_t src_gpa = desc_gpa + (current_list_byte - current_desc_start_byte);
+                void *src_hva = gpa_to_hva(src_gpa, copy_size);
+                char *dest = data + (current_list_byte - read_off);
+
+                memcpy(dest, src_hva, copy_size);
+                current_list_byte += copy_size;
+            }
+
+            current_desc_start_byte += desc_len;
+
+            assert(current_list_byte <= end_list_byte);
+            if (current_list_byte == end_list_byte) {
+                return true;
+            }
+        } else if (status == VIRTIO_ITERATOR_EXHAUSTED) {
+            return current_list_byte == end_list_byte;
         }
-
-        struct virtq_desc *desc = &desc_ring[curr_desc];
-        uint64_t current_desc_end_byte = current_desc_start_byte + desc->len;
-
-        if (current_list_byte >= current_desc_start_byte && current_list_byte < current_desc_end_byte) {
-            /* This descriptor have what we need, copy it over to `data`. */
-            uint64_t copy_size = MIN(current_desc_end_byte, end_list_byte) - current_list_byte;
-            uint64_t src_gpa = desc->addr + (current_list_byte - current_desc_start_byte);
-            void *src_hva = gpa_to_hva(src_gpa, copy_size);
-            char *dest = data + (current_list_byte - read_off);
-
-            memcpy(dest, src_hva, copy_size);
-            current_list_byte += copy_size;
-        }
-
-        assert(current_list_byte <= end_list_byte);
-        if (current_list_byte == end_list_byte) {
-            break;
-        }
-        loop_iter_count++;
-        current_desc_start_byte += desc->len;
-        curr_desc = desc_ring[curr_desc].next;
     }
-
-    return current_list_byte == end_list_byte;
 }
 
 bool virtio_write_data_to_desc_chain(virtio_queue_handler_t *vq_handler, uint16_t desc_head, uint64_t bytes_to_write,
                                      uint64_t write_off, char *data)
 {
     assert(vq_handler->ready);
-    struct virtq *virtq = &vq_handler->virtq;
-    struct virtq_desc *desc_ring = virtio_get_desc_ring(virtq);
+
+    virtio_desc_chain_iterator_t iter;
+    if (!virtio_desc_chain_iterator_new(vq_handler, desc_head, &iter)) {
+        LOG_VMM_ERR("failed to create iterator\n");
+        return 0;
+    }
 
     uint64_t current_list_byte = write_off;
     uint64_t end_list_byte = write_off + bytes_to_write;
     uint64_t current_desc_start_byte = 0;
-
-    uint16_t curr_desc = desc_head;
-    uint64_t loop_iter_count = 0;
     while (true) {
-        if (loop_iter_count > virtq->num || curr_desc >= virtq->num) {
-            LOG_VMM_ERR("bad descriptor chain starting at %u\n", desc_head);
+        uint64_t desc_gpa, desc_len;
+        virtio_desc_chain_iterator_status_t status = virtio_desc_chain_iterator_next(&iter, &desc_gpa, &desc_len);
+        if (status == VIRTIO_ITERATOR_ERROR) {
             return false;
+        } else if (status == VIRTIO_ITERATOR_MOVED) {
+            uint64_t current_desc_end_byte = current_desc_start_byte + desc_len;
+
+            if (current_list_byte >= current_desc_start_byte && current_list_byte < current_desc_end_byte) {
+                /* This descriptor have what we need, copy `data` to guest RAM. */
+                uint64_t copy_size = MIN(current_desc_end_byte, end_list_byte) - current_list_byte;
+                char *src = data + (current_list_byte - write_off);
+                uint64_t dest_gpa = desc_gpa + (current_list_byte - current_desc_start_byte);
+                void *dest_hva = gpa_to_hva(dest_gpa, copy_size);
+
+                memcpy(dest_hva, src, copy_size);
+                current_list_byte += copy_size;
+            }
+
+            current_desc_start_byte += desc_len;
+
+            assert(current_list_byte <= end_list_byte);
+            if (current_list_byte == end_list_byte) {
+                return true;
+            }
+        } else if (status == VIRTIO_ITERATOR_EXHAUSTED) {
+            return current_list_byte == end_list_byte;
         }
-
-        struct virtq_desc *desc = &desc_ring[curr_desc];
-        uint64_t current_desc_end_byte = current_desc_start_byte + desc->len;
-
-        if (current_list_byte >= current_desc_start_byte && current_list_byte < current_desc_end_byte) {
-            /* This descriptor have what we need, copy `data` to guest RAM. */
-            uint64_t copy_size = MIN(current_desc_end_byte, end_list_byte) - current_list_byte;
-            char *src = data + (current_list_byte - write_off);
-            uint64_t dest_gpa = desc->addr + (current_list_byte - current_desc_start_byte);
-            void *dest_hva = gpa_to_hva(dest_gpa, copy_size);
-
-            memcpy(dest_hva, src, copy_size);
-            current_list_byte += copy_size;
-        }
-
-        assert(current_list_byte <= end_list_byte);
-        if (current_list_byte == end_list_byte) {
-            break;
-        }
-
-        loop_iter_count++;
-        current_desc_start_byte += desc->len;
-        curr_desc = desc_ring[curr_desc].next;
     }
-
-    return true;
 }
 
 bool virtio_virtq_peek_avail(virtio_queue_handler_t *vq_handler, uint16_t *ret)

--- a/vmm.mk
+++ b/vmm.mk
@@ -69,6 +69,7 @@ ARCH_INDEP_FILES := \
 			src/virtio/net.c \
 		    src/virtio/virtio.c \
 			src/virtio/pci.c \
+			src/virtio/iterator.c \
 		    src/util/util.c \
 			src/pci.c \
 			src/guest_ram.c \


### PR DESCRIPTION
1. virtio: increase vq size from 128 to 1024

128 is too small for Windows which demand a lot of disk traffic.

2. virtio: add support for walking indirect descriptors 

3. virtio/blk+net: add indirect feature

This is important for Windows performance, as the Windows viostor driver gate
optimisations behind this feature. See `VirtIoFindAdapter()` in
virtio_stor.c of kvm-guest-drivers-windows for more details.

This is implemented by refactoring the descriptor chain walking logic
in virtio.c out into a C++ style "forward iterator".

4. virtio/block: performance tuning

- Scaled `seg_max` up a quarter of the virtqueue capacity.
- Reduced `size_max` to 4K, it seems like both Linux and Windows liked
it this way.
- Fix incorrect `opt_io_size`. It should be zero to allow the guest to
make any request size up to the maximum.
- `blk_size` should be fixed to 4K.

These fixes combined with indirect descriptor and making the block data
region 128MiB had improved Windows 11 sequential read performance
on QEMU from 25MB/s to 2.6GB/s on my machine.