### PR TITLE
x86_64/guest_time: fix timeout drifting

### DIFF
--- a/include/libvmm/arch/x86_64/guest_time.h
+++ b/include/libvmm/arch/x86_64/guest_time.h
@@ -32,5 +32,7 @@ guest_timeout_handle_t guest_time_request_timeout(uint64_t tsc_delta, guest_time
 
 bool guest_time_cancel_timeout(guest_timeout_handle_t handle);
 
-/* Call this in your VMM's `notified()`! */
 void guest_time_handle_timer_ntfn(void);
+
+/* Recompute the next time out based on the current wall clock time. */
+void guest_time_maintenance(void);

--- a/src/arch/x86_64/fault.c
+++ b/src/arch/x86_64/fault.c
@@ -486,6 +486,10 @@ bool fault_handle(size_t vcpu_id, microkit_msginfo msginfo)
     }
 #endif
 
+    /* The VMX preemption timer doesn't count down while the VMM is running.
+     * So we must correct for the time that the VMM stole away from the VM. */
+    guest_time_maintenance();
+
     if (success) {
         unsigned rip_additive = 0;
         if (!fault_is_trap_like(f_reason)) {

--- a/src/arch/x86_64/guest_time.c
+++ b/src/arch/x86_64/guest_time.c
@@ -164,7 +164,7 @@ static void vmx_timer_off(void)
     microkit_vcpu_x86_write_vmcs(0, VMX_CONTROL_EXIT_CONTROLS, VMCS_VEXC_DEFAULT);
 }
 
-static void guest_time_schedule_timeout(void)
+void guest_time_maintenance(void)
 {
     guest_time_user_error_check();
 
@@ -211,7 +211,7 @@ guest_timeout_handle_t guest_time_request_timeout(uint64_t tsc_delta, guest_time
     guest_timekeeping.timeouts[free_slot].valid = true;
 
     /* Prime the timer if needed. */
-    guest_time_schedule_timeout();
+    guest_time_maintenance();
     return free_slot;
 }
 
@@ -227,7 +227,7 @@ bool guest_time_cancel_timeout(guest_timeout_handle_t handle)
     }
     guest_timekeeping.timeouts[handle].valid = false;
     vmx_timer_off();
-    guest_time_schedule_timeout();
+    guest_time_maintenance();
     return true;
 }
 
@@ -236,5 +236,5 @@ void guest_time_handle_timer_ntfn(void)
     guest_time_user_error_check();
     vmx_timer_off();
     guest_time_service_timeouts();
-    guest_time_schedule_timeout();
+    guest_time_maintenance();
 }


### PR DESCRIPTION
Fix: https://github.com/au-ts/libvmm/issues/399

The VMX preemption timer doesn't count down when the VM is not running, i.e. when the VMM is handling a VM Exit. So if we just resume the VM without accounting for the "stolen time", the timeout will be late from the guest's perspective. Since the wall clock time will keep going while the VMX preemption timer pauses.

So for every VM Exit, we will need to correct for this by adjusting the timeout on the VMX preemption timer if it is active.