### PR TITLE
uefi: fix regression with edk2-stable202608

### DIFF
--- a/src/arch/x86_64/uefi.c
+++ b/src/arch/x86_64/uefi.c
@@ -21,6 +21,7 @@
 #include <sddf/util/util.h>
 
 extern guest_t guest;
+uint16_t cpu_count = 1; // @billn revisit for SMP
 
 /* Document referenced:
  * https://github.com/tianocore/edk2/blob/edk2-stable202605/OvmfPkg/README */
@@ -126,6 +127,12 @@ bool uefi_setup_images(uintptr_t firm_src, size_t firm_size, uintptr_t dsdt_src,
     /* Initialise the fw cfg device to give the E820 memory map, ACPI tables and other important
      * things to OVMF. */
     if (!initialise_fw_cfg()) {
+        return false;
+    }
+
+    /* CPU count, read in PlatformMaxCpuCountInitialization() in PlatformInitLib */
+    if (!fw_cfg_add_file(QEMU_FW_CFG_ITEM_SMP_CPU_COUNT, (uint8_t *)&cpu_count, sizeof(uint16_t))) {
+        LOG_VMM_ERR("Failed to add CPU count file to fw cfg\n");
         return false;
     }
 


### PR DESCRIPTION
It seems like edk2-stable202608 had changed how the number of CPU is discovered, compared to edk2-stable202605. Which lead to this crash:

```
PlatformMaxCpuCountInitialization: modern CPU hotplug interface unavailable
PlatformMaxCpuCountInitialization: BootCpuCount=30442 MaxCpuCount=30442
PlatformMaxCpuCountInitialization: enable x2apic mode
!!!! X64 Exception Type - 0D(#GP - General Protection)  CPU Apic ID - 00000000 !!!!
```

But after looking at PlatformMaxCpuCountInitialization in OVMF code, I'm surprised that our code worked at all, because we provided no way for OVMF to query to number of CPU. So this commit fixed the problem by making a FW CFG file that contain the number of CPUs as OVMF expected.